### PR TITLE
nix: add direnv support for nix shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ mesh-root.pem
 coordinator-root.pem
 justfile.env
 workspace
+.direnv/

--- a/README.md
+++ b/README.md
@@ -12,19 +12,27 @@ from the surrounding environment.
 ### Getting started
 
 1. [Install Nix](https://zero-to-nix.com/concepts/nix-installer)
-2. Enter the development environment.
+2. Enter the development environment manually.
 
     ```sh
     nix develop .#
     ```
+   Or use [direnv](https://direnv.net/) to automatically enter the nix shell.
+   On non-NixOS systems, simply install [direnv](https://direnv.net/).
+   When using NixOS, enabling [nix-direnv](https://github.com/nix-community/nix-direnv) results in better caching.
+   Additionally, you may want to add the [vscode extension](https://github.com/direnv/direnv-vscode).
 
-3. Execute and follow instructions of
+   ```sh
+   direnv allow
+   ```
+
+4. Execute and follow instructions of
 
     ```sh
     just onboard
     ```
 
-4. Provision a CoCo enables AKS cluster with
+5. Provision a CoCo enables AKS cluster with
 
     ```sh
     just create


### PR DESCRIPTION
This adds a .envrc file for use with direnv (https://direnv.net/).
If enabled, this will automatically load a cached nix shell with the default devShell from flake.nix.