### PR TITLE
chore: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ from the surrounding environment.
     just onboard
     ```
 
-5. Provision a CoCo enables AKS cluster with
+5. Provision a CoCo enabled AKS cluster with
 
     ```sh
     just create


### PR DESCRIPTION
The `README.md` had a typo, I fixed it.