### PR TITLE
snp: cache amd kds requests

### DIFF
--- a/internal/attestation/snp/cachedClient.go
+++ b/internal/attestation/snp/cachedClient.go
@@ -1,0 +1,45 @@
+package snp
+
+import (
+	"log/slog"
+
+	"github.com/edgelesssys/nunki/internal/memstore"
+	"github.com/google/go-sev-guest/verify/trust"
+)
+
+type cachedKDSHTTPClient struct {
+	trust.HTTPSGetter
+	logger *slog.Logger
+
+	cache *memstore.Store[string, cacheEntry]
+}
+
+func NewCachedKDSHTTPClient(log *slog.Logger) *cachedKDSHTTPClient {
+	trust.DefaultHTTPSGetter()
+	return &cachedKDSHTTPClient{
+		HTTPSGetter: trust.DefaultHTTPSGetter(),
+		logger:      log.WithGroup("cached-kds-http-client"),
+		cache:       memstore.New[string, cacheEntry](),
+	}
+}
+
+func (c *cachedKDSHTTPClient) Get(url string) ([]byte, error) {
+	if cached, ok := c.cache.Get(url); ok {
+		c.logger.Debug("Get cached", "url", url)
+		return cached.data, nil
+	}
+
+	c.logger.Debug("Get not cached", "url", url)
+	res, err := c.HTTPSGetter.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	c.cache.Set(url, cacheEntry{
+		data: res,
+	})
+	return res, nil
+}
+
+type cacheEntry struct {
+	data []byte
+}


### PR DESCRIPTION
* The go-sev-guest library takes a http.Getter Interface in the verify options.
* Wrap the default http getter from the library and cache URLs for 5 minutes


From non-scientific observation, this greatly improves start-up time of workloads. This also mitigates "unnecessary" KDS requests when there is no manifest set. 

With this (simplest) implementation, we currently cache all requests made by the library during verify. We should discuss reducing that to the /vcek/ endpoint or even the first endpoint mentioned in Chapter 4 Table 10 here: https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/57230.pdf.