### PR TITLE
ci: remove golangci as check, run as command

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -49,3 +49,14 @@ jobs:
         - uses: DeterminateSystems/magic-nix-cache-action@8a218f9e264e9c3803c9a1ee1c30d8e4ab55be63 #v2
         - name: Run govulncheck
           run: nix run .#govulncheck -- ./...
+
+  golangci-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: cachix/install-nix-action@7ac1ec25491415c381d9b62f0657c7a028df52a7 # v24
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/magic-nix-cache-action@8a218f9e264e9c3803c9a1ee1c30d8e4ab55be63 #v2
+      - name: Run golangci-lint
+        run: nix run .#golangci-lint -- run

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,6 @@
 
       checks = {
         formatting = treefmtEval.config.build.check self;
-        inherit (self.packages.${system}) golangci-lint;
       };
 
       legacyPackages = pkgs;

--- a/justfile
+++ b/justfile
@@ -95,6 +95,9 @@ codegen:
 fmt:
     nix fmt
 
+lint:
+    nix run .#golangci-lint -- run
+
 # Cleanup auxiliary files, caches etc.
 clean:
     rm -rf ./{{worspace_dir}}


### PR DESCRIPTION
Checks run in the sandbox, run golangci-lint as implicit command for now (with pinned toolchain, oc)