### PR TITLE
ci: recreate cluster once a week

### DIFF
--- a/.github/workflows/cluster_recreate.yml
+++ b/.github/workflows/cluster_recreate.yml
@@ -2,6 +2,8 @@ name: recreate ci cluster
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 0" # every Sunday at 1am UTC
 
 env:
   azure_resource_group: nunki-ci


### PR DESCRIPTION
Not sure if we want to merge this. On the one hand, we might get newer components in the stack below we should test, on the other hand we loose feeling what happens in long running clusters. Feedback wanted @malt3 @3u13r.