### PR TITLE
use nunki as name in demodir recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -163,7 +163,7 @@ demodir:
     d=$(mktemp -d)
     echo "Creating demo directory at ${d}"
     nix build .#nunki.cli
-    cp ./result-cli/bin/cli "${d}/nunki"
+    cp ./result-cli/bin/nunki "${d}/nunki"
     cp -R ./deployments/emojivoto "${d}/deployment"
     nix run .#patch-nunki-image-hashes -- "${d}/deployment"
     nix run .#kypatch images -- "${d}/deployment" \


### PR DESCRIPTION
The binary was renamed in b71980eba5600ee8ee3bfdaaa1c38e2f21ed9db9.