### PR TITLE
packages: remove -buildid= from ldflags of buildGoModule

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -53,7 +53,6 @@ rec {
       ldflags = [
         "-s"
         "-w"
-        "-buildid="
         "-X main.genpolicyPath=${genpolicy}/bin/genpolicy"
       ];
 


### PR DESCRIPTION
This is now set upstream.