### PR TITLE
nix: minify genpolicy binary size

### DIFF
--- a/packages/genpolicy_kata.nix
+++ b/packages/genpolicy_kata.nix
@@ -30,9 +30,6 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  dontStrip = true;
-  buildType = "debug";
-
   env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [

--- a/packages/genpolicy_msft.nix
+++ b/packages/genpolicy_msft.nix
@@ -25,9 +25,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-MRVtChYQkiU92n/z+5r4ge58t9yVeOCdqs0zx81IQUY=";
 
-  dontStrip = true;
-  buildType = "debug";
-
   OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [


### PR DESCRIPTION
Since we are embedding the genpolicy tool as part of the nunki cli, it is desirable to make the binary size smaller. This change takes the size from ~152M down to ~18M.