### PR TITLE
cli: output coordinator policy on generate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: coordinator
+      annotations:
+        nunki.edgeless.systems/pod-role: coordinator
     spec:
       runtimeClassName: kata-cc-isolation
       containers:

--- a/deployments/emojivoto/coordinator.yml
+++ b/deployments/emojivoto/coordinator.yml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: coordinator
+      annotations:
+        nunki.edgeless.systems/pod-role: coordinator
     spec:
       runtimeClassName: kata-cc-isolation
       containers:

--- a/deployments/openssl/coordinator.yml
+++ b/deployments/openssl/coordinator.yml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: coordinator
+      annotations:
+        nunki.edgeless.systems/pod-role: coordinator
     spec:
       runtimeClassName: kata-cc-isolation
       containers:

--- a/deployments/simple/coordinator.yml
+++ b/deployments/simple/coordinator.yml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: coordinator
+      annotations:
+        nunki.edgeless.systems/pod-role: coordinator
     spec:
       runtimeClassName: kata-cc-isolation
       containers:

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ generate target=default_deploy_target:
         -m ./{{ workspace_dir }}/manifest.json \
         -p ./{{ workspace_dir }} \
         -s genpolicy-msft.json \
-        ./{{ workspace_dir }}/deployment/*.yml
+        ./{{ workspace_dir }}/deployment/*.yml > ./{{ workspace_dir }}/just.coordinator-policy-hash
     duration=$(( $(date +%s) - $t ))
     echo "Generated policies in $duration seconds."
     echo "generate $duration" >> ./{{ workspace_dir }}/just.perf
@@ -79,7 +79,7 @@ set:
     PID=$!
     trap "kill $PID" EXIT
     nix run .#wait-for-port-listen -- 1313
-    policy=$(nix run .#get-coordinator-policy-hash -- ./{{ workspace_dir }}/deployment/*.yml)
+    policy=$(<./{{ workspace_dir }}/just.coordinator-policy-hash)
     t=$(date +%s)
     nix run .#cli -- set \
         -m ./{{ workspace_dir }}/manifest.json \

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -263,16 +263,4 @@ rec {
       exit 1
     '';
   };
-
-  get-coordinator-policy-hash = writeShellApplication {
-    name = "get-coordinator-policy-hash";
-    runtimeInputs = [ yq-go ];
-    text = ''
-      set -o pipefail
-      yq -e eval-all \
-        'select(.kind == "Deployment" and .metadata.name == "coordinator") |
-         .spec.template.metadata.annotations["io.katacontainers.config.agent.policy"]' "$@" |
-        base64 -d | sha256sum | cut -d' ' -f1
-    '';
-  };
 }


### PR DESCRIPTION
As soon as we embed a default coordinator policy into the CLI, the set
and verify subcommands will stop working if the coordinator policy does
not match expectations. Thus, we need to make users aware if we detect a
non-default coordinator among the deployments.

If the CLI encounters an unexpected coordinator policy in the input
YAML, it prints the policy hash to stdout and warns on stderr. This
provides the user with two choices, depending on their workflow:

1. Users that don't expect changes to the coordinator policy can abort
   right away to check why the policy changed. But even if they ignore
   the output entirely, set will still fail closed.
2. Users that deliberately changed the coordinator but want to verify it
   nonetheless. These users need to pass the output to the set command,
   if it was not empty.


Implementation note: I decided to add a field to the `deployment` type so that we don't need to do the check in `policiesFromKubeResources`, which is called by both `generate` and `set`. 