### PR TITLE
attestation: re-enable kds caching

### DIFF
--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -95,7 +95,7 @@ func (v *Validator) Validate(ctx context.Context, attDocRaw []byte, nonce []byte
 	verifyOpts.CheckRevocations = true
 	verifyOpts.Getter = v.kdsGetter
 
-	attestation, err := constructReportWithCertChain(reportRaw, verify.DefaultOptions())
+	attestation, err := constructReportWithCertChain(reportRaw, verifyOpts)
 	if err != nil {
 		return fmt.Errorf("converting report to proto: %w", err)
 	}


### PR DESCRIPTION
Caching was disabled in https://github.com/edgelesssys/nunki/commit/1c5e945bafa4fc3d55f00a95f2199e8d3184fb79#diff-d2f2420a3f10884913b4731dc84f9c711202b36421557ea68aa5c71d5a795b04R98

Among other things, this made the initialization slower/flaky since it always requested the KDS which returned a HTTP 429.