### PR TITLE
[release/v0.1] nunki: fix version injection

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -54,6 +54,7 @@ rec {
       ldflags = [
         "-s"
         "-w"
+        "-X main.version=v${version}"
       ];
 
       preCheck = ''


### PR DESCRIPTION
# Description
Backport of #128 to `release/v0.1`.