### PR TITLE
ci: checkout with token in release publish

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0 # fetch all history
+          token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
       - name: Determine branch names
         run: |
           RELEASE_BRANCH="release/${FULL_VERSION%.*}"


### PR DESCRIPTION
This allows us to specify the token owner (edgelessci) as excluded actor from branch protection. Otherwise we cannot require PR on release branches.