### PR TITLE
Revert "ci: temporary fix for hanging cachix post step"

### DIFF
--- a/.github/workflows/cluster_recreate.yml
+++ b/.github/workflows/cluster_recreate.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           name: edgelesssys
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
       - name: Login to Azure
         uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:

--- a/.github/workflows/e2e_simple.yml
+++ b/.github/workflows/e2e_simple.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           name: edgelesssys
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,6 @@ jobs:
         with:
           name: edgelesssys
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           name: edgelesssys
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
       - name: nix flake check
         run: |
           nix -L flake check
@@ -38,7 +37,6 @@ jobs:
         with:
           name: edgelesssys
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
       - name: Run code generations & tidying
         run: |
           nix run .#generate
@@ -60,7 +58,6 @@ jobs:
           with:
             name: edgelesssys
             authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-            installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
         - name: Run govulncheck
           run: |
             nix run .#govulncheck -- ./...
@@ -76,7 +73,6 @@ jobs:
         with:
           name: edgelesssys
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          installCommand: nix profile install github:cachix/cachix/cd12acd9245ac9b7e010aa3acac49f37824fdad2 --accept-flake-config # remove on v14.1/v15
       - name: Run golangci-lint
         run: |
           nix run .#golangci-lint -- run


### PR DESCRIPTION
Reverts edgelesssys/nunki#106

Currently we don't push any build results to cachix, let's see if reverting this helps. Better to timeout sometimes than not use caching at all.