### PR TITLE
genpolicy-msft: remove settings patch for env

### DIFF
--- a/packages/genpolicy_msft_settings_dev.patch
+++ b/packages/genpolicy_msft_settings_dev.patch
@@ -4,27 +4,6 @@ new mode 100644
 index 7a732b1..0dd0457
 --- a/genpolicy-settings.json
 +++ b/genpolicy-settings.json
-@@ -282,19 +282,7 @@
-     "request_defaults": {
-         "CreateContainerRequest": {
-             "allow_env_regex": [
--                "^HOSTNAME=$(dns_label)$",
--                "^$(svc_name)_PORT_$(ip_p)_TCP=tcp://$(ipv4_a):$(ip_p)$",
--                "^$(svc_name)_PORT_$(ip_p)_TCP_PROTO=tcp$",
--                "^$(svc_name)_PORT_$(ip_p)_TCP_PORT=$(ip_p)$",
--                "^$(svc_name)_PORT_$(ip_p)_TCP_ADDR=$(ipv4_a)$",
--                "^$(svc_name)_SERVICE_HOST=$(ipv4_a)$",
--                "^$(svc_name)_SERVICE_PORT=$(ip_p)$",
--                "^$(svc_name)_SERVICE_PORT_$(dns_label)=$(ip_p)$",
--                "^$(svc_name)_PORT=tcp://$(ipv4_a):$(ip_p)$",
--                "^AZURE_CLIENT_ID=[A-Fa-f0-9-]*$",
--                "^AZURE_TENANT_ID=[A-Fa-f0-9-]*$",
--                "^AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token$",
--                "^AZURE_AUTHORITY_HOST=https://login\\.microsoftonline\\.com/$"
-+                ".*"
-             ]
-         },
-         "CopyFileRequest": [
 @@ -302,10 +290,12 @@
          ],
          "ExecProcessRequest": {


### PR DESCRIPTION
The genpolicy-settings.json allow overriding the permissible set of
environment variables, and come with a generic list of env vars suitable
for the AKS environment.

We want to have a dev setting that allows debugging (e.g. pod network
settings like iptables), but that is otherwise as close to the upstream
as possible. Environment variable allowlists are generated by genpolicy,
and should thus not need blanket exemptions, even in dev setups. Thus,
we remove the blanket allowlist and work around the limitations in our
deployment yaml.
