### PR TITLE
genpolicy: backport path handling fixes to msft fork

### DIFF
--- a/cli/constants.go
+++ b/cli/constants.go
@@ -13,7 +13,6 @@ const (
 	manifestFilename       = "manifest.json"
 	settingsFilename       = "settings.json"
 	rulesFilename          = "rules.rego"
-	policyDir              = "."
 	verifyDir              = "./verify"
 	cacheDirEnv            = "NUNKI_CACHE_DIR"
 )

--- a/justfile
+++ b/justfile
@@ -39,8 +39,8 @@ generate target=default_deploy_target:
     t=$(date +%s)
     nix run .#cli -- generate \
         -m ./{{ workspace_dir }}/manifest.json \
-        -p ./{{ workspace_dir }} \
-        -s genpolicy-msft.json \
+        -p ./{{ workspace_dir }}/rules.rego \
+        -s ./{{ workspace_dir }}/genpolicy-msft.json \
         ./{{ workspace_dir }}/deployment/*.yml > ./{{ workspace_dir }}/just.coordinator-policy-hash
     duration=$(( $(date +%s) - $t ))
     echo "Generated policies in $duration seconds."

--- a/packages/genpolicy_msft.nix
+++ b/packages/genpolicy_msft.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , fetchurl
+, fetchpatch
 , applyPatches
 , rustPlatform
 , openssl
@@ -17,13 +18,28 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "kata-containers";
-    rev = "genpolicy-${version}";
-    hash = "sha256-R+kiyG3xLsoLBVTy1lmmqvDgoQuqfcV3DkfQtRCiYCw=";
+    # Latest released version of genpolicy
+    # is too old for the path handling patch.
+    # Using a commit from main for now.
+    # rev = "genpolicy-${version}";
+    rev = "401db3a3e75c699422537551e7862cd510fb68b0";
+    hash = "sha256-dyYGGQPGWe6oVcAa48Kr/SsdSpUhwQZrRQ2d54BIac8=";
   };
+
+  patches = [
+    # TODO(malt3): drop this patch when msft fork adopted this from upstream
+    (fetchpatch {
+      name = "genpolicy_path_handling.patch";
+      url = "https://github.com/kata-containers/kata-containers/commit/befef119ff4df2868cdc88d4273c8be965387793.patch";
+      sha256 = "sha256-4pfYrP9KaPVcrFbm6DkiZUNckUq0fKWZPfCONW8/kso=";
+    })
+  ];
+
+  patchFlags = [ "-p4" ];
 
   sourceRoot = "${src.name}/src/tools/genpolicy";
 
-  cargoHash = "sha256-MRVtChYQkiU92n/z+5r4ge58t9yVeOCdqs0zx81IQUY=";
+  cargoHash = "sha256-WRSDqrOgSZVcJGN7PuyIqqmOSbrob75QNE2Ztb1L9Ww=";
 
   OPENSSL_NO_VENDOR = 1;
 


### PR DESCRIPTION
Backport of https://github.com/kata-containers/kata-containers/pull/8941 to the msft fork.
This makes the flags in our generate command behave as expected.