### PR TITLE
ci: pin image for simple test

### DIFF
--- a/deployments/simple/initializer.yml
+++ b/deployments/simple/initializer.yml
@@ -30,11 +30,11 @@ spec:
               memory: 50Mi
       containers:
         - name: workload
-          image: "fedora:38"
+          image: "docker.io/library/busybox:1.36.1-musl@sha256:d4707523ce6e12afdbe9a3be5ad69027150a834870ca0933baf7516dd1fe0f56"
           command:
-            - /bin/bash
+            - /bin/sh
             - "-c"
-            - echo Workload started ; sleep inf
+            - echo Workload started ; while true; do sleep 60; done
           volumeMounts:
             - name: tls-certs
               mountPath: /tls-config


### PR DESCRIPTION
We did run into an issue where Github Actions computed a policy for a newer version of `fedora:38`, while AKS used an older variant from cache, which resulted in a policy fail.

This commit pins the image by hash, and replaces the fedora image with busybox, which should have less churn and longer availability.