### PR TITLE
deps: bump AKS K8s version to 1.29

### DIFF
--- a/packages/create-coco-aks.sh
+++ b/packages/create-coco-aks.sh
@@ -41,7 +41,7 @@ az group create \
 az aks create \
   --resource-group "${name}" \
   --name "${name}" \
-  --kubernetes-version "${k8sVersion:-1.27}" \
+  --kubernetes-version "${k8sVersion:-1.29}" \
   --os-sku AzureLinux \
   --node-vm-size Standard_DC4as_cc_v5 \
   --node-count 1 \


### PR DESCRIPTION
This allows us to use sidecar containers: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/

This only bums the version for new clusters. We need to either migrate or re-create the CI cluster. Regarding upgrades see: https://learn.microsoft.com/en-us/azure/aks/upgrade-aks-cluster?tabs=azure-cli#upgrade-an-aks-cluster