### PR TITLE
just: use released artifacts for demodir

### DIFF
--- a/justfile
+++ b/justfile
@@ -187,16 +187,18 @@ fmt:
 lint:
     nix run .#scripts.golangci-lint -- run
 
-demodir cli=default_cli: undeploy coordinator initializer
+demodir namespace="default": coordinator initializer
     #!/usr/bin/env bash
     d=$(mktemp -d)
     echo "Creating demo directory at ${d}"
-    nix build .#{{ cli }}
-    cp ./result-cli/bin/contrast "${d}/contrast"
     cp -R ./deployments/emojivoto "${d}/deployment"
+    rm -f "${d}/deployment/coordinator.yml"
     nix run .#scripts.patch-contrast-image-hashes -- "${d}/deployment"
     nix run .#kypatch images -- "${d}/deployment" \
         --replace ghcr.io/edgelesssys ${container_registry}
+    nix run .#kypatch namespace -- "${d}/deployment" \
+        --replace edg-default {{ namespace }}
+    nix run .#scripts.fetch-latest-contrast -- {{ namespace }} "${d}"
     echo "Demo directory ready at ${d}"
 
 # Cleanup auxiliary files, caches etc.

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -168,4 +168,24 @@ with pkgs;
       popd >/dev/null
     '';
   };
+
+  fetch-latest-contrast = writeShellApplication {
+    name = "fetch-latest-contrast";
+    runtimeInputs = [
+      jq
+      github-cli
+    ];
+    text = ''
+      namespace=$1
+      targetDir=$2
+      release=$(gh release list --json name,isLatest | jq -r '.[] | select(.isLatest) | .name')
+      gh release download "$release" \
+        --repo edgelesssys/contrast \
+        -D "$targetDir" \
+        --skip-existing
+      chmod a+x "$targetDir/contrast"
+
+      yq -i ".metadata.namespace = \"$namespace\"" "$targetDir/coordinator.yaml"
+    '';
+  };
 }


### PR DESCRIPTION
When demoing Contrast, we usually want a stable software version with a minimum amount of surprises, so we would like to use the released binary and coordinator YAML for that. This commit adds a script that downloads the artifacts, which is a bit complicated because of visibility restrictions, and modifies the just target to use this script.

~We're deliberately hardcoding the namespace into the demodir recipe, instead of reading it from the copied YAML, because we're going to switch to resourcegen eventually, which will make the demodir recipe decide the namespace. At that point, we can just pass the namespace to the new script and resourcegen.~