### PR TITLE
cli: fix embedding of policy hash

### DIFF
--- a/packages/by-name/cli-release/package.nix
+++ b/packages/by-name/cli-release/package.nix
@@ -12,6 +12,6 @@
   '';
 
   ldflags = previousAttrs.ldflags ++ [
-    "-X main.DefaultCoordinatorPolicyHash=${builtins.readFile ../../../cli/cmd/assets/coordinator-policy-hash}"
+    "-X github.com/edgelesssys/contrast/cli/cmd.DefaultCoordinatorPolicyHash=${builtins.readFile ../../../cli/cmd/assets/coordinator-policy-hash}"
   ];
 })).cli


### PR DESCRIPTION
The definition of the default policy hash was moved, but the -X argument for the go build was not changed accordingly.