### PR TITLE
readme: remove renamed flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ will fetch a certificate for the workload and the workload is started.
 An end user (data owner) can verify the Contrast deployment using the `verify` command.
 
 ```sh
-./contrast verify -c "${coordinator}:1313" -o ./verify
+./contrast verify -c "${coordinator}:1313"
 ```
 
 The CLI will attest the Coordinator using embedded reference values. The CLI will write the service mesh


### PR DESCRIPTION
The flag has been renamed in https://github.com/edgelesssys/contrast/commit/8e4b80032d07da069b022511c7fae1f96856f34a.
Since `./verify` is the default, I think we can remove it for simplicity.