### PR TITLE
user-manual: fix mesh root cert name

### DIFF
--- a/dev-docs/user-manual.md
+++ b/dev-docs/user-manual.md
@@ -153,7 +153,7 @@ To validate the certificate locally, use `openssl`:
 ```sh
 openssl s_client -showcerts -connect ${lbip}:443 </dev/null | sed -n -e '/-.BEGIN/,/-.END/ p' > certChain.pem
 awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "cert." c ".pem"}' < certChain.pem
-openssl verify -verbose -trusted verify/MeshCA.pem -- cert.1.pem
+openssl verify -verbose -trusted verify/mesh-root.pem -- cert.1.pem
 ```
 
 ## Current limitations


### PR DESCRIPTION
one last fix that was found when verifying the manual with the 0.4.0 draft release