### PR TITLE
dev-docs: omit current release mention from minor release

### DIFF
--- a/dev-docs/release.md
+++ b/dev-docs/release.md
@@ -1,6 +1,6 @@
 # How to release
 
-# Minor
+## Minor
 
 1. Ensure all needed PRs were were merged.
 
@@ -8,9 +8,9 @@
 
     ```sh
     export REL_VER=v0.1.0
-    export CUR_VER="$(echo $REL_VER | awk -F. -v OFS=. '{$NF -= 1 ; print}')"
-    echo "Releasing $CUR_VER -> $REL_VER"
+    echo "Releasing $REL_VER"
     ```
+
 3. Create a new temporary branch for the relese:
 
     ```sh
@@ -23,6 +23,7 @@
     ```sh
     gh workflow run release.yml --ref $(git rev-parse --abbrev-ref HEAD) -f kind=minor -f version="$REL_VER"
     ```
+
 5. Review the release notes, test the binary artifact.
 
 6. Review and merge the auto-generated update PR for main.
@@ -31,7 +32,7 @@
 
 8. Check that the release publish action succeeds.
 
-# Patch
+## Patch
 
 1. Ensure all needed PRs were backported to the current release branch, and all backport PRs were merged.
 
@@ -42,6 +43,7 @@
     export CUR_VER="$(echo $REL_VER | awk -F. -v OFS=. '{$NF -= 1 ; print}')"
     echo "Releasing $CUR_VER -> $REL_VER"
     ```
+
 3. Checkout the current release branch:
 
    ```sh
@@ -60,6 +62,7 @@
     ```sh
     gh workflow run release.yml --ref $(git rev-parse --abbrev-ref HEAD) -f kind=patch -f version="$REL_VER"
     ```
+
 6. Review the release notes, test the binary artifact.
 
 7. Publish the GitHub release.


### PR DESCRIPTION
don't mention current release since the patch version cannot be inferred from the next minor release. Also some linting.