### PR TITLE
verify: temporarily disable id block verification

### DIFF
--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -168,7 +168,7 @@ func newCoordinatorValidateOptsGen(hostData []byte) *snp.StaticValidateOptsGener
 			},
 			PermitProvisionalFirmware: true,
 			TrustedIDKeyHashes:        trustedIDKeyDigests,
-			RequireIDBlock:            true,
+			RequireIDBlock:            false, // TODO(malt3): re-enable once we control the full boot (including the id block)
 		},
 	}
 }

--- a/coordinator/mesh.go
+++ b/coordinator/mesh.go
@@ -73,7 +73,7 @@ func (m *meshAuthority) SNPValidateOpts(report *sevsnp.Report) (*validate.Option
 		},
 		PermitProvisionalFirmware: true,
 		TrustedIDKeyHashes:        trustedIDKeyDigestHashes,
-		RequireIDBlock:            true,
+		RequireIDBlock:            false, // TODO(malt3): re-enable once we control the full boot (including the id block)
 	}, nil
 }
 


### PR DESCRIPTION
Since we currently cannot control when idkeys / igvm files are updated, a working contrast deployment can break at any time. Disable the validation for now to improve UX.