### PR TITLE
e2e: return stdout/stderr even on exec failure

### DIFF
--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -112,9 +112,6 @@ func (c *Kubeclient) Exec(ctx context.Context, namespace, pod string, argv []str
 		Stderr: errBuf,
 		Tty:    false,
 	})
-	if err != nil {
-		return "", "", fmt.Errorf("executing command: %w", err)
-	}
 
-	return buf.String(), errBuf.String(), nil
+	return buf.String(), errBuf.String(), err
 }


### PR DESCRIPTION
The exec call returns an error if the remote command had a non-zero return code, which is when access to the output is most important.