### PR TITLE
igvmmeasure: package

### DIFF
--- a/packages/by-name/igvmmeasure/package.nix
+++ b/packages/by-name/igvmmeasure/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, cmake
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "igvmmeasure";
+  version = "0.1.0-unstable-2024-03-18";
+
+  src = fetchFromGitHub {
+    owner = "coconut-svsm";
+    repo = "svsm";
+    # TODO(malt3): Use a released version once available.
+    rev = "3fd89b35c56477729987390e35ad235102ccc48f";
+    hash = "sha256-SuDb+S6F1S+8apyQI/t+U6L6dlYg+zGJI9s1HWglGm0=";
+  };
+
+  cargoBuildFlags = "-p igvmmeasure";
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "packit-0.1.1" = "sha256-BLVpKYjrqTwEAPgL7V1xwMnmNn4B8bA38GSmrry0GIM=";
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/coconut-svsm/svsm/releases/tag/${version}";
+    homepage = "https://github.com/coconut-svsm/svsm";
+    mainProgram = "igvmmeasure";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Note: we will probably use this upstream implementation instead of the custom implementation that was in this PR before, since we can avoid maintenance costs: https://github.com/coconut-svsm/svsm/pull/294

This tool can be used to precalculate the SNP launch digest of a VM given an IGVM file.

Example:

```shell-session
$ igvmmeasure kata-containers-igvm.img
4a7cb0294cbeeb2dae9cad42ba97e91133f929da970aa211119389f59bc9e2560f936ecce92cbd55f03ab3c019afd591
```