### PR TITLE
resourcegen: use MkdirAll

### DIFF
--- a/e2e/internal/kuberesource/resourcegen/main.go
+++ b/e2e/internal/kuberesource/resourcegen/main.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := os.Mkdir(path.Dir(dest), 0o755); err != nil {
+	if err := os.MkdirAll(path.Dir(dest), 0o755); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This won't fail as before if either the dir already exists or we need to create parent dirs.