### PR TITLE
cli: fix writing certs when workspace dir is absolute

### DIFF
--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -139,10 +139,10 @@ func runSet(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Manifest set successfully")
 
 	filelist := map[string][]byte{
-		path.Join(flags.workspaceDir, coordRootPEMFilename): resp.CoordinatorRoot,
-		path.Join(flags.workspaceDir, meshRootPEMFilename):  resp.MeshRoot,
+		coordRootPEMFilename: resp.CoordinatorRoot,
+		meshRootPEMFilename:  resp.MeshRoot,
 	}
-	if err := writeFilelist(".", filelist); err != nil {
+	if err := writeFilelist(flags.workspaceDir, filelist); err != nil {
 		return fmt.Errorf("writing filelist: %w", err)
 	}
 


### PR DESCRIPTION
`contrast set` writes CA certificates to the `--workspace-dir` (default `.`). Due to the construction of the output paths, the workspace dir used to be interpreted as relative to the process working directory, even if it was an absolute path. This commit fixes the path construction to correctly join the workspace dir and the certificate files.