### PR TITLE
just: write image refs to file

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,26 +4,26 @@ default target=default_deploy_target cli=default_cli: soft-clean coordinator ini
 # Build the coordinator, containerize and push it.
 coordinator:
     mkdir -p {{ workspace_dir }}
-    nix run .#containers.push-coordinator -- "$container_registry/contrast/coordinator" >&2
+    nix run .#containers.push-coordinator -- "$container_registry/contrast/coordinator" >> {{ workspace_dir }}/just.containerlookup
 
 # Build the openssl container and push it.
 openssl:
     mkdir -p {{ workspace_dir }}
-    nix run .#containers.push-openssl -- "$container_registry/contrast/openssl" >&2
+    nix run .#containers.push-openssl -- "$container_registry/contrast/openssl" >> {{ workspace_dir }}/just.containerlookup
 
 # Build the port-forwarder container and push it.
 port-forwarder:
     mkdir -p {{ workspace_dir }}
-    nix run .#containers.push-port-forwarder -- "$container_registry/contrast/port-forwarder" >&2
+    nix run .#containers.push-port-forwarder -- "$container_registry/contrast/port-forwarder" >> {{ workspace_dir }}/just.containerlookup
 
 service-mesh-proxy:
     mkdir -p {{ workspace_dir }}
-    nix run .#containers.push-service-mesh-proxy -- "$container_registry/contrast/service-mesh-proxy" >&2
+    nix run .#containers.push-service-mesh-proxy -- "$container_registry/contrast/service-mesh-proxy" >> {{ workspace_dir }}/just.containerlookup
 
 # Build the initializer, containerize and push it.
 initializer:
     mkdir -p {{ workspace_dir }}
-    nix run .#containers.push-initializer -- "$container_registry/contrast/initializer" >&2
+    nix run .#containers.push-initializer -- "$container_registry/contrast/initializer" >> {{ workspace_dir }}/just.containerlookup
 
 default_cli := "contrast.cli"
 default_deploy_target := "simple"


### PR DESCRIPTION
Write container image refs to file, so we can consume them using image lookup in the Go e2e tests.

Some notes:

- While we clean up the lookup file, it is not strictly necessary. For images with the same path that are appended multiple times, image lookup will always use the latest (map insert with the same key when parsing)
- `crane push` has an `--image-refs` flag that writes the pushed image reference to a file, including the digest. However, the operation does not append.
- `crane push` can also push multiple images at once (`--index`), which could likely be used to push a collection of images at once and get a file with refs similar to the one produced by this PR. 