### PR TITLE
ci: fix docs deployment

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -38,11 +38,11 @@ jobs:
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build production website
-        if: (!env.PREVIEW)
+        if: env.PREVIEW == 'false'
         run: |
           nix build .#contrast-docs
       - name: Publish docs to GitHub Pages
-        if: (!env.PREVIEW)
+        if: env.PREVIEW == 'false'
         uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
         with:
           folder: ./result
@@ -51,11 +51,11 @@ jobs:
           force: false
 
       - name: Build preview website
-        if: env.PREVIEW
+        if: env.PREVIEW == 'true'
         run: |
           nix build --impure --expr "(builtins.getFlake \"git+file://$(pwd)?shallow=1\").outputs.legacyPackages.x86_64-linux.contrast-docs.override { docusaurusBaseUrl = \"contrast/pr-preview/pr-${{ github.event.number }}\"; }"
       - name: Deploy preview
-        if: env.PREVIEW
+        if: env.PREVIEW == 'true'
         uses: rossjrw/pr-preview-action@f31d5aa7b364955ea86228b9dcd346dc3f29c408 # v1
         with:
           source-dir: ./result


### PR DESCRIPTION
Currently, docs aren't correctly deployed when pushed to main as the PREVIEW env doesn't evaluate as expected.

See https://github.com/edgelesssys/contrast/actions/runs/8433398898/job/23095661199#step:5:15 for details.

PR tested in https://github.com/katexochen/docusaurus-testing/commit/eaed0f731aba8a99bf5ad6942db2a549e244c9dd