### PR TITLE
flake: add gotools, gopls, delve to devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,11 @@
       devShells = {
         default = pkgs.mkShell {
           packages = with pkgs; [
+            delve
             go
             golangci-lint
+            gopls
+            gotools
             just
           ];
           shellHook = ''alias make=just'';


### PR DESCRIPTION
Helps when switching Go minor version.