### PR TITLE
docs: set packageManager in package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -48,5 +48,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
This should work as a hint for renovate to use the correct package manager for updates.