### PR TITLE
release: use resourcegen tool for coordinator.yaml

### DIFF
--- a/e2e/internal/kuberesource/parts.go
+++ b/e2e/internal/kuberesource/parts.go
@@ -124,7 +124,11 @@ func ServiceForDeployment(d *applyappsv1.DeploymentApplyConfiguration) *applycor
 	selector := d.Spec.Selector.MatchLabels
 	ports := d.Spec.Template.Spec.Containers[0].Ports
 
-	s := Service(*d.Name, *d.Namespace).
+	var ns string
+	if d.Namespace != nil {
+		ns = *d.Namespace
+	}
+	s := Service(*d.Name, ns).
 		WithSpec(ServiceSpec().
 			WithSelector(selector),
 		)

--- a/e2e/internal/kuberesource/resourcegen/main.go
+++ b/e2e/internal/kuberesource/resourcegen/main.go
@@ -20,6 +20,8 @@ func main() {
 	var resources []any
 	var err error
 	switch set {
+	case "coordinator-release":
+		resources, err = kuberesource.CoordinatorRelease()
 	case "simple":
 		resources, err = kuberesource.Simple()
 	case "openssl":

--- a/e2e/internal/kuberesource/sets.go
+++ b/e2e/internal/kuberesource/sets.go
@@ -1,6 +1,24 @@
 package kuberesource
 
-import "k8s.io/apimachinery/pkg/util/intstr"
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// CoordinatorRelease will generate the Coordinator deployment YAML that is published
+// as release artifact with a pre-generated policy (which is not contained in this function).
+func CoordinatorRelease() ([]any, error) {
+	coordinator := Coordinator("").DeploymentApplyConfiguration
+	coordinatorService := ServiceForDeployment(coordinator)
+	coordinatorService.Spec.WithType(corev1.ServiceTypeLoadBalancer)
+
+	resources := []any{
+		coordinator,
+		coordinatorService,
+	}
+
+	return resources, nil
+}
 
 // Simple returns a simple set of resources for testing.
 func Simple() ([]any, error) {

--- a/e2e/internal/kuberesource/wrappers.go
+++ b/e2e/internal/kuberesource/wrappers.go
@@ -16,7 +16,11 @@ type DeploymentConfig struct {
 
 // Deployment creates a new DeploymentConfig.
 func Deployment(name, namespace string) *DeploymentConfig {
-	return &DeploymentConfig{applyappsv1.Deployment(name, namespace)}
+	d := applyappsv1.Deployment(name, namespace)
+	if namespace == "" && d.ObjectMetaApplyConfiguration != nil {
+		d.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return &DeploymentConfig{d}
 }
 
 // DeploymentSpecConfig wraps applyappsv1.DeploymentSpecApplyConfiguration.
@@ -175,7 +179,11 @@ type ServiceConfig struct {
 
 // Service creates a new ServiceConfig.
 func Service(name, namespace string) *ServiceConfig {
-	return &ServiceConfig{applycorev1.Service(name, namespace)}
+	s := applycorev1.Service(name, namespace)
+	if namespace == "" && s.ObjectMetaApplyConfiguration != nil {
+		s.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return &ServiceConfig{s}
 }
 
 // ServiceSpecConfig wraps applycorev1.ServiceSpecApplyConfiguration.


### PR DESCRIPTION
Fixes release pipeline by using the new Go codegen (resourcegen) for generating the *release* artifact for the coordinator deployment. The old source `deployments/simple` no longer exists.