### PR TITLE
ci: fix preview cleanup

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -29,7 +29,7 @@ jobs:
     name: Publish docs to GitHub Pages
     runs-on: ubuntu-22.04
     env:
-      PREVIEW: ${{ github.event_name == 'pull_request' && github.ref_name != 'main' }}
+      PREVIEW: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: ./.github/actions/setup_nix


### PR DESCRIPTION
Bug was that on PR close event, ref_name is already main. New expression tries to match the non-preview event and negates it instead, hope that's a bit more robust.