### PR TITLE
renovate: enable npm updates, document config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,20 +9,21 @@
   ],
   commitMessagePrefix: "deps:",
   commitMessageAction: "update",
+  prConcurrentLimit: 1,
   addLabels: [ "dependencies" ],
   postUpdateOptions: [
     "gomodTidy",
     "gomodUpdateImportPaths",
   ],
-  prConcurrentLimit: 1,
   nix: { enabled: true },
+  npm: { enabled: true },
   lockFileMaintenance: {
     enabled: true,
     schedule: [ "before 4am" ],
   },
   packageRules: [
     {
-      // Group lockfile maintenance updates by manager
+      // Group lockfile maintenance updates by manager.
       // https://github.com/renovatebot/renovate/discussions/28068
       matchUpdateTypes: [ "lockFileMaintenance" ],
       additionalBranchPrefix: "{{manager}}-",
@@ -30,18 +31,23 @@
       commitMessageExtra: "{{manager}} lock file",
     },
     {
+      // Enable update of indirect Go dependencies.
+      // This rule should not be confused with the grouping of
+      // indirect Go dependencies further down.
       matchManagers: [ "gomod" ],
       matchDepTypes: [ "indirect" ],
       enabled: true,
     },
     {
+      // Group update of indirect Go dependencies.
       groupName: "Go indirect dependencies",
       matchManagers: [ "gomod" ],
       matchDepTypes: [ "indirect" ],
       dependencyDashboardApproval: true,
-      prPriority: -30,
+      prPriority: -30, // Lower priority, higher risk of causing breakage.
     },
     {
+      // Group update of direct Go dependencies.
       groupName: "Go dependencies",
       matchManagers: [ "gomod" ],
       matchDepTypes: [ "require" ],
@@ -57,6 +63,7 @@
       ],
     },
     {
+      // Group update of GitHub actions dependencies.
       matchManagers: [ "github-actions" ],
       groupName: "GitHub action dependencies",
       matchUpdateTypes: [


### PR DESCRIPTION
While the yarn.lock is already updated by renovate, the package.json seems not to be touched. This PR tries to enable npm updates explicitly and add documentation to the current configuration (json5 for the win).