### PR TITLE
e2e: don't set memory limit on initContainer

### DIFF
--- a/e2e/internal/kuberesource/parts.go
+++ b/e2e/internal/kuberesource/parts.go
@@ -151,7 +151,7 @@ func Initializer() *applycorev1.ContainerApplyConfiguration {
 		WithName("initializer").
 		WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 		WithResources(ResourceRequirements().
-			WithMemoryLimitAndRequest(50),
+			WithMemoryRequest(50),
 		).
 		WithEnv(NewEnvVar("COORDINATOR_HOST", "coordinator")).
 		WithVolumeMounts(VolumeMount().

--- a/e2e/internal/kuberesource/wrappers.go
+++ b/e2e/internal/kuberesource/wrappers.go
@@ -118,6 +118,14 @@ func ResourceRequirements() *ResourceRequirementsConfig {
 	return &ResourceRequirementsConfig{applycorev1.ResourceRequirements()}
 }
 
+// WithMemoryRequest sets the memory request of the ResourceRequirements.
+func (r *ResourceRequirementsConfig) WithMemoryRequest(memoryMi int64) *applycorev1.ResourceRequirementsApplyConfiguration {
+	return r.
+		WithRequests(corev1.ResourceList{
+			corev1.ResourceMemory: fromPtr(resource.NewQuantity(memoryMi*1024*1024, resource.BinarySI)),
+		})
+}
+
 // WithMemoryLimitAndRequest sets the memory limit and request of the ResourceRequirements.
 func (r *ResourceRequirementsConfig) WithMemoryLimitAndRequest(memoryMi int64) *applycorev1.ResourceRequirementsApplyConfiguration {
 	return r.


### PR DESCRIPTION
There's a bug in AKS CoCo, where the init container's memory limit is applied to the main container.