### PR TITLE
e2e: add debug information after failed watch

### DIFF
--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -69,7 +69,7 @@ func NewFromConfigFile(configPath string, log *slog.Logger) (*Kubeclient, error)
 // NewForTest creates a Kubeclient with parameters suitable for e2e testing.
 func NewForTest(t *testing.T) *Kubeclient {
 	t.Helper()
-	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	configFile := os.Getenv("KUBECONFIG")
 	if configFile == "" {
 		configFile = clientcmd.RecommendedHomeFile


### PR DESCRIPTION
Example of a failed wait: https://github.com/edgelesssys/contrast/actions/runs/8717725093/job/23913506850#step:12:104.