### PR TITLE
[release/v0.5] e2e: add ReadinessProbe to emoji-web

### DIFF
--- a/e2e/internal/kuberesource/sets.go
+++ b/e2e/internal/kuberesource/sets.go
@@ -452,6 +452,11 @@ func generateEmojivoto() ([]any, error) {
 							WithEnv(EnvVar().WithName("EDG_DISABLE_CLIENT_AUTH").WithValue("true")).
 							WithResources(ResourceRequirements().
 								WithMemoryLimitAndRequest(50),
+							).
+							WithReadinessProbe(applycorev1.Probe().
+								WithTCPSocket(TCPSocketAction().WithPort(intstr.FromInt(8080))).
+								WithInitialDelaySeconds(1).
+								WithPeriodSeconds(5),
 							),
 					),
 				),


### PR DESCRIPTION
Backport of #375 to `release/v0.5`.

Original description:

---

This ensures that service and deployment only report ready when the app is actually serving, avoiding test failures during startup. I discovered this while trying to make #370 work, which introduces a `WaitForLoadBalancer` feature. Thus, needs to be backported so that I don't have to cherry-pick it around.