### PR TITLE
deps: update go work version to 1.22.0

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,7 +1,9 @@
-go 1.21
+go 1.22.0
+
+toolchain go1.22.2
 
 use (
 	.
-	./service-mesh
 	./node-installer
+	./service-mesh
 )


### PR DESCRIPTION
Updates the go version in the `go.work` file.