### PR TITLE
docs: fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@
 
 ### Deploy
 
-The usually developer flow is available as a single target to execute:
+The usual developer flow is available as a single target to execute:
 
 ```sh
 just [default <deployment-name>]


### PR DESCRIPTION
Fix the typo "The usually developer flow is available as a single target to execute:" to "The usual developer flow is available as a single target to execute:"