### PR TITLE
e2e: simplify emojivoto

### DIFF
--- a/e2e/internal/kuberesource/resourcegen/main.go
+++ b/e2e/internal/kuberesource/resourcegen/main.go
@@ -42,7 +42,7 @@ func main() {
 	case "openssl":
 		resources, err = kuberesource.OpenSSL()
 	case "emojivoto":
-		resources, err = kuberesource.Emojivoto()
+		resources, err = kuberesource.Emojivoto(kuberesource.ServiceMeshDisabled)
 	default:
 		fmt.Printf("Error: unknown set: %s\n", set)
 		os.Exit(1)

--- a/e2e/internal/kuberesource/sets.go
+++ b/e2e/internal/kuberesource/sets.go
@@ -233,8 +233,8 @@ func OpenSSL() ([]any, error) {
 	return resources, nil
 }
 
-// generateEmojivoto returns resources for deploying Emojivoto application.
-func generateEmojivoto(smMode serviceMeshMode) ([]any, error) {
+// Emojivoto returns resources for deploying Emojivoto application.
+func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 	ns := "edg-default"
 	var emojiSvcImage, emojiVotingSvcImage, emojiWebImage, emojiSvcHost, votingSvcHost string
 	smProxyEmoji := ServiceMeshProxy()
@@ -644,50 +644,4 @@ func PatchNamespaces(resources []any, namespace string) []any {
 		}
 	}
 	return resources
-}
-
-// EmojivotoDemo returns patched resources for deploying an Emojivoto demo.
-func EmojivotoDemo(replacements map[string]string) ([]any, error) {
-	resources, err := generateEmojivoto(ServiceMeshDisabled)
-	if err != nil {
-		return nil, err
-	}
-	patched := PatchImages(resources, replacements)
-	patched = PatchNamespaces(patched, "default")
-	return patched, nil
-}
-
-// Emojivoto returns resources for deploying Emojivoto application.
-func Emojivoto() ([]any, error) {
-	resources, err := generateEmojivoto(ServiceMeshDisabled)
-	if err != nil {
-		return nil, err
-	}
-
-	// Add coordinator
-	ns := "edg-default"
-	namespace := Namespace(ns)
-	coordinator := Coordinator(ns).DeploymentApplyConfiguration
-	coordinatorService := ServiceForDeployment(coordinator)
-	resources = append(resources, namespace, coordinator, coordinatorService)
-
-	return resources, nil
-}
-
-// EmojivotoIngressEgress returns resources for deploying Emojivoto application with
-// the service mesh configured with ingress and egress proxies.
-func EmojivotoIngressEgress() ([]any, error) {
-	resources, err := generateEmojivoto(ServiceMeshIngressEgress)
-	if err != nil {
-		return nil, err
-	}
-
-	// Add coordinator
-	ns := "edg-default"
-	namespace := Namespace(ns)
-	coordinator := Coordinator(ns).DeploymentApplyConfiguration
-	coordinatorService := ServiceForDeployment(coordinator)
-	resources = append(resources, namespace, coordinator, coordinatorService)
-
-	return resources, nil
 }

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -30,8 +30,12 @@ var imageReplacements map[string]string
 func TestIngressEgress(t *testing.T) {
 	ct := contrasttest.New(t, imageReplacements)
 
-	resources, err := kuberesource.EmojivotoIngressEgress()
+	resources, err := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
 	require.NoError(t, err)
+
+	coordinator := kuberesource.Coordinator("").DeploymentApplyConfiguration
+	coordinatorService := kuberesource.ServiceForDeployment(coordinator)
+	resources = append(resources, coordinator, coordinatorService)
 
 	ct.Init(t, resources)
 


### PR DESCRIPTION
* Flatten the call hierarchy by removing redundant dispatch.
* Remove the coordinator from Emojivoto target and only add it where necessary (on e2e test). This is necessary so that there is no coordinator in the demo release asset.