### PR TITLE
runtime: adjust memory overhead

### DIFF
--- a/dev-docs/aks/nested-virt-internals.md
+++ b/dev-docs/aks/nested-virt-internals.md
@@ -155,12 +155,12 @@ This file is a serialization of [katautils.tomlConfig] and contains decent inlin
 option.
 
 <details>
-<summary>Example of a useful drop-in fragment</summary>
+<summary>Example of a drop-in fragment raising the default memory per VM</summary>
 
 ```sh
 cat >/opt/confidential-containers/share/defaults/kata-containers/config.d/10-memory.toml <<EOF
 [hypervisor.clh]
-default_memory = 256
+default_memory = 512
 EOF
 ```
 </details>
@@ -173,9 +173,11 @@ EOF
 
 There's [AKS documentation for resource management] which explains the basics of how CPU and
 memory are allocated for a Kata VM.
-The default memory allocation is quite high at 2GiB, which fills up the node fast.
-It's unclear why this default is chosen, given that the container limit's added on top of this
-value. Forcing a size with the pod annotation
+The default memory overhead added by the `RuntimeClass` is quite high at 2GiB, which fills up the node fast.
+It's unclear why this default is chosen, given that the container limit is added on top of this
+value and that the VMs are created with a 256MiB overhead.
+
+Forcing a size with the pod annotation
 `io.katacontainers.config.hypervisor.default_memory` would be possible, but the annotation would
 need to be allow-listed in the config setting `enable_annotations`.
 
@@ -186,7 +188,7 @@ need to be allow-listed in the config setting `enable_annotations`.
 
 ```toml
 [hypervisor.clh]
-default_memory = 2048  # MiB! Minimum seems to be around 256.
+default_memory = 256
 default_vcpus = 1
 enable_annotations = ["enable_iommu"]
 

--- a/e2e/internal/kuberesource/parts.go
+++ b/e2e/internal/kuberesource/parts.go
@@ -18,7 +18,7 @@ func ContrastRuntimeClass() *RuntimeClassConfig {
 	r := RuntimeClass(runtimeHandler).
 		WithHandler(runtimeHandler).
 		WithLabels(map[string]string{"addonmanager.kubernetes.io/mode": "Reconcile"}).
-		WithOverhead(Overhead(corev1.ResourceList{"memory": resource.MustParse("2Gi")})).
+		WithOverhead(Overhead(corev1.ResourceList{"memory": resource.MustParse("1152Mi")})).
 		WithScheduling(Scheduling(map[string]string{"kubernetes.azure.com/kata-cc-isolation": "true"}))
 
 	return &RuntimeClassConfig{r}


### PR DESCRIPTION
AKS has lowered the default memory to 256MiB in the Cloud Hypervisor config. However, lowering the memory overhead in the `RuntimeClass` to 256MiB results in failures during pod creation on full nodes, instead of just pending pods. The empirical overhead which did not lead to failures was 1152Mi.