### PR TITLE
cli: set retry loop aborts early on attestation failure

### DIFF
--- a/internal/grpc/retry/retry.go
+++ b/internal/grpc/retry/retry.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package retry provides functions to check if a gRPC error is retryable.
+package retry
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	authHandshakeErr                 = `connection error: desc = "transport: authentication handshake failed`
+	authHandshakeDeadlineExceededErr = `connection error: desc = "transport: authentication handshake failed: context deadline exceeded`
+)
+
+// grpcErr is the error type that is returned by the grpc client.
+// taken from google.golang.org/grpc/status.FromError.
+type grpcErr interface {
+	GRPCStatus() *status.Status
+	Error() string
+}
+
+// ServiceIsUnavailable checks if the error is a grpc status with code Unavailable.
+// In the special case of an authentication handshake failure, false is returned to prevent further retries.
+func ServiceIsUnavailable(err error) (ret bool) {
+	var targetErr grpcErr
+	if !errors.As(err, &targetErr) {
+		return false
+	}
+
+	statusErr, ok := status.FromError(targetErr)
+	if !ok {
+		return false
+	}
+
+	if statusErr.Code() != codes.Unavailable {
+		return false
+	}
+
+	// retry if the handshake deadline was exceeded
+	if strings.HasPrefix(statusErr.Message(), authHandshakeDeadlineExceededErr) {
+		return true
+	}
+
+	return !strings.HasPrefix(statusErr.Message(), authHandshakeErr)
+}

--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestServiceIsUnavailable(t *testing.T) {
+	testCases := map[string]struct {
+		err             error
+		wantUnavailable bool
+	}{
+		"nil": {},
+		"not status error": {
+			err: errors.New("error"),
+		},
+		"not unavailable": {
+			err: status.Error(codes.Internal, "error"),
+		},
+		"unavailable error with authentication handshake failure": {
+			err: status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: bad certificate"`),
+		},
+		"normal unavailable error": {
+			err:             status.Error(codes.Unavailable, "error"),
+			wantUnavailable: true,
+		},
+		"handshake deadline exceeded error": {
+			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: context deadline exceeded"`),
+			wantUnavailable: true,
+		},
+		"wrapped error": {
+			err:             fmt.Errorf("some wrapping: %w", status.Error(codes.Unavailable, "error")),
+			wantUnavailable: true,
+		},
+		"code unknown": {
+			err: status.Error(codes.Unknown, "unknown"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tc.wantUnavailable, ServiceIsUnavailable(tc.err))
+		})
+	}
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package retry provides a simple interface for retrying operations.
+package retry
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// IntervalRetrier retries a call with an interval. The call is defined in the Doer property.
+type IntervalRetrier struct {
+	interval  time.Duration
+	doer      Doer
+	clock     clock.WithTicker
+	retriable func(error) bool
+}
+
+// NewIntervalRetrier returns a new IntervalRetrier. The optional clock is used for testing.
+func NewIntervalRetrier(doer Doer, interval time.Duration, retriable func(error) bool, optClock ...clock.WithTicker) *IntervalRetrier {
+	var clock clock.WithTicker = clock.RealClock{}
+	if len(optClock) > 0 {
+		clock = optClock[0]
+	}
+
+	return &IntervalRetrier{
+		interval:  interval,
+		doer:      doer,
+		clock:     clock,
+		retriable: retriable,
+	}
+}
+
+// Do retries performing a call until it succeeds, returns a permanent error or the context is cancelled.
+func (r *IntervalRetrier) Do(ctx context.Context) error {
+	ticker := r.clock.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		err := r.doer.Do(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if !r.retriable(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C():
+		}
+	}
+}
+
+// Doer does something and returns an error.
+type Doer interface {
+	// Do performs an operation.
+	//
+	// It should return an error that can be checked for retriability.
+	Do(ctx context.Context) error
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	testclock "k8s.io/utils/clock/testing"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
+}
+
+func TestDo(t *testing.T) {
+	testCases := map[string]struct {
+		cancel  bool
+		errors  []error
+		wantErr error
+	}{
+		"no error": {
+			errors: []error{
+				nil,
+			},
+		},
+		"permanent error": {
+			errors: []error{
+				errors.New("error"),
+			},
+			wantErr: errors.New("error"),
+		},
+		"service unavailable then success": {
+			errors: []error{
+				errors.New("retry me"),
+				nil,
+			},
+		},
+		"service unavailable then permanent error": {
+			errors: []error{
+				errors.New("retry me"),
+				errors.New("error"),
+			},
+			wantErr: errors.New("error"),
+		},
+		"cancellation works": {
+			cancel: true,
+			errors: []error{
+				errors.New("retry me"),
+			},
+			wantErr: context.Canceled,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			doer := newStubDoer()
+			clock := testclock.NewFakeClock(time.Now())
+			retrier := IntervalRetrier{
+				doer:      doer,
+				clock:     clock,
+				retriable: isRetriable,
+			}
+			retrierResult := make(chan error, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go func() { retrierResult <- retrier.Do(ctx) }()
+			for _, err := range tc.errors {
+				doer.errC <- err
+				clock.Step(retrier.interval)
+			}
+
+			if tc.cancel {
+				cancel()
+			}
+
+			assert.Equal(tc.wantErr, <-retrierResult)
+		})
+	}
+}
+
+type stubDoer struct {
+	errC chan error
+}
+
+func newStubDoer() *stubDoer {
+	return &stubDoer{
+		errC: make(chan error),
+	}
+}
+
+func (d *stubDoer) Do(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-d.errC:
+		return err
+	}
+}
+
+func isRetriable(err error) bool {
+	return err.Error() == "retry me"
+}


### PR DESCRIPTION
Before this change, the retry loop to set the manifest retries as long as the call to `SetManifest` returns an error, even if the attestation fails. If the attestation fails, the retry loop is now aborted early.