### PR TITLE
e2e: activate debug logging in tests

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -72,6 +72,7 @@ func (ct *ContrastTest) Init(t *testing.T, resources []any) {
 	// Prepare resources
 	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
 	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
+	resources = kuberesource.AddLogging(resources, "debug")
 	unstructuredResources, err := kuberesource.ResourcesToUnstructured(resources)
 	require.NoError(err)
 

--- a/e2e/internal/kuberesource/mutators.go
+++ b/e2e/internal/kuberesource/mutators.go
@@ -106,3 +106,20 @@ func AddPortForwarders(resources []any) []any {
 	}
 	return out
 }
+
+// AddLogging modifies Contrast Coordinators among the resources to enable debug logging.
+func AddLogging(resources []any, level string) []any {
+	// "contrast.edgeless.systems/pod-role": "coordinator"
+	for _, resource := range resources {
+		switch r := resource.(type) {
+		case *applyappsv1.DeploymentApplyConfiguration:
+			if r.Spec.Template.Annotations["contrast.edgeless.systems/pod-role"] == "coordinator" {
+				r.Spec.Template.Spec.Containers[0].WithEnv(
+					NewEnvVar("CONTRAST_LOG_LEVEL", level),
+					NewEnvVar("CONTRAST_LOG_SUBSYSTEMS", "*"),
+				)
+			}
+		}
+	}
+	return resources
+}

--- a/e2e/internal/kuberesource/parts.go
+++ b/e2e/internal/kuberesource/parts.go
@@ -149,9 +149,6 @@ func Coordinator(namespace string) *CoordinatorConfig {
 						Container().
 							WithName("coordinator").
 							WithImage("ghcr.io/edgelesssys/contrast/coordinator:latest").
-							WithEnv(
-								NewEnvVar("CONTRAST_LOG_LEVEL", "debug"),
-							).
 							WithPorts(
 								ContainerPort().
 									WithName("userapi").


### PR DESCRIPTION
This enables debug logging in the coordinator, but there is no automatic log collection yet. For now, it's mostly useful for manual, supervised test runs.