### PR TITLE
generate: better error message on missing runtimeClass

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -168,12 +168,15 @@ func findGenerateTargets(args []string, logger *slog.Logger) ([]string, error) {
 			return nil, fmt.Errorf("failed to walk %s: %w", path, err)
 		}
 	}
-
-	paths = filterNonCoCoRuntime("contrast-cc", paths, logger)
-
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("no .yml/.yaml files found")
 	}
+
+	paths = filterNonCoCoRuntime("contrast-cc", paths, logger)
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no .yml/.yaml files with 'contrast-cc' runtime found")
+	}
+
 	return paths, nil
 }
 


### PR DESCRIPTION
Previously, if the deployment files didn't contain any known runtimeClass, the CLI would error with `no .yml/.yaml files found`, which is pretty confusing.