### PR TITLE
[release/v0.5] embedbin: implement fallback for missing memfd

### DIFF
--- a/internal/embedbin/embedbin.go
+++ b/internal/embedbin/embedbin.go
@@ -2,3 +2,11 @@
 //
 // The Install function creates a temporary file and writes the contents to it.
 package embedbin
+
+// Installed is a handle to an installed binary.
+// Users must call Uninstall to clean it up.
+type Installed interface {
+	Path() string
+	IsRegular() bool
+	Uninstall() error
+}

--- a/internal/embedbin/regular.go
+++ b/internal/embedbin/regular.go
@@ -14,7 +14,7 @@ type RegularInstaller struct {
 // Install creates a regular file and writes the contents to it.
 // prefix is an optional prefix for the temporary file.
 // If prefix is empty, a temporary directory will be used.
-func (r *RegularInstaller) Install(prefix string, contents []byte) (*RegularInstall, error) {
+func (r *RegularInstaller) Install(prefix string, contents []byte) (Installed, error) {
 	if prefix != "" {
 		if err := r.fs.MkdirAll(prefix, os.ModePerm); err != nil {
 			return nil, err


### PR DESCRIPTION
Backport of #399 to `release/v0.5`.

Original description:

---

Some Linux platforms (notably WSL1) do not implement memfd. This adds a fallback at runtime.