### PR TITLE
cli: enable rust debug logs

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -277,6 +277,7 @@ func generatePolicyForFile(ctx context.Context, genpolicyPath, regoPath, policyP
 		fmt.Sprintf("--yaml-file=%s", yamlPath),
 	}
 	genpolicy := exec.CommandContext(ctx, genpolicyPath, args...)
+	genpolicy.Env = append(genpolicy.Env, "RUST_LOG=DEBUG")
 	var stdout, stderr bytes.Buffer
 	genpolicy.Stdout = &stdout
 	genpolicy.Stderr = &stderr


### PR DESCRIPTION
The `genpolicy` tool adopted a convention of simply panicking instead of reporting decent errors. For example, if you try to generate a resource with a non-existent image, it does not report which image it failed to pull, unless you switch on logging. This is an attempt to extract some meaningful information from the tool when debug logging is on.