### PR TITLE
[release/v0.5] release: don't publish namespace object

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -214,7 +214,8 @@ with pkgs;
     text = ''
       imageReplacements=$1
       destinationFile=$2
-      resourcegen --image-replacements="$imageReplacements" emojivoto "$destinationFile"
+      # The document at index 0 is the namespace, which we don't want to include in the release.
+      resourcegen --image-replacements="$imageReplacements" emojivoto /dev/stdout | yq 'select(di != 0)' > "$destinationFile"
       nix run .#kypatch namespace -- "$destinationFile" --replace edg-default default
     '';
   };


### PR DESCRIPTION
Previously, the deployment YAML for the emojivoto demo contained a namespace object with name "default". While such a namespace can always be applied, even if it already exists, it cannot be deleted, so an error was thrown during cleanup.

This PR removes the namespace object from the demo bundle.