### PR TITLE
kata-agent: init at 3.2.0.azl1

### DIFF
--- a/packages/by-name/kata-agent/package.nix
+++ b/packages/by-name/kata-agent/package.nix
@@ -1,0 +1,87 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, cmake
+, pkg-config
+, protobuf
+, withSeccomp ? true
+, libseccomp
+, lvm2
+, openssl
+, withAgentPolicy ? true
+, withStandardOCIRuntime ? false
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "kata-agent";
+  version = "3.2.0.azl1";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kata-containers";
+    rev = version;
+    hash = "sha256-W36RJFf0MVRIBV4ahpv6pqdAwgRYrlqmu4Y/8qiILS8=";
+  };
+
+  sourceRoot = "${src.name}/src/agent";
+
+  cargoLock = {
+    lockFile = "${src}/src/agent/Cargo.lock";
+    outputHashes = {
+      "sev-1.2.1" = "sha256-5UkHDDJMVUG18AN/c6BSMTkEgSG8MBB33DZE355gXdE=";
+      "regorus-0.1.4" = "sha256-hKhuPEgtVOW1/83fVyQB61ZPRYzNqPdDhS0lNyJpekc=";
+    };
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+    openssl.dev
+    lvm2.dev
+    rustPlatform.bindgenHook
+  ] ++ lib.optionals withSeccomp [
+    libseccomp.dev
+    libseccomp.lib
+    libseccomp
+  ];
+
+  # Build.rs writes to src
+  postConfigure = ''
+    chmod -R +w ../..
+  '';
+
+  env = {
+    LIBC = "gnu";
+    SECCOMP = if withSeccomp then "yes" else "no";
+    AGENT_POLICY = if withAgentPolicy then "yes" else "no";
+    STANDARD_OCI_RUNTIME = if withStandardOCIRuntime then "yes" else "no";
+    OPENSSL_NO_VENDOR = 1;
+    RUST_BACKTRACE = 1;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    make
+
+    runHook postBuild
+  '';
+
+  checkFlags = [
+    "--skip=mount::tests::test_already_baremounted"
+    "--skip=netlink::tests::list_routes stdout"
+  ];
+
+  meta = {
+    description = ''The Kata agent is a long running process that runs inside the Virtual Machine (VM) (also known as the "pod" or "sandbox").'';
+    license = lib.licenses.asl20;
+    mainProgram = "kata-agent";
+  };
+}


### PR DESCRIPTION
This is a part of the custom runtime efforts. The agent will be installed inside of the Contrast guest VM image and handle kata runtime calls from the host.