### PR TITLE
kata-runtime: init at 3.2.0.azl1

### DIFF
--- a/packages/by-name/kata-runtime/package.nix
+++ b/packages/by-name/kata-runtime/package.nix
@@ -1,0 +1,67 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+{ buildGoModule
+, fetchFromGitHub
+, yq-go
+, git
+}:
+buildGoModule rec {
+  pname = "kata-runtime";
+  version = "3.2.0.azl1";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kata-containers";
+    rev = version;
+    hash = "sha256-W36RJFf0MVRIBV4ahpv6pqdAwgRYrlqmu4Y/8qiILS8=";
+  };
+
+  sourceRoot = "${src.name}/src/runtime";
+
+  vendorHash = null;
+
+  subPackages = [
+    "cmd/containerd-shim-kata-v2"
+    "cmd/kata-monitor"
+    # TODO(malt3): enable kata-runtime
+    # It depends on CGO and kvm
+    # "cmd/kata-runtime"
+  ];
+
+  preBuild = ''
+    substituteInPlace Makefile \
+      --replace-fail 'include golang.mk' ""
+    for f in $(find . -name '*.in' -type f); do
+      make ''${f%.in}
+    done
+  '';
+
+  nativeBuildInputs = [
+    yq-go
+    git
+  ];
+
+  CGO_ENABLED = 0;
+  ldflags = [ "-s" ];
+
+  checkFlags =
+    let
+      # Skip tests that require a working hypervisor
+      skippedTests = [
+        "TestArchRequiredKernelModules"
+        "TestCheckCLIFunctionFail"
+        "TestEnvCLIFunction(|Fail)"
+        "TestEnvGetAgentInfo"
+        "TestEnvGetEnvInfo(|SetsCPUType|NoHypervisorVersion|AgentError|NoOSRelease|NoProcCPUInfo|NoProcVersion)"
+        "TestEnvGetRuntimeInfo"
+        "TestEnvHandleSettings(|InvalidParams)"
+        "TestGetHypervisorInfo"
+        "TestGetHypervisorInfoSocket"
+        "TestSetCPUtype"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  meta.mainProgram = "containerd-shim-kata-v2";
+}


### PR DESCRIPTION
This is a part of the custom runtime efforts. The runtime will be installed on each host (Kubernetes node) and acts as a containerd plugin.