### PR TITLE
e2e: add getdent regression test

### DIFF
--- a/.github/workflows/e2e_getdents.yml
+++ b/.github/workflows/e2e_getdents.yml
@@ -1,0 +1,53 @@
+name: e2e test getdents
+
+on:
+    workflow_dispatch:
+      inputs:
+        skip-undeploy:
+          description: "Skip undeploy"
+          required: false
+          default: "false"
+
+env:
+  container_registry: ghcr.io/edgelesssys
+  azure_resource_group: contrast-ci
+  DO_NOT_TRACK: 1
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: ./.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Azure
+        uses: azure/login@6b2456866fc08b011acb422a92a4aa20e2c4de32 # v2.1.0
+        with:
+          creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
+      - uses: nicknovitski/nix-develop@a2060d116a50b36dfab02280af558e73ab52427d # v1.1.0
+      - name: Create justfile.env
+        run: |
+          cat <<EOF > justfile.env
+          container_registry=${{ env.container_registry }}
+          azure_resource_group=${{ env.azure_resource_group }}
+          EOF
+      - name: Get credentials for CI cluster
+        run: |
+          just get-credentials
+      - name: Build and prepare deployments
+        run: |
+          just node-installer
+      - name: E2E Test
+        run: |
+          nix shell .#contrast.e2e --command getdents.test -test.v workspace/just.containerlookup

--- a/e2e/getdents/getdents_test.go
+++ b/e2e/getdents/getdents_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package getdents
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/contrast/cli/cmd"
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	getdent = "getdents-tester"
+)
+
+var imageReplacements map[string]string
+
+func TestGetDEnts(t *testing.T) {
+	ct := contrasttest.New(t, imageReplacements)
+
+	resources, err := kuberesource.GetDEnts()
+	require.NoError(t, err)
+
+	ct.Init(t, resources)
+
+	// Call generate to patch the runtime class.
+	require.True(t, t.Run("generate", func(t *testing.T) {
+		require := require.New(t)
+		args := append([]string{"--workspace-dir", ct.WorkDir}, path.Join(ct.WorkDir, "resources.yaml"))
+		generate := cmd.NewGenerateCmd()
+		generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags
+		generate.SetArgs(args)
+		generate.SetOut(io.Discard)
+		errBuf := &bytes.Buffer{}
+		generate.SetErr(errBuf)
+
+		require.NoError(generate.Execute())
+	}), "contrast generate needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+
+	// This tests an upstream bug in TarFS where a 'getdents' call hangs in an infinite loop when too many files are in a directory.
+	// If the 'find' command results in a timeout, the test fails.
+	t.Run("call find on large folder", func(t *testing.T) {
+		require := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, getdent))
+
+		pods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, getdent)
+		require.NoError(err)
+		require.Len(pods, 1, "pod not found: %s/%s", ct.Namespace, getdent)
+
+		stdout, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, pods[0].Name, []string{"/bin/sh", "-c", "find /toomany | wc -l"})
+		require.NoError(err, "stderr: %q", stderr)
+		require.Equal(stdout, "10001\n", "output: %s", stdout)
+	})
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	f, err := os.Open(flag.Arg(0))
+	if err != nil {
+		log.Fatalf("could not open image definition file %q: %v", flag.Arg(0), err)
+	}
+	imageReplacements, err = kuberesource.ImageReplacementsFromFile(f)
+	if err != nil {
+		log.Fatalf("could not parse image definition file %q: %v", flag.Arg(0), err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -164,6 +164,34 @@ func OpenSSL() ([]any, error) {
 	return resources, nil
 }
 
+// GetDEnts returns a set of resources for testing getdents entry limits.
+func GetDEnts() ([]any, error) {
+	tester := Deployment("getdents-tester", "").
+		WithSpec(DeploymentSpec().
+			WithReplicas(1).
+			WithSelector(LabelSelector().
+				WithMatchLabels(map[string]string{"app.kubernetes.io/name": "getdents-tester"}),
+			).
+			WithTemplate(PodTemplateSpec().
+				WithLabels(map[string]string{"app.kubernetes.io/name": "getdents-tester"}).
+				WithSpec(PodSpec().
+					WithRuntimeClassName(runtimeHandler).
+					WithContainers(
+						Container().
+							WithName("getdents-tester").
+							WithImage("ghcr.io/edgelesssys/contrast/getdents-e2e-test:1").
+							WithCommand("/bin/sh", "-c", "sleep inf").
+							WithResources(ResourceRequirements().
+								WithMemoryLimitAndRequest(50),
+							),
+					),
+				),
+			),
+		)
+
+	return []any{tester}, nil
+}
+
 // Emojivoto returns resources for deploying Emojivoto application.
 func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 	ns := ""

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -23,7 +23,7 @@ let
       "-X github.com/edgelesssys/contrast/internal/kuberesource.runtimeHandler=${runtimeHandler}"
     ];
 
-    subPackages = [ "e2e/openssl" "e2e/servicemesh" "e2e/release" ];
+    subPackages = [ "e2e/getdents" "e2e/openssl" "e2e/servicemesh" "e2e/release" ];
   };
 
   launchDigest = builtins.readFile "${runtime-class-files}/launch-digest.hex";


### PR DESCRIPTION
This tests if getdents can process large amounts of files by searching through a directory, which should have 10000 files. The test currently fails and is available as a workflow dispatch trigger.