### PR TITLE
create: allow overriding the AKS cluster location with justfile.env

### DIFF
--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ undeploy:
 
 # Create a CoCo-enabled AKS cluster.
 create:
-    nix run .#scripts.create-coco-aks -- --name="$azure_resource_group"
+    nix run .#scripts.create-coco-aks -- --name="$azure_resource_group" --location="$azure_location"
 
 # Set the manifest at the coordinator.
 set cli=default_cli:
@@ -232,6 +232,8 @@ azure_resource_group=""
 # No need to change anything below this line.
 #
 
+# Azure location for the resource group and AKS cluster.
+azure_location="westeurope"
 # Namespace suffix, can be empty. Will be used when patching namespaces.
 namespace_suffix=""
 # Cache directory for the CLI.

--- a/packages/create-coco-aks.sh
+++ b/packages/create-coco-aks.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 # Issue for Terraform support:
 # https://github.com/hashicorp/terraform-provider-azurerm/issues/24196
 #
+
+name=""
+location="westeurope"
+k8sVersion="1.29"
+
 for i in "$@"; do
   case $i in
   --name=*)
@@ -37,13 +42,13 @@ set -x
 # In GH actions, CI=true is part of the environment.
 az group create \
   --name "${name}" \
-  --location "${location:-westeurope}" ||
+  --location "${location}" ||
   $CI
 
 az aks create \
   --resource-group "${name}" \
   --name "${name}" \
-  --kubernetes-version "${k8sVersion:-1.29}" \
+  --kubernetes-version "${k8sVersion}" \
   --os-sku AzureLinux \
   --node-vm-size Standard_DC4as_cc_v5 \
   --node-count 1 \


### PR DESCRIPTION
Also ensure bash variables in `create-coco-aks` are not inherited from just directly.