### PR TITLE
cmd/generate: decrease RUST_LOG to info

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -330,7 +330,7 @@ func generatePolicyForFile(ctx context.Context, genpolicyPath, regoPath, policyP
 		fmt.Sprintf("--yaml-file=%s", yamlPath),
 	}
 	genpolicy := exec.CommandContext(ctx, genpolicyPath, args...)
-	genpolicy.Env = append(genpolicy.Env, "RUST_LOG=DEBUG")
+	genpolicy.Env = append(genpolicy.Env, "RUST_LOG=info")
 	var stdout, stderr bytes.Buffer
 	genpolicy.Stdout = &stdout
 	genpolicy.Stderr = &stderr


### PR DESCRIPTION
The output given on error is currently huge. Decreasing to info should still give enough information to identify the issue.