### PR TITLE
genpolicy-msft: bump version to 3.2.0.azl1.genpolicy0

### DIFF
--- a/packages/by-name/genpolicy-msft/genpolicy_msft_rules_coordinator.patch
+++ b/packages/by-name/genpolicy-msft/genpolicy_msft_rules_coordinator.patch
@@ -1,8 +1,8 @@
 diff --git a/genpolicy-rules.rego b/genpolicy-rules.rego
-index e1954e9..fb508bc 100644
+index c3eb334..a796740 100644
 --- a/genpolicy-rules.rego
 +++ b/genpolicy-rules.rego
-@@ -137,9 +137,9 @@ allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, s_name) {
+@@ -164,9 +164,9 @@ allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, s_name) {
      p_namespace := p_oci.Annotations[s_namespace]
      i_namespace := i_oci.Annotations[s_namespace]
      print("allow_by_sandbox_name: p_namespace =", p_namespace, "i_namespace =", i_namespace)

--- a/packages/by-name/genpolicy-msft/genpolicy_msft_settings_dev.patch
+++ b/packages/by-name/genpolicy-msft/genpolicy_msft_settings_dev.patch
@@ -1,10 +1,8 @@
 diff --git a/genpolicy-settings.json b/genpolicy-settings.json
-old mode 100755
-new mode 100644
-index 7a732b1..0dd0457
+index 7d35862..536c10e 100644
 --- a/genpolicy-settings.json
 +++ b/genpolicy-settings.json
-@@ -302,10 +290,12 @@
+@@ -315,11 +315,13 @@
          ],
          "ExecProcessRequest": {
              "commands": [],
@@ -13,6 +11,7 @@ index 7a732b1..0dd0457
 +                ".*"
 +            ]
          },
+         "CloseStdinRequest": false,
          "ReadStreamRequest": true,
          "UpdateEphemeralMountsRequest": false,
 -        "WriteStreamRequest": false

--- a/packages/by-name/genpolicy-msft/package.nix
+++ b/packages/by-name/genpolicy-msft/package.nix
@@ -4,7 +4,6 @@
 { lib
 , fetchFromGitHub
 , fetchurl
-, fetchpatch
 , applyPatches
 , rustPlatform
 , openssl
@@ -12,45 +11,32 @@
 , libiconv
 , zlib
 , cmake
+, protobuf
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "genpolicy";
-  version = "3.2.0.azl0.genpolicy1";
+  version = "3.2.0.azl1.genpolicy0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "kata-containers";
     rev = "refs/tags/${version}";
-    hash = "sha256-A+xlX7OsGUiYnvceUO5DKz14ASqbJnAg0SVJY5laxqs=";
+    hash = "sha256-W36RJFf0MVRIBV4ahpv6pqdAwgRYrlqmu4Y/8qiILS8=";
   };
-
-  patches = [
-    # TODO(malt3): drop this patch when msft fork adopted this from upstream
-    (fetchpatch {
-      name = "genpolicy_path_handling.patch";
-      url = "https://github.com/kata-containers/kata-containers/commit/befef119ff4df2868cdc88d4273c8be965387793.patch";
-      sha256 = "sha256-4pfYrP9KaPVcrFbm6DkiZUNckUq0fKWZPfCONW8/kso=";
-    })
-    # TODO(3u13r): drop this patch when msft fork adopted this from upstream
-    (fetchpatch {
-      name = "genpolicy_msft_settings_dev.patch";
-      url = "https://github.com/kata-containers/kata-containers/commit/5398b6466c58676db7f73370e1a56f4fbb35d8cf.patch";
-      sha256 = "sha256-cJ/uUF2F//QAP79AXu3tgfcByrWy2bvUjPfOAIZrtD8=";
-    })
-  ];
 
   patchFlags = [ "-p4" ];
 
   sourceRoot = "${src.name}/src/tools/genpolicy";
 
-  cargoHash = "sha256-BWFD3gm1big/frVCWksLyTcn3R/QSefavQ2g1EPsBkU=";
+  cargoHash = "sha256-YxIwsjs4K0TNVlwwA+PrOrCf16h7ZW+zU/jXeFfIMZo=";
 
   OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [
     pkg-config
     cmake
+    protobuf
   ];
 
   buildInputs = [
@@ -60,11 +46,15 @@ rustPlatform.buildRustPackage rec {
     zlib
   ];
 
+  preBuild = ''
+    make src/version.rs
+  '';
+
   passthru = rec {
     settings = fetchurl {
       name = "${pname}-${version}-settings";
-      url = "https://github.com/microsoft/kata-containers/releases/download/${version}/genpolicy-settings.json";
-      hash = "sha256-Q19H7Oj8c7SlPyib96fSRZhx/nJ96HXb8dfb9Y/Rsw8=";
+      url = "https://raw.githubusercontent.com/microsoft/kata-containers/${version}/src/tools/genpolicy/genpolicy-settings.json";
+      hash = "sha256-jrhzDqesm16yCV3aex48c2OcEimCUrxwhoaJUtAMPvo=";
       downloadToTemp = true;
       recursiveHash = true;
       postFetch = "install -D $downloadedFile $out/genpolicy-settings.json";
@@ -78,8 +68,8 @@ rustPlatform.buildRustPackage rec {
 
     rules = fetchurl {
       name = "${pname}-${version}-rules";
-      url = "https://github.com/microsoft/kata-containers/releases/download/${version}/rules.rego";
-      hash = "sha256-piPyARaIwtJ5CZiVlQ+t793Z80IIpWFG8iN7jHgBe6E=";
+      url = "https://raw.githubusercontent.com/microsoft/kata-containers/${version}/src/tools/genpolicy/rules.rego";
+      hash = "sha256-fhE5hDND5QeZtEw3u+qgSVsFO+00cc41k/r/Y+km6TU=";
       downloadToTemp = true;
       recursiveHash = true;
       postFetch = "install -D $downloadedFile $out/genpolicy-rules.rego";

--- a/packages/by-name/genpolicy-msft/package.nix
+++ b/packages/by-name/genpolicy-msft/package.nix
@@ -25,8 +25,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-W36RJFf0MVRIBV4ahpv6pqdAwgRYrlqmu4Y/8qiILS8=";
   };
 
-  patchFlags = [ "-p4" ];
-
   sourceRoot = "${src.name}/src/tools/genpolicy";
 
   cargoHash = "sha256-YxIwsjs4K0TNVlwwA+PrOrCf16h7ZW+zU/jXeFfIMZo=";
@@ -53,6 +51,7 @@ rustPlatform.buildRustPackage rec {
   passthru = rec {
     settings = fetchurl {
       name = "${pname}-${version}-settings";
+      # TODO(burgerdev): see whether future releases contain this file as an asset again (not true for 3.2.0.azl1).
       url = "https://raw.githubusercontent.com/microsoft/kata-containers/${version}/src/tools/genpolicy/genpolicy-settings.json";
       hash = "sha256-jrhzDqesm16yCV3aex48c2OcEimCUrxwhoaJUtAMPvo=";
       downloadToTemp = true;
@@ -68,6 +67,7 @@ rustPlatform.buildRustPackage rec {
 
     rules = fetchurl {
       name = "${pname}-${version}-rules";
+      # TODO(burgerdev): see whether future releases contain this file as an asset again (not true for 3.2.0.azl1).
       url = "https://raw.githubusercontent.com/microsoft/kata-containers/${version}/src/tools/genpolicy/rules.rego";
       hash = "sha256-fhE5hDND5QeZtEw3u+qgSVsFO+00cc41k/r/Y+km6TU=";
       downloadToTemp = true;


### PR DESCRIPTION
This release is what's currently available on AKS.