### PR TITLE
[release/v0.6] kuberesource: remove namespace when patching with empty string

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -580,18 +580,22 @@ func PatchImages(resources []any, replacements map[string]string) []any {
 
 // PatchNamespaces replaces namespaces in a set of resources.
 func PatchNamespaces(resources []any, namespace string) []any {
+	var nsPtr *string
+	if namespace != "" {
+		nsPtr = &namespace
+	}
 	for _, resource := range resources {
 		switch r := resource.(type) {
 		case *applycorev1.PodApplyConfiguration:
-			r.Namespace = &namespace
+			r.Namespace = nsPtr
 		case *applyappsv1.DeploymentApplyConfiguration:
-			r.Namespace = &namespace
+			r.Namespace = nsPtr
 		case *applyappsv1.DaemonSetApplyConfiguration:
-			r.Namespace = &namespace
+			r.Namespace = nsPtr
 		case *applycorev1.ServiceApplyConfiguration:
-			r.Namespace = &namespace
+			r.Namespace = nsPtr
 		case *applycorev1.ServiceAccountApplyConfiguration:
-			r.Namespace = &namespace
+			r.Namespace = nsPtr
 		}
 	}
 	return resources


### PR DESCRIPTION
Backport of #465 to `release/v0.6`.

Original description:

---

In the emojivoto-demo deployment YAML that we released with v0.6.0, the namespace is explicitly set to the empty string.
While this is valid for Kubernetes (empty string is synonym to the default namespace), genpolicy can't handle these empty strings and will enforce in the policy the literal empty string, leading to the deployment being unable to start.