### PR TITLE
ci: fix backport of workflow failures

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,6 +23,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
       - name: Create backport PRs
         uses: korthout/backport-action@ef20d86abccbac3ee3a73cb2efbdc06344c390e5 # v2.5.0
         with:


### PR DESCRIPTION
Apparently passing a token with sufficient permission to the action isn't enough, we also need to check out using that token. See https://github.com/korthout/backport-action/issues/368