### PR TITLE
coordinator: add metric for attestation failures with error string

### DIFF
--- a/docs/docs/architecture/observability.md
+++ b/docs/docs/architecture/observability.md
@@ -29,7 +29,8 @@ not.
 For the mesh API, the metric names are prefixed with `meshapi_grpc_server_`. The
 metrics include similar data to the user API for the method `NewMeshCert` which
 gets called by the [Initializer](../components#the-initializer) when starting a
-new workload.
+new workload. Attestation failures from workloads to the Coordinator can be
+tracked with the counter `meshapi_attestation_failures`.
 
 The current manifest generation is exposed as a
 [gauge](https://prometheus.io/docs/concepts/metric_types/#gauge) with the metric


### PR DESCRIPTION
This adds a metrics for attestation failures from workloads to the Coordinator when calling NewMeshCert on the initial startup. If the attestation fails, the metric counter `coordinator_attestation_failures` increases with the label `error` which stores the error string.