### PR TITLE
resourcegen: support StatefulSet in PatchImages

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -114,7 +114,6 @@ func AddPortForwarders(resources []any) []any {
 
 // AddLoadBalancers adds a load balancer to each Service resource.
 func AddLoadBalancers(resources []any) []any {
-	// "contrast.edgeless.systems/expose-service":"true"
 	var out []any
 	for _, resource := range resources {
 		switch obj := resource.(type) {
@@ -130,7 +129,6 @@ func AddLoadBalancers(resources []any) []any {
 
 // AddLogging modifies Contrast Coordinators among the resources to enable debug logging.
 func AddLogging(resources []any, level string) []any {
-	// "contrast.edgeless.systems/pod-role": "coordinator"
 	for _, resource := range resources {
 		switch r := resource.(type) {
 		case *applyappsv1.DeploymentApplyConfiguration:

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -147,39 +147,23 @@ func AddLogging(resources []any, level string) []any {
 
 // PatchImages replaces images in a set of resources.
 func PatchImages(resources []any, replacements map[string]string) []any {
+	var out []any
 	for _, resource := range resources {
-		switch r := resource.(type) {
-		case *applyappsv1.DeploymentApplyConfiguration:
-			for i := 0; i < len(r.Spec.Template.Spec.InitContainers); i++ {
-				if replacement, ok := replacements[*r.Spec.Template.Spec.InitContainers[i].Image]; ok {
-					r.Spec.Template.Spec.InitContainers[i].Image = &replacement
+		out = append(out, MapPodSpec(resource, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
+			for i := 0; i < len(spec.InitContainers); i++ {
+				if replacement, ok := replacements[*spec.InitContainers[i].Image]; ok {
+					spec.InitContainers[i].Image = &replacement
 				}
 			}
-			for i := 0; i < len(r.Spec.Template.Spec.Containers); i++ {
-				if replacement, ok := replacements[*r.Spec.Template.Spec.Containers[i].Image]; ok {
-					r.Spec.Template.Spec.Containers[i].Image = &replacement
+			for i := 0; i < len(spec.Containers); i++ {
+				if replacement, ok := replacements[*spec.Containers[i].Image]; ok {
+					spec.Containers[i].Image = &replacement
 				}
 			}
-		case *applyappsv1.DaemonSetApplyConfiguration:
-			for i := 0; i < len(r.Spec.Template.Spec.InitContainers); i++ {
-				if replacement, ok := replacements[*r.Spec.Template.Spec.InitContainers[i].Image]; ok {
-					r.Spec.Template.Spec.InitContainers[i].Image = &replacement
-				}
-			}
-			for i := 0; i < len(r.Spec.Template.Spec.Containers); i++ {
-				if replacement, ok := replacements[*r.Spec.Template.Spec.Containers[i].Image]; ok {
-					r.Spec.Template.Spec.Containers[i].Image = &replacement
-				}
-			}
-		case *applycorev1.PodApplyConfiguration:
-			for i := 0; i < len(r.Spec.Containers); i++ {
-				if replacement, ok := replacements[*r.Spec.Containers[i].Image]; ok {
-					r.Spec.Containers[i].Image = &replacement
-				}
-			}
-		}
+			return spec
+		}))
 	}
-	return resources
+	return out
 }
 
 // PatchNamespaces replaces namespaces in a set of resources.

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -5,6 +5,8 @@ package kuberesource
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	applybatchv1 "k8s.io/client-go/applyconfigurations/batch/v1"
@@ -137,6 +139,103 @@ func AddLogging(resources []any, level string) []any {
 					NewEnvVar("CONTRAST_LOG_LEVEL", level),
 					NewEnvVar("CONTRAST_LOG_SUBSYSTEMS", "*"),
 				)
+			}
+		}
+	}
+	return resources
+}
+
+// PatchImages replaces images in a set of resources.
+func PatchImages(resources []any, replacements map[string]string) []any {
+	for _, resource := range resources {
+		switch r := resource.(type) {
+		case *applyappsv1.DeploymentApplyConfiguration:
+			for i := 0; i < len(r.Spec.Template.Spec.InitContainers); i++ {
+				if replacement, ok := replacements[*r.Spec.Template.Spec.InitContainers[i].Image]; ok {
+					r.Spec.Template.Spec.InitContainers[i].Image = &replacement
+				}
+			}
+			for i := 0; i < len(r.Spec.Template.Spec.Containers); i++ {
+				if replacement, ok := replacements[*r.Spec.Template.Spec.Containers[i].Image]; ok {
+					r.Spec.Template.Spec.Containers[i].Image = &replacement
+				}
+			}
+		case *applyappsv1.DaemonSetApplyConfiguration:
+			for i := 0; i < len(r.Spec.Template.Spec.InitContainers); i++ {
+				if replacement, ok := replacements[*r.Spec.Template.Spec.InitContainers[i].Image]; ok {
+					r.Spec.Template.Spec.InitContainers[i].Image = &replacement
+				}
+			}
+			for i := 0; i < len(r.Spec.Template.Spec.Containers); i++ {
+				if replacement, ok := replacements[*r.Spec.Template.Spec.Containers[i].Image]; ok {
+					r.Spec.Template.Spec.Containers[i].Image = &replacement
+				}
+			}
+		case *applycorev1.PodApplyConfiguration:
+			for i := 0; i < len(r.Spec.Containers); i++ {
+				if replacement, ok := replacements[*r.Spec.Containers[i].Image]; ok {
+					r.Spec.Containers[i].Image = &replacement
+				}
+			}
+		}
+	}
+	return resources
+}
+
+// PatchNamespaces replaces namespaces in a set of resources.
+func PatchNamespaces(resources []any, namespace string) []any {
+	var nsPtr *string
+	if namespace != "" {
+		nsPtr = &namespace
+	}
+	for _, resource := range resources {
+		switch r := resource.(type) {
+		case *applycorev1.PodApplyConfiguration:
+			r.Namespace = nsPtr
+		case *applyappsv1.DeploymentApplyConfiguration:
+			r.Namespace = nsPtr
+		case *applyappsv1.DaemonSetApplyConfiguration:
+			r.Namespace = nsPtr
+		case *applycorev1.ServiceApplyConfiguration:
+			r.Namespace = nsPtr
+		case *applycorev1.ServiceAccountApplyConfiguration:
+			r.Namespace = nsPtr
+		}
+	}
+	return resources
+}
+
+// PatchServiceMeshAdminInterface activates the admin interface on the
+// specified port for all Service Mesh components in a set of resources.
+func PatchServiceMeshAdminInterface(resources []any, port int32) []any {
+	for _, resource := range resources {
+		switch r := resource.(type) {
+		case *applyappsv1.DeploymentApplyConfiguration:
+			for i := 0; i < len(r.Spec.Template.Spec.InitContainers); i++ {
+				// TODO(davidweisse): find service mesh containers by unique name as specified in RFC 005.
+				if strings.Contains(*r.Spec.Template.Spec.InitContainers[i].Image, "service-mesh-proxy") {
+					r.Spec.Template.Spec.InitContainers[i] = *r.Spec.Template.Spec.InitContainers[i].
+						WithEnv(NewEnvVar("EDG_ADMIN_PORT", fmt.Sprint(port))).
+						WithPorts(
+							ContainerPort().
+								WithName("admin-interface").
+								WithContainerPort(port),
+						)
+					ingressProxyConfig := false
+					for j, env := range r.Spec.Template.Spec.InitContainers[i].Env {
+						if *env.Name == "EDG_INGRESS_PROXY_CONFIG" {
+							ingressProxyConfig = true
+							env.WithValue(fmt.Sprintf("%s##admin#%d#true", *env.Value, port))
+							r.Spec.Template.Spec.InitContainers[i].Env[j] = env
+							break
+						}
+					}
+					if !ingressProxyConfig {
+						r.Spec.Template.Spec.InitContainers[i].WithEnv(
+							NewEnvVar("EDG_INGRESS_PROXY_CONFIG", fmt.Sprintf("admin#%d#true", port)),
+						)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR changes the implementation of `PatchImages` to use `MapPodSpec`. That way, we only implement the big switch statement once (in `MapPodSpec`) and automatically get support for all types that have a `PodSpec` - including `StatefulSet`, which is currently not supported.

Drive-by fixes:
* Move `Patch*` functions to mutators (as they are not sets).
* Remove leftover comments.