### PR TITLE
resourcegen: settle on one set for the Coordinator

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -39,9 +39,8 @@ func TestOpenSSL(t *testing.T) {
 	resources, err := kuberesource.OpenSSL()
 	require.NoError(t, err)
 
-	coordinator := kuberesource.Coordinator("").DeploymentApplyConfiguration
-	coordinatorService := kuberesource.ServiceForDeployment(coordinator)
-	resources = append(resources, coordinator, coordinatorService)
+	coordinator := kuberesource.CoordinatorBundle()
+	resources = append(resources, coordinator...)
 
 	resources = kuberesource.AddPortForwarders(resources)
 

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -33,9 +33,8 @@ func TestIngressEgress(t *testing.T) {
 	resources, err := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
 	require.NoError(t, err)
 
-	coordinator := kuberesource.Coordinator("").DeploymentApplyConfiguration
-	coordinatorService := kuberesource.ServiceForDeployment(coordinator)
-	resources = append(resources, coordinator, coordinatorService)
+	coordinator := kuberesource.CoordinatorBundle()
+	resources = append(resources, coordinator...)
 
 	resources = kuberesource.AddPortForwarders(resources)
 

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -31,11 +31,7 @@ func main() {
 		var err error
 		switch set {
 		case "coordinator":
-			c := kuberesource.Coordinator("").DeploymentApplyConfiguration
-			s := kuberesource.ServiceForDeployment(c)
-			subResources, err = []any{c, s}, nil
-		case "coordinator-release":
-			subResources, err = kuberesource.CoordinatorRelease()
+			subResources = kuberesource.CoordinatorBundle()
 		case "runtime":
 			subResources, err = kuberesource.Runtime()
 		case "openssl":

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -10,9 +10,8 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
-// CoordinatorRelease will generate the Coordinator deployment YAML that is published
-// as release artifact with a pre-generated policy (which is not contained in this function).
-func CoordinatorRelease() ([]any, error) {
+// CoordinatorBundle returns the Coordinator and a matching Service.
+func CoordinatorBundle() []any {
 	coordinator := Coordinator("").DeploymentApplyConfiguration
 	coordinatorService := ServiceForDeployment(coordinator).
 		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"})
@@ -22,7 +21,7 @@ func CoordinatorRelease() ([]any, error) {
 		coordinatorService,
 	}
 
-	return resources, nil
+	return resources
 }
 
 // Runtime returns a set of resources for registering and installing the runtime.

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -200,7 +200,7 @@ with pkgs;
       trap 'rm -rf $tmpdir' EXIT
 
       echo "ghcr.io/edgelesssys/contrast/coordinator:latest=$imageRef" > "$tmpdir/image-replacements.txt"
-      resourcegen --image-replacements "$tmpdir/image-replacements.txt" --add-load-balancers coordinator-release > "$tmpdir/coordinator_base.yml"
+      resourcegen --image-replacements "$tmpdir/image-replacements.txt" --add-load-balancers coordinator > "$tmpdir/coordinator_base.yml"
 
       pushd "$tmpdir" >/dev/null
       cp ${genpolicy-msft.rules-coordinator}/genpolicy-rules.rego rules.rego


### PR DESCRIPTION
We currently have a `Coordinator` (only deployment) and a `CoordinatorRelease` (with service and LB annotation), both in use. Since 

1. there is no release-specific information in the `CoordinatorRelease` set,
2. the coordinator definition is functionally identical and
3. the coordinator is always used with its service

settle on one `CoordinatorBundle` that's used everywhere.