### PR TITLE
coordinator: make metrics endpoint configurable

### DIFF
--- a/docs/docs/architecture/observability.md
+++ b/docs/docs/architecture/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
-The Contrast Coordinator exposes metrics in the
+The Contrast Coordinator can expose metrics in the
 [Prometheus](https://prometheus.io/) format. These can be monitored to quickly
 identify problems in the gRPC layer or attestation errors. Prometheus metrics
 are numerical values associated with a name and additional key/values pairs,
@@ -8,11 +8,10 @@ called labels.
 
 ## Exposed metrics
 
-The Coordinator pod has the annotation `prometheus.io/scrape` set to `true` so
-it can be found by the [service discovery of
-Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config).
-The metrics can be accessed at the Coordinator pod at port `9102` under the
-`/metrics` endpoint.
+The metrics can be accessed at the Coordinator pod at the port specified in the
+`CONTRAST_METRICS_PORT` environment variable under the `/metrics` endpoint. By
+default, this environment variable isn't specified, hence no metrics will be
+exposed.
 
 The Coordinator starts two gRPC servers, one for the user API on port `1313` and
 one for the mesh API on port `7777`. Metrics for both servers can be accessed

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -96,6 +96,7 @@ func (ct *ContrastTest) Init(t *testing.T, resources []any) {
 	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
 	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
 	resources = kuberesource.PatchServiceMeshAdminInterface(resources, 9901)
+	resources = kuberesource.PatchCoordinatorMetrics(resources, 9102)
 	resources = kuberesource.AddLogging(resources, "debug")
 	unstructuredResources, err := kuberesource.ResourcesToUnstructured(resources)
 	require.NoError(err)

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -147,7 +147,7 @@ func Coordinator(namespace string) *CoordinatorConfig {
 				WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)). // TODO(burgerdev): this should be RETAIN for released coordinators.
 			WithTemplate(PodTemplateSpec().
 				WithLabels(map[string]string{"app.kubernetes.io/name": "coordinator"}).
-				WithAnnotations(map[string]string{"contrast.edgeless.systems/pod-role": "coordinator", "prometheus.io/scrape": "true"}).
+				WithAnnotations(map[string]string{"contrast.edgeless.systems/pod-role": "coordinator"}).
 				WithSpec(PodSpec().
 					WithRuntimeClassName(runtimeHandler).
 					WithContainers(
@@ -170,9 +170,6 @@ func Coordinator(namespace string) *CoordinatorConfig {
 								ContainerPort().
 									WithName("meshapi").
 									WithContainerPort(7777),
-								ContainerPort().
-									WithName("prometheus").
-									WithContainerPort(9102),
 							).
 							WithReadinessProbe(Probe().
 								WithInitialDelaySeconds(1).


### PR DESCRIPTION
This makes the Coordinator metrics endpoint configurable via an environment variable. If `CONTRAST_METRICS_PORT` is set, the metrics server will start on that port. If the variable is not set, the metrics server will not start.

For CI, the endpoint is activated through the `PatchCoordinatorMetrics` function.