### PR TITLE
resourcegen: don't return errors when creating sets

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -226,9 +226,7 @@ func (ct *ContrastTest) commonArgs() []string {
 func (ct *ContrastTest) installRuntime(t *testing.T) {
 	require := require.New(t)
 
-	resources, err := kuberesource.Runtime()
-	require.NoError(err)
-
+	resources := kuberesource.Runtime()
 	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
 	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
 

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -39,9 +39,8 @@ func TestOpenSSL(t *testing.T) {
 	resources, err := kuberesource.OpenSSL()
 	require.NoError(t, err)
 
-	coordinator := kuberesource.Coordinator("").DeploymentApplyConfiguration
-	coordinatorService := kuberesource.ServiceForDeployment(coordinator)
-	resources = append(resources, coordinator, coordinatorService)
+	coordinator := kuberesource.CoordinatorBundle()
+	resources = append(resources, coordinator...)
 
 	resources = kuberesource.AddPortForwarders(resources)
 

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -36,8 +36,7 @@ var imageReplacements map[string]string
 func TestOpenSSL(t *testing.T) {
 	ct := contrasttest.New(t, imageReplacements)
 
-	resources, err := kuberesource.OpenSSL()
-	require.NoError(t, err)
+	resources := kuberesource.OpenSSL()
 
 	coordinator := kuberesource.CoordinatorBundle()
 	resources = append(resources, coordinator...)

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -33,9 +33,8 @@ func TestIngressEgress(t *testing.T) {
 	resources, err := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
 	require.NoError(t, err)
 
-	coordinator := kuberesource.Coordinator("").DeploymentApplyConfiguration
-	coordinatorService := kuberesource.ServiceForDeployment(coordinator)
-	resources = append(resources, coordinator, coordinatorService)
+	coordinator := kuberesource.CoordinatorBundle()
+	resources = append(resources, coordinator...)
 
 	resources = kuberesource.AddPortForwarders(resources)
 

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -30,8 +30,7 @@ var imageReplacements map[string]string
 func TestIngressEgress(t *testing.T) {
 	ct := contrasttest.New(t, imageReplacements)
 
-	resources, err := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
-	require.NoError(t, err)
+	resources := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
 
 	coordinator := kuberesource.CoordinatorBundle()
 	resources = append(resources, coordinator...)

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -15,45 +15,33 @@ import (
 
 const exposeServiceAnnotation = "contrast.edgeless.systems/expose-service"
 
-// AddInitializer adds an initializer to a deployment.
+// AddInitializer adds an initializer and its shared volume to the resource.
+//
+// If the resource does not contain a PodSpec, this function does nothing.
+// This function is not idempotent.
 func AddInitializer(
-	deployment *applyappsv1.DeploymentApplyConfiguration,
+	resource any,
 	initializer *applycorev1.ContainerApplyConfiguration,
-) (*applyappsv1.DeploymentApplyConfiguration, error) {
-	if initializer == nil {
-		return nil, errors.New("initializer is nil")
-	}
-	if deployment == nil {
-		return nil, errors.New("deployment is nil")
-	}
-	if deployment.Spec == nil {
-		return nil, errors.New("deployment.Spec is nil")
-	}
-	if deployment.Spec.Template == nil {
-		return nil, errors.New("deployment.Spec.Template is nil")
-	}
-	if deployment.Spec.Template.Spec == nil {
-		return nil, errors.New("deployment.Spec.Template.Spec is nil")
-	}
-	if len(deployment.Spec.Template.Spec.Containers) == 0 {
-		return nil, errors.New("deployment.Spec.Template.Spec.Containers is empty")
-	}
-
-	// Add the initializer as an init container.
-	deployment.Spec.Template.Spec.WithInitContainers(
-		initializer,
-	)
-	// Create the volume written by the initializer.
-	deployment.Spec.Template.Spec.WithVolumes(Volume().
-		WithName("tls-certs").
-		WithEmptyDir(EmptyDirVolumeSource().Inner()),
-	)
-	// Add the volume mount written by the initializer to the worker container.
-	deployment.Spec.Template.Spec.Containers[0].WithVolumeMounts(VolumeMount().
-		WithName("tls-certs").
-		WithMountPath("/tls-config"),
-	)
-	return deployment, nil
+) any {
+	return MapPodSpec(resource, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
+		// Add the initializer as an init container.
+		spec.WithInitContainers(
+			initializer,
+		)
+		if len(initializer.VolumeMounts) < 1 {
+			return spec
+		}
+		// Create the volume written by the initializer.
+		spec.WithVolumes(Volume().
+			WithName(*initializer.VolumeMounts[0].Name).
+			WithEmptyDir(EmptyDirVolumeSource().Inner()),
+		)
+		// Add the volume mount written by the initializer to the worker container.
+		spec.Containers[0].WithVolumeMounts(VolumeMount().
+			WithName(*initializer.VolumeMounts[0].Name).
+			WithMountPath(*initializer.VolumeMounts[0].MountPath))
+		return spec
+	})
 }
 
 type serviceMeshMode string

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -14,8 +14,7 @@ import (
 func TestPatchNamespaces(t *testing.T) {
 	coordinator := CoordinatorBundle()
 	openssl := OpenSSL()
-	emojivoto, err := Emojivoto(ServiceMeshIngressEgress)
-	require.NoError(t, err)
+	emojivoto := Emojivoto(ServiceMeshIngressEgress)
 
 	for _, tc := range []struct {
 		name string
@@ -78,4 +77,19 @@ func TestAddInitializer(t *testing.T) {
 	require.NotEmpty(d.Spec.Template.Spec.Volumes)
 	require.Equal(*d.Spec.Template.Spec.Volumes[0].Name, *d.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].Name)
 	require.Equal(*d.Spec.Template.Spec.Volumes[0].Name, *d.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
+}
+
+func TestAddServiceMesh(t *testing.T) {
+	require := require.New(t)
+	d := applyappsv1.Deployment("test", "default").
+		WithSpec(applyappsv1.DeploymentSpec().
+			WithTemplate(applycorev1.PodTemplateSpec().
+				WithSpec(applycorev1.PodSpec().
+					WithContainers(applycorev1.Container()))))
+
+	smProxy := ServiceMeshProxy()
+	AddServiceMesh(d, smProxy)
+
+	require.NotEmpty(d.Spec.Template.Spec.InitContainers)
+	require.Equal(d.Spec.Template.Spec.InitContainers[0], *smProxy)
 }

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package kuberesource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatchNamespaces(t *testing.T) {
+	coordinator := CoordinatorBundle()
+	openssl, err := OpenSSL()
+	require.NoError(t, err)
+	emojivoto, err := Emojivoto(ServiceMeshIngressEgress)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		set  []any
+	}{
+		{
+			name: "coordinator",
+			set:  coordinator,
+		},
+		{
+			name: "openssl",
+			set:  openssl,
+		},
+		{
+			name: "emojivoto",
+			set:  emojivoto,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			expectedNamespace := "right-namespace"
+			set := PatchNamespaces(tc.set, expectedNamespace)
+			u, err := ResourcesToUnstructured(set)
+			require.NoError(err)
+			require.NotEmpty(u)
+			for _, obj := range u {
+				require.Equal(expectedNamespace, obj.GetNamespace())
+			}
+		})
+		t.Run(tc.name+"-empty-namespace", func(t *testing.T) {
+			require := require.New(t)
+			set := PatchNamespaces(tc.set, "some-namespace")
+			set = PatchNamespaces(set, "")
+			u, err := ResourcesToUnstructured(set)
+			require.NoError(err)
+			require.NotEmpty(u)
+			for _, obj := range u {
+				meta := obj.Object["metadata"].(map[string]any)
+				_, ok := meta["namespace"]
+				require.False(ok, "namespace should have been deleted")
+			}
+		})
+	}
+}

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -37,11 +37,11 @@ func main() {
 		case "openssl":
 			subResources = kuberesource.OpenSSL()
 		case "emojivoto":
-			subResources, err = kuberesource.Emojivoto(kuberesource.ServiceMeshDisabled)
+			subResources = kuberesource.Emojivoto(kuberesource.ServiceMeshDisabled)
 		case "emojivoto-sm-ingress":
-			subResources, err = kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
+			subResources = kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
 		case "emojivoto-sm-egress":
-			subResources, err = kuberesource.Emojivoto(kuberesource.ServiceMeshEgress)
+			subResources = kuberesource.Emojivoto(kuberesource.ServiceMeshEgress)
 		default:
 			log.Fatalf("Error: unknown set: %s\n", set)
 		}

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -31,11 +31,7 @@ func main() {
 		var err error
 		switch set {
 		case "coordinator":
-			c := kuberesource.Coordinator("").DeploymentApplyConfiguration
-			s := kuberesource.ServiceForDeployment(c)
-			subResources, err = []any{c, s}, nil
-		case "coordinator-release":
-			subResources, err = kuberesource.CoordinatorRelease()
+			subResources = kuberesource.CoordinatorBundle()
 		case "runtime":
 			subResources, err = kuberesource.Runtime()
 		case "openssl":

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -33,7 +33,7 @@ func main() {
 		case "coordinator":
 			subResources = kuberesource.CoordinatorBundle()
 		case "runtime":
-			subResources, err = kuberesource.Runtime()
+			subResources = kuberesource.Runtime()
 		case "openssl":
 			subResources = kuberesource.OpenSSL()
 		case "emojivoto":

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -35,7 +35,7 @@ func main() {
 		case "runtime":
 			subResources, err = kuberesource.Runtime()
 		case "openssl":
-			subResources, err = kuberesource.OpenSSL()
+			subResources = kuberesource.OpenSSL()
 		case "emojivoto":
 			subResources, err = kuberesource.Emojivoto(kuberesource.ServiceMeshDisabled)
 		case "emojivoto-sm-ingress":

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -40,7 +40,7 @@ func Runtime() ([]any, error) {
 }
 
 // OpenSSL returns a set of resources for testing with OpenSSL.
-func OpenSSL() ([]any, error) {
+func OpenSSL() []any {
 	ns := ""
 
 	backend := Deployment("openssl-backend", ns).
@@ -77,10 +77,7 @@ func OpenSSL() ([]any, error) {
 			),
 		)
 
-	backend, err := AddInitializer(backend, Initializer())
-	if err != nil {
-		return nil, err
-	}
+	AddInitializer(backend, Initializer())
 
 	backendService := ServiceForDeployment(backend)
 
@@ -106,10 +103,7 @@ func OpenSSL() ([]any, error) {
 				),
 			),
 		)
-	client, err = AddInitializer(client, Initializer())
-	if err != nil {
-		return nil, err
-	}
+	AddInitializer(client, Initializer())
 
 	frontend := Deployment("openssl-frontend", ns).
 		WithSpec(DeploymentSpec().
@@ -144,10 +138,7 @@ func OpenSSL() ([]any, error) {
 				),
 			),
 		)
-	frontend, err = AddInitializer(frontend, Initializer())
-	if err != nil {
-		return nil, err
-	}
+	AddInitializer(frontend, Initializer())
 
 	frontendService := ServiceForDeployment(frontend)
 
@@ -159,7 +150,7 @@ func OpenSSL() ([]any, error) {
 		frontendService,
 	}
 
-	return resources, nil
+	return resources
 }
 
 // GetDEnts returns a set of resources for testing getdents entry limits.
@@ -294,10 +285,7 @@ func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 				),
 			),
 		)
-	emoji, err := AddInitializer(emoji, Initializer())
-	if err != nil {
-		return nil, err
-	}
+	AddInitializer(emoji, Initializer())
 
 	emojiService := ServiceForDeployment(emoji).
 		WithName("emoji-svc").
@@ -401,10 +389,7 @@ func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 				),
 			),
 		)
-	voting, err = AddInitializer(voting, Initializer())
-	if err != nil {
-		return nil, err
-	}
+	AddInitializer(voting, Initializer())
 
 	votingService := ServiceForDeployment(voting).
 		WithName("voting-svc").
@@ -479,11 +464,9 @@ func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 				),
 			),
 		)
-	web, err = AddInitializer(web, Initializer())
-	if err != nil {
-		return nil, err
-	}
+	AddInitializer(web, Initializer())
 
+	var err error
 	if smProxyEmoji != nil {
 		emoji, err = AddServiceMesh(emoji, smProxyEmoji, smMode)
 		if err != nil {

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -10,9 +10,8 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
-// CoordinatorRelease will generate the Coordinator deployment YAML that is published
-// as release artifact with a pre-generated policy (which is not contained in this function).
-func CoordinatorRelease() ([]any, error) {
+// CoordinatorBundle returns the Coordinator and a matching Service.
+func CoordinatorBundle() []any {
 	coordinator := Coordinator("").DeploymentApplyConfiguration
 	coordinatorService := ServiceForDeployment(coordinator).
 		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"})
@@ -22,7 +21,7 @@ func CoordinatorRelease() ([]any, error) {
 		coordinatorService,
 	}
 
-	return resources, nil
+	return resources
 }
 
 // Runtime returns a set of resources for registering and installing the runtime.

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -25,18 +25,16 @@ func CoordinatorBundle() []any {
 }
 
 // Runtime returns a set of resources for registering and installing the runtime.
-func Runtime() ([]any, error) {
+func Runtime() []any {
 	ns := ""
 
 	runtimeClass := ContrastRuntimeClass().RuntimeClassApplyConfiguration
 	nodeInstaller := NodeInstaller(ns).DaemonSetApplyConfiguration
 
-	resources := []any{
+	return []any{
 		runtimeClass,
 		nodeInstaller,
 	}
-
-	return resources, nil
 }
 
 // OpenSSL returns a set of resources for testing with OpenSSL.

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -182,7 +182,7 @@ func GetDEnts() ([]any, error) {
 }
 
 // Emojivoto returns resources for deploying Emojivoto application.
-func Emojivoto(smMode serviceMeshMode) ([]any, error) {
+func Emojivoto(smMode serviceMeshMode) []any {
 	ns := ""
 	var emojiSvcImage, emojiVotingSvcImage, emojiWebImage, emojiWebVoteBotImage, emojiSvcHost, votingSvcHost string
 	smProxyEmoji := ServiceMeshProxy()
@@ -466,26 +466,6 @@ func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 		)
 	AddInitializer(web, Initializer())
 
-	var err error
-	if smProxyEmoji != nil {
-		emoji, err = AddServiceMesh(emoji, smProxyEmoji, smMode)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if smProxyWeb != nil {
-		web, err = AddServiceMesh(web, smProxyWeb, smMode)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if smProxyVoting != nil {
-		voting, err = AddServiceMesh(voting, smProxyVoting, smMode)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	webService := ServiceForDeployment(web).
 		WithName("web-svc").
 		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"}).
@@ -519,5 +499,19 @@ func Emojivoto(smMode serviceMeshMode) ([]any, error) {
 		webserviceAccount,
 	}
 
-	return resources, nil
+	if smMode == ServiceMeshDisabled {
+		return resources
+	}
+
+	if smProxyEmoji != nil {
+		AddServiceMesh(emoji, smProxyEmoji)
+	}
+	if smProxyWeb != nil {
+		AddServiceMesh(web, smProxyWeb)
+	}
+	if smProxyVoting != nil {
+		AddServiceMesh(voting, smProxyVoting)
+	}
+
+	return resources
 }

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -200,7 +200,7 @@ with pkgs;
       trap 'rm -rf $tmpdir' EXIT
 
       echo "ghcr.io/edgelesssys/contrast/coordinator:latest=$imageRef" > "$tmpdir/image-replacements.txt"
-      resourcegen --image-replacements "$tmpdir/image-replacements.txt" --add-load-balancers coordinator-release > "$tmpdir/coordinator_base.yml"
+      resourcegen --image-replacements "$tmpdir/image-replacements.txt" --add-load-balancers coordinator > "$tmpdir/coordinator_base.yml"
 
       pushd "$tmpdir" >/dev/null
       cp ${genpolicy-msft.rules-coordinator}/genpolicy-rules.rego rules.rego


### PR DESCRIPTION
Our sets are known at compile time and thus creating them should never cause an error. This PR changes the implementation of a couple of mutators to be error-less, by switching them to `MapPodSpec`, and adds tests to ensure that this mapping still works. As a byproduct, `AddInitializer` and `AddServiceMesh` can now be used with any pod-creating resource.