### PR TITLE
e2e: support StatefulSet

### DIFF
--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -117,10 +117,8 @@ func (c *Kubeclient) PodsFromDeployment(ctx context.Context, namespace, deployme
 	return out, nil
 }
 
-// PodsFromDaemonSet returns the pods from a daemonset in a namespace.
-//
-// A pod is considered to belong to a daemonset if it is owned by the DaemonSet in question.
-func (c *Kubeclient) PodsFromDaemonSet(ctx context.Context, namespace, daemonset string) ([]v1.Pod, error) {
+// PodsFromOwner returns the pods owned by an object in the namespace of the given kind.
+func (c *Kubeclient) PodsFromOwner(ctx context.Context, namespace, kind, name string) ([]v1.Pod, error) {
 	pods, err := c.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("listing pods: %w", err)
@@ -129,7 +127,7 @@ func (c *Kubeclient) PodsFromDaemonSet(ctx context.Context, namespace, daemonset
 	var out []v1.Pod
 	for _, pod := range pods.Items {
 		for _, ref := range pod.OwnerReferences {
-			if ref.Kind == "DaemonSet" && ref.Name == daemonset {
+			if ref.Kind == kind && ref.Name == name {
 				out = append(out, pod)
 			}
 		}

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -178,6 +178,8 @@ func PatchNamespaces(resources []any, namespace string) []any {
 			r.Namespace = nsPtr
 		case *applyappsv1.DaemonSetApplyConfiguration:
 			r.Namespace = nsPtr
+		case *applyappsv1.StatefulSetApplyConfiguration:
+			r.Namespace = nsPtr
 		case *applycorev1.ServiceApplyConfiguration:
 			r.Namespace = nsPtr
 		case *applycorev1.ServiceAccountApplyConfiguration:

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -61,6 +61,30 @@ func DaemonSetSpec() *DaemonSetSpecConfig {
 	return &DaemonSetSpecConfig{applyappsv1.DaemonSetSpec()}
 }
 
+// StatefulSetConfig wraps applyappsv1.StatefulSetApplyConfiguration.
+type StatefulSetConfig struct {
+	*applyappsv1.StatefulSetApplyConfiguration
+}
+
+// StatefulSet creates a new StatefulSetConfig.
+func StatefulSet(name, namespace string) *StatefulSetConfig {
+	s := applyappsv1.StatefulSet(name, namespace)
+	if namespace == "" && s.ObjectMetaApplyConfiguration != nil {
+		s.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return &StatefulSetConfig{s}
+}
+
+// StatefulSetSpecConfig wraps applyappsv1.StatefulSetSpecApplyConfiguration.
+type StatefulSetSpecConfig struct {
+	*applyappsv1.StatefulSetSpecApplyConfiguration
+}
+
+// StatefulSetSpec creates a new StatefulSetSpecConfig.
+func StatefulSetSpec() *StatefulSetSpecConfig {
+	return &StatefulSetSpecConfig{applyappsv1.StatefulSetSpec()}
+}
+
 // PodConfig wraps applyappsv1.PodApplyConfiguration.
 type PodConfig struct {
 	*applycorev1.PodApplyConfiguration


### PR DESCRIPTION
This is a preparation for changing the Coordinator kind to StatefulSet, but should be useful on its own for dealing with StatefulSets in e2e.