### PR TITLE
docs: harden curl invocation in installation instruction

### DIFF
--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -3,7 +3,7 @@
 Download the Contrast CLI from the latest release:
 
 ```bash
-curl -fLo contrast https://github.com/edgelesssys/contrast/releases/latest/download/contrast
+curl --proto '=https' --tlsv1.2 -fLo contrast https://github.com/edgelesssys/contrast/releases/latest/download/contrast
 ```
 
 After that, install the Contrast CLI in your PATH, e.g.:


### PR DESCRIPTION
* Force >=TLS1.2
* Force HTTPS

Inspired by the rustup.sh installation instructions: https://rustup.rs