### PR TITLE
docs: add curl hardening flags for released version

### DIFF
--- a/docs/versioned_docs/version-0.6/getting-started/install.md
+++ b/docs/versioned_docs/version-0.6/getting-started/install.md
@@ -3,7 +3,7 @@
 Download the Contrast CLI from the latest release:
 
 ```bash
-curl -fLo contrast https://github.com/edgelesssys/contrast/releases/latest/download/contrast
+curl --proto '=https' --tlsv1.2 -fLo contrast https://github.com/edgelesssys/contrast/releases/latest/download/contrast
 ```
 
 After that, install the Contrast CLI in your PATH, e.g.:


### PR DESCRIPTION
Backport of #498 to versioned docs of v0.6