### PR TITLE
coordinator: add grpc latency metrics

### DIFF
--- a/coordinator/meshapi.go
+++ b/coordinator/meshapi.go
@@ -57,6 +57,10 @@ func newMeshAPIServer(meshAuth *meshAuthority, caGetter certChainGetter, reg *pr
 		grpcprometheus.WithServerCounterOptions(
 			grpcprometheus.WithSubsystem("meshapi"),
 		),
+		grpcprometheus.WithServerHandlingTimeHistogram(
+			grpcprometheus.WithHistogramSubsystem("meshapi"),
+			grpcprometheus.WithHistogramBuckets([]float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5}),
+		),
 	)
 
 	grpcServer := grpc.NewServer(

--- a/coordinator/userapi.go
+++ b/coordinator/userapi.go
@@ -58,6 +58,10 @@ func newUserAPIServer(mSGetter manifestSetGetter, caGetter certChainGetter, reg 
 		grpcprometheus.WithServerCounterOptions(
 			grpcprometheus.WithSubsystem("userapi"),
 		),
+		grpcprometheus.WithServerHandlingTimeHistogram(
+			grpcprometheus.WithHistogramSubsystem("userapi"),
+			grpcprometheus.WithHistogramBuckets([]float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5}),
+		),
 	)
 
 	manifestGeneration := promauto.With(reg).NewGauge(prometheus.GaugeOpts{

--- a/docs/docs/architecture/observability.md
+++ b/docs/docs/architecture/observability.md
@@ -24,7 +24,7 @@ Exposed metrics include the number of  handled requests of the methods
 manifest](../deployment#set-the-manifest) and [verifying the
 Coordinator](../deployment#verify-the-coordinator) respectively. For each method
 you can see the gRPC status code indicating whether the request succeeded or
-not.
+not and the request latency.
 
 For the mesh API, the metric names are prefixed with `meshapi_grpc_server_`. The
 metrics include similar data to the user API for the method `NewMeshCert` which


### PR DESCRIPTION
This adds a histogram to the metrics exposed by the Coordinator to track request times of the user API and the mesh API.