### PR TITLE
coordinator: prefix metrics with contrast

### DIFF
--- a/coordinator/meshapi.go
+++ b/coordinator/meshapi.go
@@ -45,7 +45,7 @@ func newMeshAPIServer(meshAuth *meshAuthority, caGetter certChainGetter, reg *pr
 	kdsGetter := snp.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(log, "kds-getter"))
 
 	attestationFailuresCounter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Subsystem: "meshapi",
+		Subsystem: "contrast_meshapi",
 		Name:      "attestation_failures",
 		Help:      "Number of attestation failures from workloads to the Coordinator.",
 	})
@@ -55,10 +55,10 @@ func newMeshAPIServer(meshAuth *meshAuthority, caGetter certChainGetter, reg *pr
 
 	grpcMeshAPIMetrics := grpcprometheus.NewServerMetrics(
 		grpcprometheus.WithServerCounterOptions(
-			grpcprometheus.WithSubsystem("meshapi"),
+			grpcprometheus.WithSubsystem("contrast_meshapi"),
 		),
 		grpcprometheus.WithServerHandlingTimeHistogram(
-			grpcprometheus.WithHistogramSubsystem("meshapi"),
+			grpcprometheus.WithHistogramSubsystem("contrast_meshapi"),
 			grpcprometheus.WithHistogramBuckets([]float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5}),
 		),
 	)

--- a/coordinator/userapi.go
+++ b/coordinator/userapi.go
@@ -56,16 +56,16 @@ func newUserAPIServer(mSGetter manifestSetGetter, caGetter certChainGetter, reg 
 
 	grpcUserAPIMetrics := grpcprometheus.NewServerMetrics(
 		grpcprometheus.WithServerCounterOptions(
-			grpcprometheus.WithSubsystem("userapi"),
+			grpcprometheus.WithSubsystem("contrast_userapi"),
 		),
 		grpcprometheus.WithServerHandlingTimeHistogram(
-			grpcprometheus.WithHistogramSubsystem("userapi"),
+			grpcprometheus.WithHistogramSubsystem("contrast_userapi"),
 			grpcprometheus.WithHistogramBuckets([]float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5}),
 		),
 	)
 
 	manifestGeneration := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-		Subsystem: "coordinator",
+		Subsystem: "contrast_coordinator",
 		Name:      "manifest_generation",
 		Help:      "Current manifest generation.",
 	})

--- a/docs/docs/architecture/observability.md
+++ b/docs/docs/architecture/observability.md
@@ -18,7 +18,7 @@ The Coordinator starts two gRPC servers, one for the user API on port `1313` and
 one for the mesh API on port `7777`. Metrics for both servers can be accessed
 using different prefixes.
 
-All metric names for the user API are prefixed with `userapi_grpc_server_`.
+All metric names for the user API are prefixed with `contrast_userapi_grpc_server_`.
 Exposed metrics include the number of  handled requests of the methods
 `SetManifest` and `GetManifest`, which get called when [setting the
 manifest](../deployment#set-the-manifest) and [verifying the
@@ -26,15 +26,15 @@ Coordinator](../deployment#verify-the-coordinator) respectively. For each method
 you can see the gRPC status code indicating whether the request succeeded or
 not and the request latency.
 
-For the mesh API, the metric names are prefixed with `meshapi_grpc_server_`. The
+For the mesh API, the metric names are prefixed with `contrast_meshapi_grpc_server_`. The
 metrics include similar data to the user API for the method `NewMeshCert` which
 gets called by the [Initializer](../components#the-initializer) when starting a
 new workload. Attestation failures from workloads to the Coordinator can be
-tracked with the counter `meshapi_attestation_failures`.
+tracked with the counter `contrast_meshapi_attestation_failures`.
 
 The current manifest generation is exposed as a
 [gauge](https://prometheus.io/docs/concepts/metric_types/#gauge) with the metric
-name `coordinator_manifest_generation`. If no manifest is set at the
+name `contrast_coordinator_manifest_generation`. If no manifest is set at the
 Coordinator, this counter will be zero.
 
 ## Service Mesh metrics


### PR DESCRIPTION
This adds the additional `contrast_` prefix to all exposed metrics from the Coordinator.