### PR TITLE
e2e: test verify with root CA after cert rotation

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -96,7 +96,6 @@ func TestOpenSSL(t *testing.T) {
 		})
 	}
 
-	// TODO(burgerdev): this test should be run with its own kubectl apply/contrast set preface.
 	t.Run("certificates can be used by OpenSSL", func(t *testing.T) {
 		// This test verifies that the certificates minted by the coordinator are accepted by OpenSSL in server and client mode.
 		require := require.New(t)

--- a/justfile
+++ b/justfile
@@ -157,7 +157,6 @@ wait-for-workload target=default_deploy_target:
     case {{ target }} in
         "openssl")
             nix run .#scripts.kubectl-wait-ready -- $ns openssl-backend
-            nix run .#scripts.kubectl-wait-ready -- $ns openssl-client
             nix run .#scripts.kubectl-wait-ready -- $ns openssl-frontend
         ;;
         "emojivoto" | "emojivoto-sm-egress" | "emojivoto-sm-ingress")


### PR DESCRIPTION
This adds 

* a new test to verify that the root CA is still accepted after certificate rotation. 
* another run of the certificate rotation test that restarts the other deployment

I want these tests to prepare for RFC004 changes to meshauth/ca.

To make these changes easier, I introduced

* a helper function to exec in a random pod of a deployment
* a helper function to construct `s_client` arguments

While I was looking into the test, I noticed that there are a couple of leftovers in the OpenSSL deployment originating from when we used it for manual testing. I don't think we need the OpenSSL pods to communicate without user interaction - Emojivoto should be sufficient to test this kind of thing.