### PR TITLE
release: fix coordinator policy hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Update coordinator policy hash
         run: |
           yq < workspace/coordinator.yml \
-            'select(.kind == "Deployment") | .spec.template.metadata.annotations["io.katacontainers.config.agent.policy"]' |
+            'select(.kind == "StatefulSet") | .spec.template.metadata.annotations["io.katacontainers.config.agent.policy"]' |
             base64 -d | sha256sum | cut -d " " -f1 > cli/cmd/assets/coordinator-policy-hash
 
           git config --global user.name "edgelessci"

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -119,7 +119,7 @@ func TestRelease(t *testing.T) {
 		}
 
 		require.NoError(k.Apply(ctx, resources...))
-		require.NoError(k.WaitForDeployment(ctx, *namespace, "coordinator"))
+		require.NoError(k.WaitForStatefulSet(ctx, *namespace, "coordinator"))
 		coordinatorIP, err = k.WaitForLoadBalancer(ctx, *namespace, "coordinator")
 		require.NoError(err)
 	}), "the coordinator is required for subsequent tests to run")


### PR DESCRIPTION
Failed release run on PR #510 : https://github.com/edgelesssys/contrast/actions/runs/9346382093

`contrast set` failed because the Coordinator policy hash was not correctly generated due to the Coordinator now being a StatefulSet.

Rerun: https://github.com/edgelesssys/contrast/actions/runs/9349135584