### PR TITLE
coordinator: rotate certs in authority

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
-	"github.com/edgelesssys/contrast/internal/ca"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/meshapi"
 	"github.com/edgelesssys/contrast/internal/userapi"
@@ -50,14 +49,9 @@ func run() (retErr error) {
 
 	metricsPort := os.Getenv(metricsPortEnvVar)
 
-	caInstance, err := ca.New()
-	if err != nil {
-		return fmt.Errorf("creating CA: %w", err)
-	}
-
 	promRegistry := prometheus.NewRegistry()
 
-	meshAuth := authority.New(caInstance, logger)
+	meshAuth := authority.New(logger)
 	userAPI := newUserAPIServer(meshAuth, promRegistry, logger)
 	meshAPI := newMeshAPIServer(meshAuth, meshAuth, promRegistry, logger)
 

--- a/coordinator/userapi_test.go
+++ b/coordinator/userapi_test.go
@@ -407,7 +407,15 @@ func (s *stubManifestSetGetter) SetManifest(*manifest.Manifest) error {
 }
 
 func (s *stubManifestSetGetter) GetManifestsAndLatestCA() ([]*manifest.Manifest, *ca.CA) {
-	ca, err := ca.New()
+	rootKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	meshKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	ca, err := ca.New(rootKey, meshKey)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR adds a SeedEngine instance to the Authority and moves certificate rotation out of the CA object, which is now an instance dedicated to a single manifest generation. For now the SeedEngine is initialized with ad-hoc random bytes and the mesh key is created at random, which should yield the same observable behaviour as before this change. After switching to `history` we can use `LatestTransition` to seed the mesh key, and later on we can recover from an input seed.