### PR TITLE
coordinator: usability improvements to the history package

### DIFF
--- a/coordinator/history/aferostore.go
+++ b/coordinator/history/aferostore.go
@@ -36,7 +36,7 @@ func (s *AferoStore) Get(key string) ([]byte, error) {
 func (s *AferoStore) Set(key string, value []byte) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	if err := s.fs.MkdirAll(filepath.Base(key), 0o755); err != nil {
+	if err := s.fs.MkdirAll(filepath.Dir(key), 0o755); err != nil {
 		return fmt.Errorf("creating directory for %q: %w", key, err)
 	}
 	return s.fs.WriteFile(key, value, 0o644)
@@ -54,7 +54,7 @@ func (s *AferoStore) CompareAndSwap(key string, oldVal, newVal []byte) error {
 	if !bytes.Equal(current, oldVal) {
 		return fmt.Errorf("object %q has changed since last read", key)
 	}
-	if err := s.fs.MkdirAll(filepath.Base(key), 0o755); err != nil {
+	if err := s.fs.MkdirAll(filepath.Dir(key), 0o755); err != nil {
 		return fmt.Errorf("creating directory for %q: %w", key, err)
 	}
 	return s.fs.WriteFile(key, newVal, 0o644)

--- a/coordinator/history/aferostore.go
+++ b/coordinator/history/aferostore.go
@@ -14,22 +14,26 @@ import (
 	"github.com/spf13/afero"
 )
 
-type fsStore struct {
+// AferoStore is a Store implementation backed by an Afero filesystem.
+type AferoStore struct {
 	fs  *afero.Afero
 	mux sync.RWMutex
 }
 
-func newPVStore(fs *afero.Afero) *fsStore {
-	return &fsStore{fs: fs}
+// NewAferoStore creates a new instance backed by the given fs.
+func NewAferoStore(fs *afero.Afero) *AferoStore {
+	return &AferoStore{fs: fs}
 }
 
-func (s *fsStore) Get(key string) ([]byte, error) {
+// Get the value for key.
+func (s *AferoStore) Get(key string) ([]byte, error) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 	return s.fs.ReadFile(key)
 }
 
-func (s *fsStore) Set(key string, value []byte) error {
+// Set the value for key.
+func (s *AferoStore) Set(key string, value []byte) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	if err := s.fs.MkdirAll(filepath.Base(key), 0o755); err != nil {
@@ -38,7 +42,8 @@ func (s *fsStore) Set(key string, value []byte) error {
 	return s.fs.WriteFile(key, value, 0o644)
 }
 
-func (s *fsStore) CompareAndSwap(key string, oldVal, newVal []byte) error {
+// CompareAndSwap updates the key to newVal if its current value is oldVal.
+func (s *AferoStore) CompareAndSwap(key string, oldVal, newVal []byte) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	current, err := s.fs.ReadFile(key)

--- a/coordinator/history/aferostore_test.go
+++ b/coordinator/history/aferostore_test.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package history
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAferoStore(t *testing.T) {
+	t.Run("memmap", func(t *testing.T) {
+		suite(t, func(_ *testing.T) Store {
+			return NewAferoStore(&afero.Afero{Fs: afero.NewMemMapFs()})
+		})
+	})
+
+	t.Run("tmpdir", func(t *testing.T) {
+		suite(t, func(t *testing.T) Store {
+			return NewAferoStore(&afero.Afero{Fs: afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())})
+		})
+	})
+}
+
+func suite(t *testing.T, storeFactory func(t *testing.T) Store) {
+	t.Run("Get and Set", func(t *testing.T) {
+		require := require.New(t)
+		s := storeFactory(t)
+
+		key := "/foo/bar"
+		val1 := []byte("val1")
+		val2 := []byte("val2")
+
+		x, err := s.Get(key)
+		require.ErrorIs(err, os.ErrNotExist)
+		require.Empty(x)
+
+		require.NoError(s.Set(key, val1))
+
+		y, err := s.Get(key)
+		require.NoError(err)
+		require.Equal(val1, y)
+
+		require.NoError(s.Set(key, val2))
+
+		z, err := s.Get(key)
+		require.NoError(err)
+		require.Equal(val2, z)
+	})
+
+	t.Run("CompareAndSwap", func(t *testing.T) {
+		require := require.New(t)
+		s := storeFactory(t)
+
+		key := "/foo/bar"
+		val1 := []byte("val1")
+		val2 := []byte("val2")
+
+		x, err := s.Get(key)
+		require.ErrorIs(err, os.ErrNotExist)
+		require.Empty(x)
+
+		require.Error(s.CompareAndSwap(key, val1, val2))
+
+		require.NoError(s.CompareAndSwap(key, nil, val1))
+
+		y, err := s.Get(key)
+		require.NoError(err)
+		require.Equal(val1, y)
+
+		require.Error(s.CompareAndSwap(key, nil, val1))
+
+		require.NoError(s.CompareAndSwap(key, val1, val2))
+
+		z, err := s.Get(key)
+		require.NoError(err)
+		require.Equal(val2, z)
+	})
+}

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	hashSize = 32 // byte, History.hashFun().Size()
+	hashSize = sha256.Size // byte, History.hashFun().Size()
 	histPath = "/mnt/state/history"
 )
 

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -36,7 +36,7 @@ func New() (*History, error) {
 	if err := osFS.MkdirAll(histPath, 0o755); err != nil {
 		return nil, fmt.Errorf("creating history directory: %w", err)
 	}
-	store := newPVStore(&afero.Afero{Fs: afero.NewBasePathFs(osFS, histPath)})
+	store := NewAferoStore(&afero.Afero{Fs: afero.NewBasePathFs(osFS, histPath)})
 	return NewWithStore(store), nil
 }
 

--- a/coordinator/history/history_test.go
+++ b/coordinator/history/history_test.go
@@ -85,7 +85,7 @@ func TestHistory_GetLatest(t *testing.T) {
 			}
 
 			h := &History{
-				store:      newPVStore(&fs),
+				store:      NewAferoStore(&fs),
 				hashFun:    sha256.New,
 				signingKey: tc.signingKey,
 			}
@@ -205,7 +205,7 @@ func TestHistory_SetLatest(t *testing.T) {
 			}
 
 			h := &History{
-				store:      newPVStore(&fs),
+				store:      NewAferoStore(&fs),
 				hashFun:    sha256.New,
 				signingKey: tc.signingKey,
 			}
@@ -267,7 +267,7 @@ func TestHistory_GetTransition(t *testing.T) {
 			}
 
 			h := &History{
-				store:   newPVStore(&fs),
+				store:   NewAferoStore(&fs),
 				hashFun: sha256.New,
 			}
 
@@ -343,7 +343,7 @@ func TestHistory_SetTransition(t *testing.T) {
 			}
 
 			h := &History{
-				store:   newPVStore(&fs),
+				store:   NewAferoStore(&fs),
 				hashFun: sha256.New,
 			}
 
@@ -418,7 +418,7 @@ func TestHistory_getCA(t *testing.T) {
 			}
 
 			h := &History{
-				store:   newPVStore(&fs),
+				store:   NewAferoStore(&fs),
 				hashFun: sha256.New,
 			}
 
@@ -490,7 +490,7 @@ func TestHistory_setCA(t *testing.T) {
 			}
 
 			h := &History{
-				store:   newPVStore(&fs),
+				store:   NewAferoStore(&fs),
 				hashFun: sha256.New,
 			}
 
@@ -525,7 +525,7 @@ func TestHistory_setCA(t *testing.T) {
 
 func TestHistory_SetGet(t *testing.T) {
 	h := &History{
-		store:   &fsStore{fs: &afero.Afero{Fs: afero.NewMemMapFs()}},
+		store:   &AferoStore{fs: &afero.Afero{Fs: afero.NewMemMapFs()}},
 		hashFun: sha256.New,
 	}
 

--- a/coordinator/history/history_test.go
+++ b/coordinator/history/history_test.go
@@ -537,8 +537,8 @@ func TestHistory_SetGet(t *testing.T) {
 			"Gnügen; oder ist's nötig, noch andere Hilfe zu suchen?",
 	}
 	testFunPairs := map[string]struct {
-		setFun func([]byte) ([hashSize]byte, error)
-		getFun func([hashSize]byte) ([]byte, error)
+		setFun func([]byte) ([HashSize]byte, error)
+		getFun func([HashSize]byte) ([]byte, error)
 	}{
 		"manifest": {h.SetManifest, h.GetManifest},
 		"policy":   {h.SetPolicy, h.GetPolicy},
@@ -574,11 +574,11 @@ xuwYqSFfVxr6ECQWyrTkApzVkz8b6n5BeQ==
 	return key
 }
 
-func strToHash(require *require.Assertions, s string) [hashSize]byte {
+func strToHash(require *require.Assertions, s string) [HashSize]byte {
 	hashSlc, err := hex.DecodeString(s)
 	require.NoError(err)
-	require.Len(hashSlc, hashSize)
-	var hash [hashSize]byte
+	require.Len(hashSlc, HashSize)
+	var hash [HashSize]byte
 	copy(hash[:], hashSlc)
 	return hash
 }


### PR DESCRIPTION
* Export hash size because it is part of the API (via hashRef arguments).
* Export `store` and allow it as an argument for creating `History` (useful for `authority` tests).
* Same for the fs-based implementation.
* Add tests for AferoStore and fix a bug in the implementation (when run on `OsFs`).