### PR TITLE
cli: check yaml for unknown fields

### DIFF
--- a/internal/kuberesource/reader.go
+++ b/internal/kuberesource/reader.go
@@ -23,7 +23,7 @@ func UnmarshalApplyConfigurations(data []byte) ([]any, error) {
 		if applyConfig == nil {
 			return nil, fmt.Errorf("unmarshalling: unsupported resource type %s for %q", obj.GroupVersionKind().String(), obj.GetName())
 		}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), applyConfig); err != nil {
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(obj.UnstructuredContent(), applyConfig, true); err != nil {
 			return nil, err
 		}
 		result = append(result, applyConfig)

--- a/internal/kuberesource/reader_writer_test.go
+++ b/internal/kuberesource/reader_writer_test.go
@@ -10,9 +10,14 @@ import (
 )
 
 func TestEncodeDecode(t *testing.T) {
-	require := require.New(t)
-
-	fixture := `apiVersion: v1
+	testCases := []struct {
+		name    string
+		fixture string
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			fixture: `apiVersion: v1
 kind: Pod
 metadata:
   name: foo
@@ -20,13 +25,40 @@ spec:
   containers:
   - image: image
     name: bar
-`
+`,
+			wantErr: false,
+		},
+		{
+			name: "unknown field",
+			fixture: `apiVersion: v1
+kind: Pod
+unknown: field
+metadata:
+  name: foo
+spec:
+  containers:
+  - image: image
+    name: bar
+`,
+			wantErr: true,
+		},
+	}
 
-	resources, err := UnmarshalApplyConfigurations([]byte(fixture))
-	require.NoError(err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
 
-	got, err := EncodeResources(resources...)
-	require.NoError(err)
+			resources, err := UnmarshalApplyConfigurations([]byte(tc.fixture))
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
 
-	require.Equal(fixture, string(got))
+			got, err := EncodeResources(resources...)
+			require.NoError(err)
+
+			require.Equal(tc.fixture, string(got))
+		})
+	}
 }


### PR DESCRIPTION
This checks for unknown fields in the user's YAML files. Before this change, any unknown fields would be silently discarded in the `generate` step. This does not check for required fields in the resources.