### PR TITLE
coordinator: use history in authority

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -189,7 +189,7 @@ func (m *Authority) GetCertBundle(peerPublicKeyHashStr string) (Bundle, error) {
 
 // GetManifestsAndLatestCA retrieves the manifest history and the currently active CA instance.
 //
-// If no manifest is configured, it returns an empty slice and a nil CA.
+// If no manifest is configured, it returns an error.
 func (m *Authority) GetManifestsAndLatestCA() ([]*manifest.Manifest, *ca.CA, error) {
 	if m.se.Load() == nil {
 		return nil, nil, ErrNoManifest

--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -9,13 +9,17 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 
+	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/seedengine"
-	"github.com/edgelesssys/contrast/internal/appendable"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/ca"
 	"github.com/edgelesssys/contrast/internal/crypto"
@@ -28,6 +32,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// ErrNoManifest is returned when a manifest is needed but not present.
+var ErrNoManifest = errors.New("no manifest configured")
+
 // Bundle is a set of PEM-encoded certificates for Contrast workloads.
 type Bundle struct {
 	WorkloadCert   []byte
@@ -38,11 +45,14 @@ type Bundle struct {
 
 // Authority manages the manifest state of Contrast.
 type Authority struct {
+	// state holds all required configuration to serve requests from userapi.
+	// We bundle it in its own struct type so we can atomically update it while not blocking other
+	// requests or risking inconsistency between e.g. CA and Manifest.
+	state      atomic.Pointer[state]
 	se         atomic.Pointer[seedengine.SeedEngine]
-	ca         atomic.Pointer[ca.CA]
+	hist       *history.History
 	bundles    map[string]Bundle
 	bundlesMux sync.RWMutex
-	manifests  appendableList[*manifest.Manifest]
 	logger     *slog.Logger
 	metrics    metrics
 }
@@ -52,17 +62,18 @@ type metrics struct {
 }
 
 // New creates a new Authority instance.
-func New(reg *prometheus.Registry, log *slog.Logger) *Authority {
+func New(hist *history.History, reg *prometheus.Registry, log *slog.Logger) *Authority {
 	manifestGeneration := promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 		Subsystem: "contrast_coordinator",
 		Name:      "manifest_generation",
 		Help:      "Current manifest generation.",
 	})
+	manifestGeneration.Set(0)
 
 	return &Authority{
-		bundles:   make(map[string]Bundle),
-		manifests: new(appendable.Appendable[*manifest.Manifest]),
-		logger:    log.WithGroup("mesh-authority"),
+		bundles: make(map[string]Bundle),
+		hist:    hist,
+		logger:  log.WithGroup("mesh-authority"),
 		metrics: metrics{
 			manifestGeneration: manifestGeneration,
 		},
@@ -74,10 +85,11 @@ func New(reg *prometheus.Registry, log *slog.Logger) *Authority {
 // It also ensures that the policy hash in the report's HOSTDATA is allowed by the current
 // manifest.
 func (m *Authority) SNPValidateOpts(report *sevsnp.Report) (*validate.Options, error) {
-	mnfst, err := m.manifests.Latest()
-	if err != nil {
-		return nil, fmt.Errorf("getting latest manifest: %w", err)
+	state := m.state.Load()
+	if state == nil {
+		return nil, ErrNoManifest
 	}
+	mnfst := state.manifest
 
 	hostData := manifest.NewHexString(report.HostData)
 	if _, ok := mnfst.Policies[hostData]; !ok {
@@ -120,18 +132,13 @@ func (m *Authority) SNPValidateOpts(report *sevsnp.Report) (*validate.Options, e
 func (m *Authority) ValidateCallback(_ context.Context, report *sevsnp.Report,
 	_ asn1.ObjectIdentifier, _, _, peerPubKeyBytes []byte,
 ) error {
-	mnfst, err := m.manifests.Latest()
-	if err != nil {
-		return fmt.Errorf("getting latest manifest: %w", err)
-	}
-	// TODO(burgerdev): The CA should be tied to the manifest.
-	caInstance := m.ca.Load()
-	if caInstance == nil {
-		return fmt.Errorf("no available CA")
+	state := m.state.Load()
+	if state == nil {
+		return ErrNoManifest
 	}
 
 	hostData := manifest.NewHexString(report.HostData)
-	dnsNames, ok := mnfst.Policies[hostData]
+	dnsNames, ok := state.manifest.Policies[hostData]
 	if !ok {
 		return fmt.Errorf("report data %s not found in manifest", hostData)
 	}
@@ -145,7 +152,7 @@ func (m *Authority) ValidateCallback(_ context.Context, report *sevsnp.Report,
 	if err != nil {
 		return fmt.Errorf("failed to construct extensions: %w", err)
 	}
-	cert, err := caInstance.NewAttestedMeshCert(dnsNames, extensions, peerPubKey)
+	cert, err := state.ca.NewAttestedMeshCert(dnsNames, extensions, peerPubKey)
 	if err != nil {
 		return fmt.Errorf("failed to issue new attested mesh cert: %w", err)
 	}
@@ -158,9 +165,9 @@ func (m *Authority) ValidateCallback(_ context.Context, report *sevsnp.Report,
 	defer m.bundlesMux.Unlock()
 	m.bundles[peerPublicKeyHashStr] = Bundle{
 		WorkloadCert:   cert,
-		MeshCA:         caInstance.GetMeshCACert(),
-		IntermediateCA: caInstance.GetIntermCACert(),
-		RootCA:         caInstance.GetRootCACert(),
+		MeshCA:         state.ca.GetMeshCACert(),
+		IntermediateCA: state.ca.GetIntermCACert(),
+		RootCA:         state.ca.GetRootCACert(),
 	}
 
 	return nil
@@ -174,51 +181,152 @@ func (m *Authority) GetCertBundle(peerPublicKeyHashStr string) (Bundle, error) {
 	bundle, ok := m.bundles[peerPublicKeyHashStr]
 
 	if !ok {
-		return Bundle{}, fmt.Errorf("cert for peer public key %s not found", peerPublicKeyHashStr)
+		return Bundle{}, fmt.Errorf("cert for peer public key hash %s not found", peerPublicKeyHashStr)
 	}
 
 	return bundle, nil
 }
 
 // GetManifestsAndLatestCA retrieves the manifest history and the currently active CA instance.
-func (m *Authority) GetManifestsAndLatestCA() ([]*manifest.Manifest, *ca.CA) {
-	// TODO(burgerdev): The CA should be tied to the manifest.
-	return m.manifests.All(), m.ca.Load()
+//
+// If no manifest is configured, it returns an empty slice and a nil CA.
+func (m *Authority) GetManifestsAndLatestCA() ([]*manifest.Manifest, *ca.CA, error) {
+	if m.se.Load() == nil {
+		return nil, nil, ErrNoManifest
+	}
+	if err := m.syncState(); err != nil {
+		return nil, nil, fmt.Errorf("syncing internal state: %w", err)
+	}
+	state := m.state.Load()
+	if state == nil {
+		return nil, nil, ErrNoManifest
+	}
+
+	var manifests []*manifest.Manifest
+	err := m.walkTransitions(state.latest.TransitionHash, func(_ [history.HashSize]byte, t *history.Transition) error {
+		manifestBytes, err := m.hist.GetManifest(t.ManifestHash)
+		if err != nil {
+			return err
+		}
+		var mnfst manifest.Manifest
+		if err := json.Unmarshal(manifestBytes, &mnfst); err != nil {
+			return err
+		}
+		manifests = append(manifests, &mnfst)
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	// Traversing the history yields manifests in the wrong order, so reverse the slice.
+	slices.Reverse(manifests)
+	return manifests, state.ca, nil
 }
 
 // SetManifest updates the active manifest.
-func (m *Authority) SetManifest(mnfst *manifest.Manifest) error {
-	se := m.se.Load()
-	if se == nil {
-		if err := m.createSeedEngine(); err != nil {
-			return fmt.Errorf("could not create SeedEngine: %w", err)
+func (m *Authority) SetManifest(manifestBytes []byte, policies [][]byte) (*ca.CA, error) {
+	if err := m.createSeedEngine(); err != nil {
+		return nil, fmt.Errorf("creating SeedEngine: %w", err)
+	}
+
+	if err := m.syncState(); err != nil {
+		return nil, fmt.Errorf("syncing internal state: %w", err)
+	}
+
+	var mnfst manifest.Manifest
+	if err := json.Unmarshal(manifestBytes, &mnfst); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	policyMap := make(map[[history.HashSize]byte][]byte)
+	for _, policy := range policies {
+		policyHash, err := m.hist.SetPolicy(policy)
+		if err != nil {
+			return nil, fmt.Errorf("setting policy: %w", err)
 		}
-		se = m.se.Load()
+		policyMap[policyHash] = policy
 	}
-	// TODO(burgerdev): get hash from manifest transition
-	hash, err := crypto.GenerateRandomBytes(32)
+
+	for hexRef := range mnfst.Policies {
+		var ref [history.HashSize]byte
+		refSlice, err := hexRef.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("invalid policy hash: %w", err)
+		}
+		copy(ref[:], refSlice)
+		if _, ok := policyMap[ref]; !ok {
+			return nil, fmt.Errorf("no policy for hash %q", hexRef)
+		}
+	}
+
+	manifestHash, err := m.hist.SetManifest(manifestBytes)
 	if err != nil {
-		return fmt.Errorf("generating random bytes: %w", err)
+		return nil, fmt.Errorf("setting manifest: %w", err)
 	}
-	var fixedLengthHash [32]byte
-	copy(fixedLengthHash[:], hash)
-	meshKey, err := se.DeriveMeshCAKey(fixedLengthHash)
+
+	oldState := m.state.Load()
+
+	nextTransition := &history.Transition{
+		ManifestHash: manifestHash,
+	}
+	var oldLatest *history.LatestTransition
+	var oldGeneration int
+	if oldState != nil {
+		nextTransition.PreviousTransitionHash = oldState.latest.TransitionHash
+		oldLatest = oldState.latest
+		oldGeneration = oldState.generation
+	}
+	nextTransitionHash, err := m.hist.SetTransition(nextTransition)
 	if err != nil {
-		return fmt.Errorf("deriving new mesh CA key: %w", err)
+		return nil, fmt.Errorf("setting transition: %w", err)
 	}
-	ca, err := ca.New(se.RootCAKey(), meshKey)
+	nextLatest := &history.LatestTransition{TransitionHash: nextTransitionHash}
+
+	if err := m.hist.SetLatest(oldLatest, nextLatest); err != nil {
+		return nil, fmt.Errorf("setting latest: %w", err)
+	}
+
+	meshKey, err := m.se.Load().DeriveMeshCAKey(nextTransitionHash)
 	if err != nil {
-		return fmt.Errorf("creating new CA: %w", err)
+		return nil, fmt.Errorf("deriving mesh CA key: %w", err)
 	}
-	m.ca.Store(ca)
-	m.manifests.Append(mnfst)
-	m.metrics.manifestGeneration.Set(float64(len(m.manifests.All())))
-	return nil
+	ca, err := ca.New(m.se.Load().RootCAKey(), meshKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating CA: %w", err)
+	}
+
+	nextState := &state{
+		latest:     nextLatest,
+		manifest:   &mnfst,
+		ca:         ca,
+		generation: oldGeneration + 1,
+	}
+
+	if m.state.CompareAndSwap(oldState, nextState) {
+		m.metrics.manifestGeneration.Set(float64(nextState.generation))
+	}
+	// If the CompareAndSwap did not go through, this means that another SetManifest happened in
+	// the meantime. This is fine: we know that m.state must be a transition after ours because
+	// the SetLatest call succeeded. That other SetManifest call must have been operating on our
+	// nextState already, because it had to refer to our transition. Thus, we can forget about
+	// the state, except that we need to return the right CA for the manifest _our_ user set.
+
+	return ca, nil
 }
 
 // LatestManifest retrieves the active manifest.
 func (m *Authority) LatestManifest() (*manifest.Manifest, error) {
-	return m.manifests.Latest()
+	if m.se.Load() == nil {
+		return nil, ErrNoManifest
+	}
+	if err := m.syncState(); err != nil {
+		return nil, fmt.Errorf("syncing internal state: %w", err)
+	}
+	c := m.state.Load()
+	if c == nil {
+		return nil, ErrNoManifest
+	}
+	return c.manifest, nil
 }
 
 // createSeedEngine populates m.se.
@@ -226,7 +334,7 @@ func (m *Authority) LatestManifest() (*manifest.Manifest, error) {
 // It is fine to call this function concurrently. After it returns, m.se is guaranteed to be
 // non-nil.
 func (m *Authority) createSeedEngine() error {
-	// TODO(burgerdev): return this seed to the user
+	// TODO(burgerdev): the seed should be an input
 	seed, err := crypto.GenerateRandomBytes(32)
 	if err != nil {
 		return fmt.Errorf("generating random bytes: %w", err)
@@ -241,11 +349,91 @@ func (m *Authority) createSeedEngine() error {
 	}
 	// It's fine if the seedEngine has already been created by another thread.
 	m.se.CompareAndSwap(nil, seedEngine)
+
+	m.hist.ConfigureSigningKey(m.se.Load().TransactionSigningKey())
 	return nil
 }
 
-type appendableList[T any] interface {
-	Append(T)
-	All() []T
-	Latest() (T, error)
+// syncState ensures that a.state is up-to-date.
+//
+// This function guarantees to include all state updates committed before it was called.
+func (m *Authority) syncState() error {
+	oldState := m.state.Load()
+	latest, err := m.hist.GetLatest()
+	if errors.Is(err, os.ErrNotExist) {
+		return nil // No history yet -> nothing to sync.
+	} else if err != nil {
+		return fmt.Errorf("getting latest transition: %w", err)
+	}
+	if oldState != nil && latest.TransitionHash == oldState.latest.TransitionHash {
+		return nil
+	}
+
+	// The latest transition in the backend is newer than ours, so we need to update our state.
+
+	transition, err := m.hist.GetTransition(latest.TransitionHash)
+	if err != nil {
+		return fmt.Errorf("getting transition: %w", err)
+	}
+
+	manifestBytes, err := m.hist.GetManifest(transition.ManifestHash)
+	if err != nil {
+		return fmt.Errorf("getting manifest: %w", err)
+	}
+	mnfst := &manifest.Manifest{}
+	if err := json.Unmarshal(manifestBytes, mnfst); err != nil {
+		return fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	meshKey, err := m.se.Load().DeriveMeshCAKey(latest.TransitionHash)
+	if err != nil {
+		return fmt.Errorf("deriving mesh CA key: %w", err)
+	}
+	ca, err := ca.New(m.se.Load().RootCAKey(), meshKey)
+	if err != nil {
+		return fmt.Errorf("creating CA: %w", err)
+	}
+	var generation int
+	err = m.walkTransitions(latest.TransitionHash, func(_ [history.HashSize]byte, _ *history.Transition) error {
+		generation++
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walking transitions: %w", err)
+	}
+	nextState := &state{
+		latest:     latest,
+		ca:         ca,
+		manifest:   mnfst,
+		generation: generation,
+	}
+	// We consider the sync successful even if the state was updated by someone else.
+	if m.state.CompareAndSwap(oldState, nextState) {
+		// Only set the gauge if our state modification was actually successful - otherwise, it
+		// won't match the active state.
+		m.metrics.manifestGeneration.Set(float64(generation))
+	}
+	return nil
+}
+
+// walkTransitions executes a function for all transitions in the history of transitionRef, starting from most recent.
+func (m *Authority) walkTransitions(transitionRef [history.HashSize]byte, consume func([history.HashSize]byte, *history.Transition) error) error {
+	for transitionRef != [history.HashSize]byte{} {
+		transition, err := m.hist.GetTransition(transitionRef)
+		if err != nil {
+			return fmt.Errorf("getting transition: %w", err)
+		}
+		if err := consume(transitionRef, transition); err != nil {
+			return err
+		}
+		transitionRef = transition.PreviousTransitionHash
+	}
+	return nil
+}
+
+type state struct {
+	latest     *history.LatestTransition
+	manifest   *manifest.Manifest
+	ca         *ca.CA
+	generation int
 }

--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -1,0 +1,200 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package authority
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/edgelesssys/contrast/coordinator/history"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/google/go-sev-guest/proto/sevsnp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	manifestGenerationExpected = `
+# HELP contrast_coordinator_manifest_generation Current manifest generation.
+# TYPE contrast_coordinator_manifest_generation gauge
+contrast_coordinator_manifest_generation %d
+`
+)
+
+var keyDigest = manifest.HexString("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+
+func TestEmptyAuthority(t *testing.T) {
+	a, reg := newAuthority(t)
+
+	// A fresh authority does not have a signing key, so this should fail.
+	manifests, ca, err := a.GetManifestsAndLatestCA()
+	assert.Error(t, err)
+	assert.Nil(t, ca)
+	assert.Empty(t, manifests)
+
+	manifest, err := a.LatestManifest()
+	assert.Error(t, err)
+	assert.Nil(t, manifest)
+
+	requireGauge(t, reg, 0)
+}
+
+func TestSetManifest(t *testing.T) {
+	require := require.New(t)
+	a, reg := newAuthority(t)
+	expected, mnfstBytes, policies := newManifest(t)
+
+	mnfst, err := a.LatestManifest()
+	require.ErrorIs(err, ErrNoManifest)
+	require.Nil(mnfst)
+
+	ca, err := a.SetManifest(mnfstBytes, policies)
+	require.NoError(err)
+	require.NotNil(ca)
+	requireGauge(t, reg, 1)
+
+	actual, err := a.LatestManifest()
+	require.NoError(err)
+	require.NotNil(actual)
+
+	require.Equal(expected, actual)
+
+	// Simulate manifest updates that this instance is not aware of by deleting its state.
+	a.state.Store(nil)
+
+	_, err = a.SetManifest(mnfstBytes, policies)
+	require.NoError(err)
+	requireGauge(t, reg, 2)
+}
+
+func TestSetManifest_TooFewPolicies(t *testing.T) {
+	require := require.New(t)
+	a, reg := newAuthority(t)
+	_, mnfstBytes, _ := newManifest(t)
+
+	ca, err := a.SetManifest(mnfstBytes, [][]byte{})
+	require.Error(err)
+	require.Nil(ca)
+	requireGauge(t, reg, 0)
+}
+
+func TestSetManifest_BadManifest(t *testing.T) {
+	require := require.New(t)
+	a, reg := newAuthority(t)
+	_, _, policies := newManifest(t)
+
+	ca, err := a.SetManifest([]byte(`{ "policies": 1 }`), policies)
+	require.Error(err)
+	require.Nil(ca)
+	requireGauge(t, reg, 0)
+}
+
+func TestGetManifests(t *testing.T) {
+	require := require.New(t)
+	a, reg := newAuthority(t)
+	originalManifest, mnfstBytes, policies := newManifest(t)
+
+	manifests, ca, err := a.GetManifestsAndLatestCA()
+	require.ErrorIs(err, ErrNoManifest)
+	require.Empty(manifests)
+	require.Nil(ca)
+
+	oldCA, err := a.SetManifest(mnfstBytes, policies)
+	require.NoError(err)
+	require.NotNil(oldCA)
+	requireGauge(t, reg, 1)
+
+	alteredManifest := *originalManifest
+	alteredManifest.WorkloadOwnerKeyDigests = nil
+	alteredManifestBytes, err := json.Marshal(alteredManifest)
+	require.NoError(err)
+
+	expectedCA, err := a.SetManifest(alteredManifestBytes, policies)
+	require.NoError(err)
+	require.NotNil(expectedCA)
+	requireGauge(t, reg, 2)
+
+	require.NotEqual(expectedCA.GetMeshCACert(), oldCA.GetMeshCACert())
+
+	expectedManifests := []*manifest.Manifest{originalManifest, &alteredManifest}
+
+	manifests, currentCA, err := a.GetManifestsAndLatestCA()
+	require.NoError(err)
+	require.Equal(expectedCA.GetMeshCACert(), currentCA.GetMeshCACert())
+	require.Equal(expectedCA.GetRootCACert(), currentCA.GetRootCACert())
+	require.Equal(expectedManifests, manifests)
+
+	// Simulate manifest updates that this instance is not aware of by deleting its state.
+	a.state.Store(nil)
+
+	manifests, _, err = a.GetManifestsAndLatestCA()
+	require.NoError(err)
+	require.Equal(expectedManifests, manifests)
+	requireGauge(t, reg, len(expectedManifests))
+}
+
+func TestSNPValidateOpts(t *testing.T) {
+	require := require.New(t)
+	a, _ := newAuthority(t)
+	_, mnfstBytes, policies := newManifest(t)
+	policyHash := sha256.Sum256(policies[0])
+	report := &sevsnp.Report{HostData: policyHash[:]}
+
+	opts, err := a.SNPValidateOpts(report)
+	require.Error(err)
+	require.Nil(opts)
+
+	_, err = a.SetManifest(mnfstBytes, policies)
+	require.NoError(err)
+
+	opts, err = a.SNPValidateOpts(report)
+	require.NoError(err)
+	require.NotNil(opts)
+
+	// Change to unknown policy hash in HostData.
+	report.HostData[0]++
+
+	opts, err = a.SNPValidateOpts(report)
+	require.Error(err)
+	require.Nil(opts)
+}
+
+// TODO(burgerdev): test ValidateCallback and GetCertBundle
+
+func newAuthority(t *testing.T) (*Authority, *prometheus.Registry) {
+	t.Helper()
+	fs := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
+	store := history.NewAferoStore(&afero.Afero{Fs: fs})
+	hist := history.NewWithStore(store)
+	reg := prometheus.NewRegistry()
+	return New(hist, reg, slog.Default()), reg
+}
+
+func newManifest(t *testing.T) (*manifest.Manifest, []byte, [][]byte) {
+	t.Helper()
+	policy := []byte("=== SOME REGO HERE ===")
+	policyHash := sha256.Sum256(policy)
+	policyHashHex := manifest.NewHexString(policyHash[:])
+	mnfst := &manifest.Manifest{
+		Policies:                map[manifest.HexString][]string{policyHashHex: {"test"}},
+		WorkloadOwnerKeyDigests: []manifest.HexString{keyDigest},
+	}
+	mnfstBytes, err := json.Marshal(mnfst)
+	require.NoError(t, err)
+	return mnfst, mnfstBytes, [][]byte{policy}
+}
+
+func requireGauge(t *testing.T, reg *prometheus.Registry, val int) {
+	t.Helper()
+
+	expected := fmt.Sprintf(manifestGenerationExpected, val)
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "contrast_coordinator_manifest_generation"))
+}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/meshapi"
@@ -51,7 +52,11 @@ func run() (retErr error) {
 
 	promRegistry := prometheus.NewRegistry()
 
-	meshAuth := authority.New(promRegistry, logger)
+	hist, err := history.New()
+	if err != nil {
+		return fmt.Errorf("creating history: %w", err)
+	}
+	meshAuth := authority.New(hist, promRegistry, logger)
 	userAPI := newUserAPIServer(meshAuth, promRegistry, logger)
 	meshAPI := newMeshAPIServer(meshAuth, meshAuth, promRegistry, logger)
 


### PR DESCRIPTION
This change swaps the in-memory persistence for a filesystem-backed KV store wrapped by `History`.  

Through the use of an internal atomic state pointer, the `Authority` struct is now thread-safe and responds with the correct state (esp. CA certs) even under concurrent calls to `SetManifest`. It also anticipates out-of-band modifications of persistence and syncs accordingly, which should make it ready for a distributed setup.