### PR TITLE
release: test in the default namespace

### DIFF
--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -291,7 +291,11 @@ func (c *Kubeclient) resourceInterfaceFor(obj *unstructured.Unstructured) (dynam
 	}
 	c.log.Info("found mapping", "resource", mapping.Resource)
 	ri := dyn.Resource(mapping.Resource)
-	if namespace := obj.GetNamespace(); namespace != "" {
+	if mapping.Scope.Name() == "namespace" {
+		namespace := obj.GetNamespace()
+		if namespace == "" {
+			namespace = "default"
+		}
 		return ri.Namespace(namespace), nil
 	}
 	return ri, nil


### PR DESCRIPTION
This brings us closer to the documented instructions (we had a broken release before because of this discrepancy).

Drive-by: use the appropriate way to determine whether an unstructured object is namespaced or not. This allows applying/deleting resources with no (or empty) namespace using kubeclient.