### PR TITLE
logging: enable subsystem warn level by default

### DIFF
--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/google/go-sev-guest/abi"
 	"github.com/google/go-sev-guest/proto/sevsnp"
@@ -69,7 +68,7 @@ func NewValidatorWithCallbacks(optsGen validateOptsGenerator, kdsGetter trust.HT
 		validateOptsGen: optsGen,
 		callbackers:     callbacks,
 		kdsGetter:       kdsGetter,
-		logger:          slog.New(logger.NewHandler(log.Handler(), "snp-validator")),
+		logger:          log,
 		metrics:         metrics{attestationFailures: attestataionFailures},
 	}
 }

--- a/internal/logger/handler.go
+++ b/internal/logger/handler.go
@@ -21,6 +21,7 @@ type Handler struct {
 	inner     slog.Handler
 	subsystem string
 	enabled   bool
+	level     slog.Level
 }
 
 // NewHandler returns a new Handler.
@@ -29,6 +30,7 @@ func NewHandler(inner slog.Handler, subsystem string) *Handler {
 		inner:     inner.WithGroup(subsystem),
 		subsystem: subsystem,
 		enabled:   subsystemEnvEnabled(os.Getenv, subsystem),
+		level:     slog.LevelWarn,
 	}
 	slog.New(handler).Info("Subsystem logger initialized", "subsystem", subsystem, "state", handler.state())
 	return handler
@@ -36,7 +38,7 @@ func NewHandler(inner slog.Handler, subsystem string) *Handler {
 
 // Enabled returns true if the given level is enabled.
 func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
-	return h.enabled && h.inner.Enabled(ctx, level)
+	return (h.enabled || level >= h.level) && h.inner.Enabled(ctx, level)
 }
 
 // Handle handles the given record.


### PR DESCRIPTION
This enables the all log subsystems at `warn` level or above. These logs will be get printed regardless of the `CONTRAST_LOG_SUBSYSTEMS` list. The `CONTRAST_LOG_LEVEL` variable is also considered, so when the global log level is set to `error`, only error messages will get printed from the subsystems