### PR TITLE
resourcegen: add startup probe to service mesh

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -301,5 +301,12 @@ func ServiceMeshProxy() *applycorev1.ContainerApplyConfiguration {
 			WithPrivileged(true).
 			AddCapabilities("NET_ADMIN").
 			SecurityContextApplyConfiguration,
+		).
+		WithStartupProbe(Probe().
+			WithInitialDelaySeconds(1).
+			WithPeriodSeconds(5).
+			WithFailureThreshold(5).
+			WithTCPSocket(TCPSocketAction().
+				WithPort(intstr.FromInt(15006))),
 		)
 }


### PR DESCRIPTION
This adds a startup probe to the Service Mesh sidecar container. It probes on the port the Envoy proxy listens on for incoming traffic. Envoy only starts after the iptables rules have been updated, which is when the regular containers should start.