### PR TITLE
packages: update kata-igvm to microsoft upstream

### DIFF
--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     owner = "microsoft";
     repo = "kata-containers";
     rev = "refs/tags/${version}";
-    hash = "sha256-W36RJFf0MVRIBV4ahpv6pqdAwgRYrlqmu4Y/8qiILS8=";
+    hash = "sha256-sFh2V7ylRDL6H50BcaHcgJAhrx4yvXzHNxtdQ9VYXdk=";
   };
 
   patches = [

--- a/packages/by-name/microsoft/kata-igvm/package.nix
+++ b/packages/by-name/microsoft/kata-igvm/package.nix
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 { lib
-, fetchFromGitHub
 , stdenv
 , microsoft
 , igvm-tooling
@@ -11,20 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "kata-igvm";
-  version = "3.2.0.azl1.genpolicy0";
+  inherit (microsoft.genpolicy) src version;
 
   outputs = [ "out" "debug" ];
 
   nativeBuildInputs = [
     igvm-tooling
   ];
-
-  src = fetchFromGitHub {
-    owner = "microsoft";
-    repo = "kata-containers";
-    rev = "refs/tags/${version}";
-    hash = "sha256-sFh2V7ylRDL6H50BcaHcgJAhrx4yvXzHNxtdQ9VYXdk=";
-  };
 
   sourceRoot = "${src.name}/tools/osbuilder/igvm-builder";
 


### PR DESCRIPTION
The microsoft.kata-igvm package was using an outdated branch that didn't reflect the build process in Microsoft's upstream branch very well, even though building almost the same image. This updates our build process of the image to the new upstream build. Tested to be reproducible and work in a Contrast cluster.