### PR TITLE
packages/contrast-releases: fix v0.7.0 and update workflow on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
           nix build -L .#cli-release
       - name: Update contrast-releases.json with new release
         env:
-          VERSION: ${{ needs.process-inputs.outputs.MAJOR_MINOR_PATCH }}
+          VERSION: ${{ inputs.version }}
         run: nix run .#scripts.update-contrast-releases
       - name: Upload updated contrast-releases.json (for main branch PR)
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/packages/contrast-releases.json
+++ b/packages/contrast-releases.json
@@ -33,7 +33,7 @@
       "hash": "sha256-wkFrKsnoTfoe+iKM3GwJShLdLzdgwl5S+3RToGdMdUg="
     },
     {
-      "version": "0.7.0",
+      "version": "v0.7.0",
       "hash": "sha256-0arNzOsh9FBUV+uzF/bOZe/2Bat+Qb7EqS5n5VCUcJQ="
     }
   ],
@@ -71,7 +71,7 @@
       "hash": "sha256-Y8SOqsFnknDM8j/bsjLgkEjyLtONUE68SWIWG566QE8="
     },
     {
-      "version": "0.7.0",
+      "version": "v0.7.0",
       "hash": "sha256-SCodY1iwWrGUOY5oMJKBxOvkOnK+ujfNFheV3ip7qCk="
     }
   ],
@@ -93,7 +93,7 @@
       "hash": "sha256-gkORMN5x9L5QdSSdszaeij57PHkxY12ZpqZ7Ud6VrIg="
     },
     {
-      "version": "0.7.0",
+      "version": "v0.7.0",
       "hash": "sha256-7wpPTpxAOh3vsECdZh+BsJQCzkrnJwG+2O+WctKuwlk="
     }
   ],
@@ -107,7 +107,7 @@
       "hash": "sha256-7A/r68T8BlYeTgMQtrCUqR/+dQlwFimeGz+7JSxAT4w="
     },
     {
-      "version": "0.7.0",
+      "version": "v0.7.0",
       "hash": "sha256-HFz0blP1yGs3wjUs5z9/cyPqCkzxh5AWAD25PLRONGw="
     }
   ]


### PR DESCRIPTION
`contrast-releases.json` is not updated with the correct version on release (e.g. `0.7.0` instead of `v0.7.0`). This breaks `just demodir`.

- PR generated by the new release workflow with correct versioning: https://github.com/edgelesssys/contrast/pull/579