### PR TITLE
packages: package cloud-hypervisor-cvm

### DIFF
--- a/packages/by-name/microsoft/cloud-hypervisor/package.nix
+++ b/packages/by-name/microsoft/cloud-hypervisor/package.nix
@@ -1,0 +1,73 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, patchelf
+, withIGVM ? true
+, withSEVSNP ? true
+, withTDX ? false
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cloud-hypervisor";
+  version = "32.0.317";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "cloud-hypervisor";
+    rev = "refs/tags/msft/v${version}";
+    hash = "sha256-D9wfCat0GVHUpppjFghKTYPl5rXE12aVxVkAFxxq78U=";
+  };
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "acpi_tables-0.1.0" = "sha256-aT0p85QDGjBEnbABedm0q7JPpiNjhupoIzBWifQ0RaQ=";
+      "micro_http-0.1.0" = "sha256-w2witqKXE60P01oQleujmHSnzMKxynUGKWyq5GEh1Ew=";
+      "mshv-bindings-0.1.1" = "sha256-9Q7IXznZ+qdf/d4gO7qVEjbNUUygQDNYLNxz2BECLHc=";
+      "vfio-bindings-0.4.0" = "sha256-lKdoo/bmnZTRV7RRWugwHDFFCB6FKxpzxDEEMVqSbwA=";
+      "vfio_user-0.1.0" = "sha256-JYNiONQNNpLu57Pjdn2BlWOdmSf3c4/XJg/RsVxH3uk=";
+      "vm-fdt-0.2.0" = "sha256-gVKGiE3ZSe+z3oOHR3zqVdc7XMHzkp4kO4p/WfK0VI8=";
+      "kvm-bindings-0.6.0" = "sha256-wGdAuPwsgRIqx9dh0m+hC9A/Akz9qg9BM+p06Fi5ACM=";
+      "kvm-ioctls-0.13.0" = "sha256-jHnFGwBWnAa2lRu4a5eRNy1Y26NX5MV8alJ86VR++QE=";
+      "versionize_derive-0.1.4" = "sha256-BPl294UqjVl8tThuvylXUFjFNjJx8OSfBGJLg8jIkWw=";
+    };
+  };
+
+  separateDebugInfo = true;
+
+  nativeBuildInputs = [ pkg-config patchelf ];
+  buildInputs = [ openssl ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "mshv"
+    "kvm"
+  ] ++ lib.optional withIGVM [ "igvm" ]
+  ++ lib.optional withSEVSNP [ "snp" ]
+  ++ lib.optional withTDX [ "tdx" ];
+
+  OPENSSL_NO_VENDOR = true;
+
+  cargoTestFlags = [
+    "--workspace"
+    "--bins"
+    "--lib" # Integration tests require root.
+    "--exclude"
+    "net_util" # /dev/net/tun
+    "--exclude"
+    "vmm" # /dev/kvm
+  ];
+
+  meta = {
+    homepage = "https://github.com/microsoft/cloud-hypervisor";
+    description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM";
+    changelog = "https://github.com/microsoft/cloud-hypervisor/releases/tag/msft/v${version}";
+    license = with lib.licenses; [ asl20 bsd3 ];
+    mainProgram = "cloud-hypervisor";
+  };
+}

--- a/packages/by-name/runtime-class-files/package.nix
+++ b/packages/by-name/runtime-class-files/package.nix
@@ -1,8 +1,7 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ fetchurl
-, stdenvNoCC
+{ stdenvNoCC
 , microsoft
 , igvmmeasure
 , debugRuntime ? false
@@ -11,10 +10,7 @@
 let
   rootfs = microsoft.kata-image;
   igvm = if debugRuntime then microsoft.kata-igvm.debug else microsoft.kata-igvm;
-  cloud-hypervisor-bin = fetchurl {
-    url = "https://cdn.confidential.cloud/contrast/node-components/1714998420/cloud-hypervisor-cvm";
-    hash = "sha256-coTHzd5/QLjlPQfrp9d2TJTIXKNuANTN7aNmpa8PRXo=";
-  };
+  cloud-hypervisor-bin = "${microsoft.cloud-hypervisor}/bin/cloud-hypervisor";
   containerd-shim-contrast-cc-v2 = "${microsoft.kata-runtime}/bin/containerd-shim-kata-v2";
 in
 

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -16,6 +16,7 @@ let
     contrast-releases = callPackages ./contrast-releases.nix { };
     microsoft = self'.microsoft // {
       genpolicy = pkgs.pkgsStatic.callPackage ./by-name/microsoft/genpolicy/package.nix { };
+      cloud-hypervisor = pkgs.pkgsStatic.callPackage ./by-name/microsoft/cloud-hypervisor/package.nix { };
     };
     kata = self'.kata // {
       genpolicy = pkgs.pkgsStatic.callPackage ./by-name/kata/genpolicy/package.nix { };


### PR DESCRIPTION
Previously, we relied on a cloud-hypervisor-cvm artifact that we fetched from the AKS nodes once. This enables us to reproducibly build the cloud-hypervisor fork of Microsoft that's deployed on Kata-enabled AKS VMs ourselves, and uses it in the runtime-class-files we deploy through the node-installer.