### PR TITLE
e2e: cleanup when test is cancelled

### DIFF
--- a/.github/workflows/e2e_getdents.yml
+++ b/.github/workflows/e2e_getdents.yml
@@ -6,7 +6,8 @@ on:
         skip-undeploy:
           description: "Skip undeploy"
           required: false
-          default: "false"
+          type: boolean
+          default: false
 
 env:
   container_registry: ghcr.io/edgelesssys
@@ -50,4 +51,11 @@ jobs:
           just node-installer
       - name: E2E Test
         run: |
-          nix shell .#contrast.e2e --command getdents.test -test.v workspace/just.containerlookup
+          nix shell .#contrast.e2e --command getdents.test -test.v \
+            --image-replacements workspace/just.containerlookup \
+            --namespace-file workspace/e2e.namespace \
+            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+      - name: Cleanup
+        if: cancelled() && !inputs.skip-undeploy
+        run: |
+          kubectl delete ns $(cat workspace/e2e.namespace) --timeout 5m

--- a/.github/workflows/e2e_openssl.yml
+++ b/.github/workflows/e2e_openssl.yml
@@ -6,7 +6,8 @@ on:
         skip-undeploy:
           description: "Skip undeploy"
           required: false
-          default: "false"
+          type: boolean
+          default: false
     pull_request:
       paths-ignore:
         - docs/**
@@ -60,4 +61,11 @@ jobs:
           just coordinator initializer openssl port-forwarder node-installer
       - name: E2E Test
         run: |
-          nix shell .#contrast.e2e --command openssl.test -test.v workspace/just.containerlookup
+          nix shell .#contrast.e2e --command openssl.test -test.v \
+            --image-replacements workspace/just.containerlookup \
+            --namespace-file workspace/e2e.namespace \
+            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+      - name: Cleanup
+        if: cancelled() && !inputs.skip-undeploy
+        run: |
+          kubectl delete ns $(cat workspace/e2e.namespace) --timeout 5m

--- a/.github/workflows/e2e_servicemesh.yml
+++ b/.github/workflows/e2e_servicemesh.yml
@@ -6,7 +6,8 @@ on:
         skip-undeploy:
           description: "Skip undeploy"
           required: false
-          default: "false"
+          type: boolean
+          default: false
     pull_request:
       paths-ignore:
         - docs/**
@@ -60,8 +61,11 @@ jobs:
           just coordinator initializer port-forwarder service-mesh-proxy node-installer
       - name: E2E Test
         run: |
-          nix shell .#contrast.e2e --command servicemesh.test -test.v workspace/just.containerlookup
-      - name: Undeploy
-        if: always() && inputs.skip-undeploy != 'true'
+          nix shell .#contrast.e2e --command servicemesh.test -test.v \
+            --image-replacements workspace/just.containerlookup \
+            --namespace-file workspace/e2e.namespace \
+            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+      - name: Cleanup
+        if: cancelled() && !inputs.skip-undeploy
         run: |
-          just undeploy
+          kubectl delete ns $(cat workspace/e2e.namespace) --timeout 5m

--- a/e2e/getdents/getdents_test.go
+++ b/e2e/getdents/getdents_test.go
@@ -25,10 +25,13 @@ const (
 	getdent = "getdents-tester"
 )
 
-var imageReplacementsFile string
+var (
+	imageReplacementsFile, namespaceFile string
+	skipUndeploy                         bool
+)
 
 func TestGetDEnts(t *testing.T) {
-	ct := contrasttest.New(t, imageReplacementsFile)
+	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, skipUndeploy)
 
 	resources, err := kuberesource.GetDEnts()
 	require.NoError(t, err)
@@ -72,9 +75,10 @@ func TestGetDEnts(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
+	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
+	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
 	flag.Parse()
-
-	imageReplacementsFile = flag.Arg(0)
 
 	os.Exit(m.Run())
 }

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -30,11 +30,14 @@ const (
 	opensslBackend  = "openssl-backend"
 )
 
-var imageReplacementsFile string
+var (
+	imageReplacementsFile, namespaceFile string
+	skipUndeploy                         bool
+)
 
 // TestOpenSSL runs e2e tests on the example OpenSSL deployment.
 func TestOpenSSL(t *testing.T) {
-	ct := contrasttest.New(t, imageReplacementsFile)
+	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, skipUndeploy)
 
 	resources := kuberesource.OpenSSL()
 
@@ -177,9 +180,10 @@ func TestOpenSSL(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
+	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
+	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
 	flag.Parse()
-
-	imageReplacementsFile = flag.Arg(0)
 
 	os.Exit(m.Run())
 }

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -23,11 +23,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var imageReplacementsFile string
+var (
+	imageReplacementsFile, namespaceFile string
+	skipUndeploy                         bool
+)
 
 // TestIngressEgress tests that the ingress and egress proxies work as configured.
 func TestIngressEgress(t *testing.T) {
-	ct := contrasttest.New(t, imageReplacementsFile)
+	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, skipUndeploy)
 
 	resources := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
 
@@ -136,9 +139,10 @@ func TestIngressEgress(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
+	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
+	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
 	flag.Parse()
-
-	imageReplacementsFile = flag.Arg(0)
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Adds an extra cleanup step to both the OpenSSL and Service Mesh test to clean up the resources in the CI cluster if the test was cancelled.