### PR TITLE
Change CN: Constellation -> Contrast

### DIFF
--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -164,7 +164,7 @@ func getCertificate(ctx context.Context, issuer Issuer, priv, pub any, nonce []b
 	now := time.Now()
 	template := &x509.Certificate{
 		SerialNumber:    serialNumber,
-		Subject:         pkix.Name{CommonName: "Constellation"},
+		Subject:         pkix.Name{CommonName: "Contrast"},
 		NotBefore:       now.Add(-2 * time.Hour),
 		NotAfter:        now.Add(2 * time.Hour),
 		ExtraExtensions: extensions,


### PR DESCRIPTION
The self-signed x.509 cert of the Coordinator has currently the CN: Constellation. Seems like a copy & paste error so I changed it to Contrast.