### PR TITLE
packages: package Kata upstream UVM image

### DIFF
--- a/.github/workflows/rpm_updates.yml
+++ b/.github/workflows/rpm_updates.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-rpm-packages:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -18,9 +18,12 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Update rpm packages
+      - name: Update Microsoft RPMs
         run: |
-           nix run .#rpm-pin-vendor > packages/by-name/microsoft/kata-image/package-index.json
+           nix run .#rpm-pin-vendor -- kata-packages-uvm kata-packages-uvm-coco systemd libseccomp > packages/by-name/microsoft/kata-image/package-index.json
+      - name: Update Kata RPMs
+        run: |
+           nix run .#rpm-pin-vendor -- kata-packages-uvm kata-packages-uvm-coco systemd libseccomp core-packages-base-image > packages/by-name/kata/kata-image/package-index.json
       - name: Create PR
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:

--- a/packages/by-name/kata/kata-image/buildimage.sh
+++ b/packages/by-name/kata/kata-image/buildimage.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+# Image layout:
+#
+#   +---------------------------------+-------------------+-------------------------+
+#   | 512B DOS MBR (padded to 1 MiB)  | p0    rootfs      | p1      hashtree        |
+#   +---------------------------------+-------------------+-------------------------+
+#   |                                 |                   |                         |
+#   0                                 1MiB                1MiB + rootfs_size        1MiB + rootfs_size + hashtree_size
+
+# rootfs: erofs filesystem mounted at / (read-only)
+# hashtree: dm-verity hashtree without superblock
+
+readonly MIB=1048576
+
+in=$1
+out=$2
+tmpdir=$(mktemp -d)
+trap 'rm -rf $tmpdir' EXIT
+rootfs=$tmpdir/01_rootfs
+hashtree=$tmpdir/02_verity_hashtree
+dm_verity_file=$out/dm_verity.txt
+roothash=$out/roothash
+raw=$out/raw.img
+uuid=c1b9d5a2-f162-11cf-9ece-0020afc76f16
+salt=0102030405060708090a0b0c0d0e0f
+
+if [ -z "${SOURCE_DATE_EPOCH}" ]; then
+  echo "SOURCE_DATE_EPOCH is not set" >&2
+  exit 1
+fi
+
+mkdir -p "$out"
+
+# create the rootfs and pad it to 1MiB
+mkfs.erofs \
+  -z lz4 \
+  -b 4096 \
+  -T "$SOURCE_DATE_EPOCH" \
+  -U "$uuid" \
+  --tar=f \
+  "$rootfs" \
+  "$in"
+truncate -s '%1MiB' "$rootfs"
+
+# create the dm-verity hashtree
+verity_out=$(
+  veritysetup format \
+    "$rootfs" \
+    "$hashtree" \
+    --data-block-size 4096 \
+    --hash-block-size 4096 \
+    --no-superblock \
+    --uuid "$uuid" \
+    --salt "$salt" | tee "$dm_verity_file"
+)
+# pad the hashtree to multiple of 1MiB
+truncate -s '%1MiB' "$hashtree"
+# extract dm-verity parameters from text output to individual files
+sed -i 1d "$dm_verity_file"
+root_hash=$(echo "$verity_out" | grep -oP 'Root hash:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$root_hash" >"$roothash"
+hash_type=$(echo "$verity_out" | grep -oP 'Hash type:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$hash_type" >"$out/hash_type"
+data_blocks=$(echo "$verity_out" | grep -oP 'Data blocks:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$data_blocks" >"$out/data_blocks"
+data_block_size=$(echo "$verity_out" | grep -oP 'Data block size:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$data_block_size" >"$out/data_block_size"
+hash_blocks=$(echo "$verity_out" | grep -oP 'Hash blocks:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$hash_blocks" >"$out/hash_blocks"
+hash_block_size=$(echo "$verity_out" | grep -oP 'Hash block size:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$hash_block_size" >"$out/hash_block_size"
+hash_algorithm=$(echo "$verity_out" | grep -oP 'Hash algorithm:\s+\K\w+' | tr -d "[:space:]")
+echo -n "$hash_algorithm" >"$out/hash_algorithm"
+echo -n "$salt" >"$out/salt"
+
+rootfs_size_mib=$(($(stat -c %s "$rootfs") / "$MIB"))
+# full image size is dos header + rootfs + hashtree
+hashtree_size_bytes=$(stat -c %s "$hashtree")
+hashtree_size_mib=$(($(stat -c %s "$hashtree") / "$MIB"))
+# img_size is the size of the full image in bytes
+# DOS MBR (padded to 1MiB) + rootfs + hashtree
+img_size_bytes=$(("$MIB" + "$rootfs_size_mib" * "$MIB" + "$hashtree_size_bytes"))
+
+# Where the rootfs starts in MiB
+readonly rootfs_start=1
+# hash_start is the start of the hashtree in MiB
+hash_start=$((rootfs_start + rootfs_size_mib))
+hash_end=$((hash_start + hashtree_size_mib))
+
+rs=$(printf "%4dMiB" "$rootfs_start")
+hs=$(printf "%4dMiB" "$hash_start")
+he=$(printf "%4dMiB" "$hash_end")
+cat <<EOF
+Image layout:
+
+  +---------------------------------+-------------------+-------------------------+
+  | 512B DOS MBR (padded to 1 MiB)  | p0    rootfs      | p1      hashtree        |
+  +---------------------------------+-------------------+-------------------------+
+  |                                 |                   |                         |
+  0                             $rs             $hs                   $he
+EOF
+
+# create the raw image
+truncate -s "$img_size_bytes" "$raw"
+
+# create the partition table
+parted -s -a optimal "${raw}" -- \
+  mklabel msdos \
+  mkpart primary ext4 ${rootfs_start}MiB ${hash_start}MiB \
+  mkpart primary ext4 ${hash_start}MiB '100%'
+sfdisk --disk-id "${raw}" 0
+
+# write the rootfs and hashtree to the raw image
+dd if="$rootfs" of="${raw}" bs=1MiB seek=${rootfs_start} conv=notrunc,fsync
+dd if="$hashtree" of="${raw}" bs=1MiB seek=${hash_start} conv=notrunc,fsync

--- a/packages/by-name/kata/kata-image/package-index.json
+++ b/packages/by-name/kata/kata-image/package-index.json
@@ -1,0 +1,562 @@
+[
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/a/audit-libs-3.0.6-8.cm2.x86_64.rpm",
+    "hash": "sha256-VgGfQp0tWzNLEgIm1cGDdKy9NH2GG7zjeAUukokpD2k="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bash-5.1.8-4.cm2.x86_64.rpm",
+    "hash": "sha256-ThaBW0Ncj45PBFetz3YeQdcFV3qQkhLUPnjc0iERN0s="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bc-1.07.1-4.cm2.x86_64.rpm",
+    "hash": "sha256-V3voScF7Xe831YpKhtAQkijMPR7terd8s+9v7Oq9Kk0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bind-libs-9.16.48-1.cm2.x86_64.rpm",
+    "hash": "sha256-14binuszcUw7a0BiLVlchK1TVoymFRVA3+ljxtSNF/0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bind-license-9.16.48-1.cm2.noarch.rpm",
+    "hash": "sha256-7B8MOzaGuqQQp0BxyDqPd1f10V1C0vK0mPJkSg4M8vg="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bind-utils-9.16.48-1.cm2.x86_64.rpm",
+    "hash": "sha256-xjsfNPOrvMp+Ayb89m89FXEZcVHKYGi7sDQ+jEqFQvE="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bridge-utils-1.7.1-2.cm2.x86_64.rpm",
+    "hash": "sha256-ErLVq6o7vhPBzkSbXl18h5IAMBOOqio5C8GTrbd54hA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bzip2-1.0.8-1.cm2.x86_64.rpm",
+    "hash": "sha256-GPa2ZcpiiedP5TpfBNwVpvNlfoEiYuxQO2PYt0CrgsI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/b/bzip2-libs-1.0.8-1.cm2.x86_64.rpm",
+    "hash": "sha256-xy3NTfx4doQNZyzw2flp7ObWz0HkpGXySQ54DAYV8H8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/ca-certificates-2.0.0-17.cm2.noarch.rpm",
+    "hash": "sha256-veHtDRgLlq/QWGBmmm8ZRjsNUerjQuU6B8gs9bYwgnc="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/ca-certificates-base-2.0.0-17.cm2.noarch.rpm",
+    "hash": "sha256-WnL+F7/FR8Zlkq7pV/ahy7o8WnVDfNZaEAaDsiP/LB0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/ca-certificates-shared-2.0.0-17.cm2.noarch.rpm",
+    "hash": "sha256-hmBlXDDMutNJS98qofZHtwHHo5WhsoGjonH0h0x8wTA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/ca-certificates-tools-2.0.0-17.cm2.noarch.rpm",
+    "hash": "sha256-wgitZWbKli11+REdYx9mLrgwF6RDRcOdUJu89jWUaBI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/chkconfig-1.20-4.cm2.x86_64.rpm",
+    "hash": "sha256-3tHthHWZa5BYK8OoeQ2XNjew6t6yONdU6f5dVeP8v3Y="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/chrony-4.1-3.cm2.x86_64.rpm",
+    "hash": "sha256-WH8M2Arqc/gLJSfJFCo0grNwOcseqa348kNt7vvi9Rk="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cifs-utils-6.14-2.cm2.x86_64.rpm",
+    "hash": "sha256-2J+ybspZFthyKq9jnXRKbEPc8A07AuX7XbiABKHc1bY="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/core-packages-base-image-2.0-8.cm2.x86_64.rpm",
+    "hash": "sha256-g8oIsNCIihNNBbs41I/8614jTIQtayn8NJchPHX5yeY="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/core-packages-container-2.0-8.cm2.x86_64.rpm",
+    "hash": "sha256-AvGiZXDeH1i0vT+NaaVJowEfhNv+CNBc4YfHFPs16f0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/coreutils-8.32-7.cm2.x86_64.rpm",
+    "hash": "sha256-CJjEDYi1s1FSX80g+zMZu7+PVpDdoJcR1DiTYMBOxfY="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cpio-2.13-5.cm2.x86_64.rpm",
+    "hash": "sha256-BowsmhHh2jZIAeXYgLHR6N23TDkREBpvZKT1biSoqpM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cracklib-2.9.7-5.cm2.x86_64.rpm",
+    "hash": "sha256-O2orWkJmbN3fk9sph7i+H3X2KvqwR2Dk/TBpi/d8c1o="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cracklib-dicts-2.9.7-5.cm2.x86_64.rpm",
+    "hash": "sha256-uZMuKcOR0D6SbM7VgYm+fcuBv5LILcvfZuxQHzGp0So="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cryptsetup-2.4.3-4.cm2.x86_64.rpm",
+    "hash": "sha256-FtWBVFh7I/tmGqkh6tqFtb3kmXUxOd6lcwaU884SMu8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cryptsetup-libs-2.4.3-4.cm2.x86_64.rpm",
+    "hash": "sha256-pco7TmLwLTuWKT87qTTAnin5IeoHAiXzbK3p6nJ0BKI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/curl-8.5.0-2.cm2.x86_64.rpm",
+    "hash": "sha256-a5g8iIlRGKa02+QHKxSmbi8YONjcgJTUfPBP4gSEIb4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/curl-libs-8.5.0-2.cm2.x86_64.rpm",
+    "hash": "sha256-da7Xof+YA9z2fn9qHcbdB0pTQFHZZZzUnjRoHjG85dU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/c/cyrus-sasl-lib-2.1.28-4.cm2.x86_64.rpm",
+    "hash": "sha256-jsX83c9gctllHEk2hOa8WIf1sLUXd2s4sRKc6dUmPAg="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/d/dbus-1.15.6-1.cm2.x86_64.rpm",
+    "hash": "sha256-wckUbLIkZlarlQBtxI+vZoHPGAdG4dd0cHuDem+b+Q8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/d/device-mapper-2.03.15-3.cm2.x86_64.rpm",
+    "hash": "sha256-5Rg8i20MFovplvtH9hUBMkmiD/hLqVTOjUgdneDvuDI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/d/device-mapper-event-2.03.15-3.cm2.x86_64.rpm",
+    "hash": "sha256-oPegONloxOxPMYmX4IbU4P4wSVdOC+FcSIWpPB7VQkw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/d/device-mapper-event-libs-2.03.15-3.cm2.x86_64.rpm",
+    "hash": "sha256-hgnvTrKRJcVksrHPHU2dIoSATnkLj+3PpRrwjwhk7RU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/d/device-mapper-libs-2.03.15-3.cm2.x86_64.rpm",
+    "hash": "sha256-Jyjy2IfuKM8ImBytElAN+vl79Uqdc79YTL2XZdIQA48="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/e/e2fsprogs-1.46.5-3.cm2.x86_64.rpm",
+    "hash": "sha256-xq9SvSg7M6aeg/vmEooNAd9OEJ1sYr43y43aLU9klAs="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/e/e2fsprogs-libs-1.46.5-3.cm2.x86_64.rpm",
+    "hash": "sha256-V4exraE0dMe3ddS8PVtzwsP4W3FsZBk//866Vcjv3As="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/e/elfutils-libelf-0.186-2.cm2.x86_64.rpm",
+    "hash": "sha256-pRI7/zb7FDLFSiKHWqkm+ijy4YBk928n6l7D7ydkpLw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/e/expat-2.6.2-2.cm2.x86_64.rpm",
+    "hash": "sha256-6I2mCGEGprX5C4qNct6PaPfFAU+7hPiOfhBxcl72xd8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/e/expat-libs-2.6.2-2.cm2.x86_64.rpm",
+    "hash": "sha256-5bbAXY/HU8kZK45+9JCq/8SZRBdKuGH9AtHJLnPmLgs="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/f/file-5.40-2.cm2.x86_64.rpm",
+    "hash": "sha256-bcMQVAkvoY4aRazaQTNFLSf+eofMbYiZZTOIBi1xIo8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/f/file-libs-5.40-2.cm2.x86_64.rpm",
+    "hash": "sha256-d7J5iFwn/Sorzbl49E9u3n0z/Iw9dTzCdrQLYjzCLpU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/f/filesystem-1.1-20.cm2.x86_64.rpm",
+    "hash": "sha256-n6iNUlfrX2WRcQGA+fglFeOt44fG+89y4oz+v/rgHuI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/f/findutils-4.8.0-5.cm2.x86_64.rpm",
+    "hash": "sha256-BO6S/wrhyFjXtSB/2kvIv/oNBKz7sYJzOmcjy9sJttQ="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/gdbm-1.21-1.cm2.x86_64.rpm",
+    "hash": "sha256-EabAF/yQigDCXyHjMz+0krDq4M10JHtMQqdNBWez5nM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/glib-2.71.0-2.cm2.x86_64.rpm",
+    "hash": "sha256-wWRoNzbo1MX0XEvT6mshHGcxc+ukzxQ6J1FEkHGZF6g="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/glibc-2.35-7.cm2.x86_64.rpm",
+    "hash": "sha256-ihRSOw4jeE9n25nIXfpPZJHBkU9oQiDmokr0fo+ro0g="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/gmp-6.2.1-4.cm2.x86_64.rpm",
+    "hash": "sha256-bnJ3D11SQi5WfnpuiSQFnLw8ssQ22ErcefG4IwdkS3o="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/gnupg2-2.4.0-2.cm2.x86_64.rpm",
+    "hash": "sha256-A3OX8UfloyDEgjPVcGN8xOWTrFLQqgOTChoL3HbX3cM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/gpgme-1.16.0-2.cm2.x86_64.rpm",
+    "hash": "sha256-APEWBTJJoPn+qG8E3aNL/v88pY0B0+6zxRcnm57WTO8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/grep-3.7-2.cm2.x86_64.rpm",
+    "hash": "sha256-TwjKeKFBJYR4zhuMw1Ltk/n/uihu0mzNI8duayX6T5I="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/g/gzip-1.12-2.cm2.x86_64.rpm",
+    "hash": "sha256-yAGT2o3W9f4E1GyHoV8utyIweETf6L3fivCJuBczOcU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/i/iana-etc-20211115-2.cm2.noarch.rpm",
+    "hash": "sha256-AGTXuDYJCG/kABzV2oUzc7kgIn6PcmBbAIGAsJARzN0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/i/iproute-5.15.0-3.cm2.x86_64.rpm",
+    "hash": "sha256-++U8bP0w46rRd6hw+Ggsu7kMrN+6AmsUy4ysaiIrqmM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/i/iptables-1.8.7-4.cm2.x86_64.rpm",
+    "hash": "sha256-2/DeCWzVM43YazbA5DbtfNjPstwVnFf/Irmp4ZZUp44="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/i/iputils-20211215-2.cm2.x86_64.rpm",
+    "hash": "sha256-DDNR+lKZhgFR8oDeSXkKWE52zyOH9YTPtYJMZkG+02Q="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/i/irqbalance-1.8.0-4.cm2.x86_64.rpm",
+    "hash": "sha256-4rZVtmCSQEntJDneWXIUM3p3AGnZDHhja+t6UN8Q/P4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/j/json-c-0.15-2.cm2.x86_64.rpm",
+    "hash": "sha256-dsOH9HRz8wMBsq2aDLHiYjI7dvvQYatobmEAN0WGId8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/k/kata-packages-uvm-1.0.0-4.cm2.x86_64.rpm",
+    "hash": "sha256-eNxQ4J00TYohfg5izZknLpQfxmb9uZ/71WjYd46RxpY="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/k/kata-packages-uvm-coco-1.0.0-4.cm2.x86_64.rpm",
+    "hash": "sha256-mHJPnYEBVxiEeoBiJw/4bDNnVqp9g8WVwq7iL08RNQk="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/k/keyutils-1.6.3-1.cm2.x86_64.rpm",
+    "hash": "sha256-mEWiqQ+YdK3ZHhf7aRWBUYRgjs98GTI4Q1vZPapbzkA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/k/kmod-29-2.cm2.x86_64.rpm",
+    "hash": "sha256-2PFXCoxuz9v+SuQn5+opDbP3pNKuKZoH4wEA9Oy9Pxw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/k/krb5-1.19.4-2.cm2.x86_64.rpm",
+    "hash": "sha256-6jK+D2Cvv3YLGGBnX3D59UQtWbp176S1bcdpxSsTA1o="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libaio-0.3.112-4.cm2.x86_64.rpm",
+    "hash": "sha256-GubbB8lO6NJKURIn8hzJAWsshmR52aQniybY3alvO5k="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libarchive-3.6.1-2.cm2.x86_64.rpm",
+    "hash": "sha256-eQ00MPKITbKJdGyzqzUZJDx2xU1zso+U8fLDyEKMt8s="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libassuan-2.5.5-2.cm2.x86_64.rpm",
+    "hash": "sha256-Vroe0tFtlgvGDstpMUYcSTKugkAbkV2VttURBVUBluw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libcap-2.60-2.cm2.x86_64.rpm",
+    "hash": "sha256-vh8o1sFZ0pNCx75g+1aeAvCH6fZib4cpu+0XATlK3wA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libcap-ng-0.8.2-2.cm2.x86_64.rpm",
+    "hash": "sha256-hbj5/nlIlftez1UU/h4//DEgELfz7HbpQ5qiLLcFG8I="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libdb-5.3.28-7.cm2.x86_64.rpm",
+    "hash": "sha256-8SHWMLtJtCXtbo44BFXlPIPTPmsm4zcnayKXd5FOo3c="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libedit-3.1.20210910-1.cm2.x86_64.rpm",
+    "hash": "sha256-/lksTEQ9fSb/DFK5cEEfQ0EYq6gE6afKZ7akINiTZwE="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libffi-3.4.2-3.cm2.x86_64.rpm",
+    "hash": "sha256-g0VUg7rGiuGmbqImqw8tQOJAzjhLHWLp1b9BcPWug5I="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libgcc-11.2.0-8.cm2.x86_64.rpm",
+    "hash": "sha256-A1sdPjobGh94QTejGUgXTGIxGYxAu4ZYTYK5hS4B+/4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libgcrypt-1.10.3-1.cm2.x86_64.rpm",
+    "hash": "sha256-RHHtKFEeb/KmSw5wkxQAXry3IuoKvzodhWqCoEC/sIw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libgpg-error-1.46-1.cm2.x86_64.rpm",
+    "hash": "sha256-JpDOmG/y3I4mTpVcESf+DOmePuSkTyfmpSC9mZE85KU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libksba-1.6.3-1.cm2.x86_64.rpm",
+    "hash": "sha256-swan1Euq7DG9z5SzyNdodfyJqKWoUQIH9q8KCNSVJ7k="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libmnl-1.0.4-6.cm2.x86_64.rpm",
+    "hash": "sha256-qdDvZd5IjjmRNqv1ORGbp7vxqC6weBtUX99kL+xERK0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libpkgconf-1.8.0-3.cm2.x86_64.rpm",
+    "hash": "sha256-MZi/sMPe+DFHws2FGAsDNLp6K4Uz+I7z9vpz9sm5UXQ="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libpwquality-1.4.4-1.cm2.x86_64.rpm",
+    "hash": "sha256-hL5GcugM6Ea8efMo8ncLx8Ip7iRmHDh6OXoS/kpR2KU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libseccomp-2.5.3-1.cm2.x86_64.rpm",
+    "hash": "sha256-WF0KXWdcPw64VxTjahj1VIas9mV8dy7+mfLUXaaDyq8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libselinux-3.2-1.cm2.x86_64.rpm",
+    "hash": "sha256-MUZb/jB2sek6KcmRZwapCznY9H2E5XAUuPR5kYgtkyA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libsemanage-3.2-2.cm2.x86_64.rpm",
+    "hash": "sha256-UR+h2Y3N2FRMrV+8kfxx9Lubp37noGyewpI+hMgiDiM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libsepol-3.2-2.cm2.x86_64.rpm",
+    "hash": "sha256-iweA41BQuSYGkwEE7vD9GvUDSFnk1Hb+C2VZc/XsiCw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libsolv-0.7.24-1.cm2.x86_64.rpm",
+    "hash": "sha256-KTqumlw9Rt1k9NYuf6KC9PCIcX7H2IzP5Gtr2RPGKz0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libssh2-1.9.0-4.cm2.x86_64.rpm",
+    "hash": "sha256-FAwwrXlYYoFPO8CkYdCW3ioR0h0JYNSiSqnxei6taSU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libstdc++-11.2.0-8.cm2.x86_64.rpm",
+    "hash": "sha256-r6Fgv8hDePRrMdqvNItPEWtP7hb08IPaO35AHRTp+zM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libtasn1-4.19.0-1.cm2.x86_64.rpm",
+    "hash": "sha256-a5Zc9qACmE2Uj+JNj1rvKjuBtxPmPCNz7KrzX/RywNY="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libtool-2.4.6-8.cm2.x86_64.rpm",
+    "hash": "sha256-NnaIVXLFLcX1YvDzlC/ySMOmQ/79AchaX3M3RzUF8zo="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libuv-1.43.0-2.cm2.x86_64.rpm",
+    "hash": "sha256-f4FaPv5CDV6YOwbsrGMb7j8JviWeAf8kAeYAAWfy2hs="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/libxml2-2.10.4-3.cm2.x86_64.rpm",
+    "hash": "sha256-AsiXci3voNrsMSJTEjkyn5VZutE58miCru8TUL0gYkg="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/lmdb-libs-0.9.29-1.cm2.x86_64.rpm",
+    "hash": "sha256-PsSD81SHiCHWVrxXZ1kP4TnQaVQVbxt+ME/qkwch73c="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/lua-libs-5.4.4-1.cm2.x86_64.rpm",
+    "hash": "sha256-5YwCaHwNkA3dln09WoUv2Bg4mFIoCPu13rwS6Cgi4Ck="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/lvm2-2.03.15-3.cm2.x86_64.rpm",
+    "hash": "sha256-Qro2ZHBptJFBtW6zUSmphkKJrbSVfUbnnAfKZAiVVjA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/l/lz4-1.9.4-1.cm2.x86_64.rpm",
+    "hash": "sha256-B9pc1N0WbufYfjCBtX1uca+TczWWEmuuT3Frgq/etjo="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/m/mariner-release-2.0-63.cm2.noarch.rpm",
+    "hash": "sha256-zfdcEgbiivXm9VnbF8Y7KRGL9dLAYIkdNyoklW2QsVQ="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/m/mariner-repos-2.0-9.cm2.noarch.rpm",
+    "hash": "sha256-DOlTg2FG+lREEZ3IL34g9j4FiGV8djgaOjD6VLa9Gak="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/m/mariner-repos-extras-2.0-9.cm2.noarch.rpm",
+    "hash": "sha256-rWD3EHg0vEKxDeLcSbIhSeWRK+Uuqay7nSGlFXJtlL4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/m/mariner-repos-microsoft-2.0-9.cm2.noarch.rpm",
+    "hash": "sha256-DuX7mm5GsLUuR/X62smAM0Vv9oWZxFZ4SkVtcz3dd6E="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/m/mariner-repos-shared-2.0-9.cm2.noarch.rpm",
+    "hash": "sha256-ATNFrwjKKHl6xKxr9zu3xHJMqgOO3FU/SYOJ9eGqqcA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/m/mariner-rpm-macros-2.0-25.cm2.noarch.rpm",
+    "hash": "sha256-vz1LyLbAXDBfBrcdFRcOvksc3fR+SNW4bQss14Uf10M="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/ncurses-6.4-2.cm2.x86_64.rpm",
+    "hash": "sha256-oD35Y+rTXJzbZAtolyPnGXWS9LHCdfJpL+XQL3kC/QM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/ncurses-libs-6.4-2.cm2.x86_64.rpm",
+    "hash": "sha256-63ZtTLoOEUhwfCrg7mVQazPHbCDiRxqHHfYClq+8Kkw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/net-tools-2.10-3.cm2.x86_64.rpm",
+    "hash": "sha256-YRIVTtyC2XBAfNd+GREt5ZcCAGUp5JvkUIZ8T6iKFTU="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/nettle-3.7.3-3.cm2.x86_64.rpm",
+    "hash": "sha256-qSVA+6HrMJbsF6LjSB92UNkFQzA4oaO3USNVXJJ0CvE="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/newt-0.52.21-5.cm2.x86_64.rpm",
+    "hash": "sha256-JOpgdnPQXqDfSw3fNaC8TO1pZG4MtywQ1E3nGNIlXr4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/nghttp2-1.57.0-1.cm2.x86_64.rpm",
+    "hash": "sha256-hFwa9UTkB3S1SBKShNGT2rrxtyRUN4U6of6GX8R3Muw="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/n/npth-1.6-4.cm2.x86_64.rpm",
+    "hash": "sha256-mSkp1/58/hSRh7OtRPg9hn6+gETsKvLFImjD+H00bTc="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/o/openldap-2.4.57-8.cm2.x86_64.rpm",
+    "hash": "sha256-BJPpicUC7x/QgERAgW41ZuMbxitstXD6EdN2MYu79W0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/o/openssh-clients-8.9p1-4.cm2.x86_64.rpm",
+    "hash": "sha256-QZnrXGBuXwN2DpXcmZXN3iAdDPuuLeO1oipVqw6w8bk="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/o/openssl-1.1.1k-32.cm2.x86_64.rpm",
+    "hash": "sha256-gwGGPAs0+oeFQURPnM506gbZ3bJS/cSK/FSZCt23rNk="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/o/openssl-libs-1.1.1k-32.cm2.x86_64.rpm",
+    "hash": "sha256-ohjfMoEcNIoe71vprzyZEURH52wWm0mEUZcKk75pZ/8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/p11-kit-0.24.1-1.cm2.x86_64.rpm",
+    "hash": "sha256-SbffcLRyOKxaufw1Lyi5Z1amZj8WFDrLbDGMPtBmzBE="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/p11-kit-trust-0.24.1-1.cm2.x86_64.rpm",
+    "hash": "sha256-osFhYsJm2wy3cg5+Mc2r5iyFG3mdtQwZ9oQkb2ZyhU8="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pam-1.5.1-6.cm2.x86_64.rpm",
+    "hash": "sha256-ouuV+lKf2Bszm5nzod2Wh6os6hAnyC/4XUdaVQDREmE="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pcre-8.45-2.cm2.x86_64.rpm",
+    "hash": "sha256-88hsYBw30B6Uc89H4qpawyHB9unDXDcvxgbltvpkcKA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pcre-libs-8.45-2.cm2.x86_64.rpm",
+    "hash": "sha256-a+5GUpTEWh6gZekstJyoZLUJvdiDtq+1j/XghKWzz3Q="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pinentry-1.2.0-1.cm2.x86_64.rpm",
+    "hash": "sha256-0xNVCMY6Nz766MmKPs0zBMq+mXtjw6SCio0tsc7vyMI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pkgconf-1.8.0-3.cm2.x86_64.rpm",
+    "hash": "sha256-CGvrVc0eIRs1tGXJvbn70rUSqi8To74HSElkzTXXR7c="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pkgconf-m4-1.8.0-3.cm2.noarch.rpm",
+    "hash": "sha256-pvN4ywNh/eysI9qzKsJtFYvy5aNIP7XcRCVOR8T/d3Y="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/pkgconf-pkg-config-1.8.0-3.cm2.x86_64.rpm",
+    "hash": "sha256-hVvFRxsd6HEO+HcJASnNgxwyWsFT9tnWNZfiXkyyPMc="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/popt-1.18-1.cm2.x86_64.rpm",
+    "hash": "sha256-ldYUsNFpIo5fC/09SIB3HbXH9F4a3eoO/KuYD62elqg="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/p/procps-ng-3.3.17-2.cm2.x86_64.rpm",
+    "hash": "sha256-oN9ewJlO+s7wQJ49gBu9SscJGONSaZ2QcGiysDmbrds="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/r/readline-8.1-1.cm2.x86_64.rpm",
+    "hash": "sha256-qfmf8QCo83/QXkKIJAfJrMx2Vv6ozco0RlqpI1b4CTI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/r/rpm-4.18.0-4.cm2.x86_64.rpm",
+    "hash": "sha256-Fx05hcb7qfoiz5UVFFWQcBf3/8EMlT8n//gWKPanQ9I="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/r/rpm-libs-4.18.0-4.cm2.x86_64.rpm",
+    "hash": "sha256-aGQ2tOfZZKewRLs9S4Q27f+ByXB2RsUGrFarmfbhZ40="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/sed-4.8-3.cm2.x86_64.rpm",
+    "hash": "sha256-pFIMOh5ahIYgdWLPLoutirT6SVl0Dser/W9PDakfzW4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/shadow-utils-4.9-13.cm2.x86_64.rpm",
+    "hash": "sha256-XJd4oqNearPQT7vvf/r+HzU//ppRBDXYi5IcDjgE3gI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/slang-2.3.2-4.cm2.x86_64.rpm",
+    "hash": "sha256-gTRB1RxZmn9AqvvLA1sB/8pdhEpz4tySH8nuS4TtoEA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/sqlite-libs-3.39.2-3.cm2.x86_64.rpm",
+    "hash": "sha256-28fCucOtzXHZLKiryg79NVHhlmsKFJU1DGs7z75RMWI="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/sudo-1.9.15p5-1.cm2.x86_64.rpm",
+    "hash": "sha256-vLcX9e4wzILO54mC1U3OO+VYwwH0xfm0/KEO4zy3Z9k="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/systemd-250.3-21.cm2.x86_64.rpm",
+    "hash": "sha256-YVg6D3xfaTDq4TtoPbNs3Ue+i4JhS0zPU0ftvjEuq1Y="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/s/systemd-rpm-macros-250.3-21.cm2.noarch.rpm",
+    "hash": "sha256-aCP9r25fzsZG2rbFP/P/Ox2IIQlhALUbh4xX7l+qEdM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/t/tar-1.34-2.cm2.x86_64.rpm",
+    "hash": "sha256-TilL7GxKGaGJx9k05zzRflNf12/LZHqnzMz3YDxMSHk="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/t/tdnf-3.5.2-4.cm2.x86_64.rpm",
+    "hash": "sha256-Wpe2F7lVB2V9T1VIRHVKoejvsxh/cjA6Xk3etVXE3fc="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/t/tdnf-cli-libs-3.5.2-4.cm2.x86_64.rpm",
+    "hash": "sha256-oyWs6IL0d5/ORUO3i5uh1VVwBTarOoXnshoZ/2zSYx4="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/t/tdnf-plugin-repogpgcheck-3.5.2-4.cm2.x86_64.rpm",
+    "hash": "sha256-HlKSuio9358b1S3RiSEwZ8mbSZbqy92fKRCYH36+jKM="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/t/tzdata-2024a-1.cm2.noarch.rpm",
+    "hash": "sha256-OOfIUtDsDkrDSdJEC5FoM9TFA3FznvowI1ucaI+ToQg="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/u/util-linux-2.37.4-9.cm2.x86_64.rpm",
+    "hash": "sha256-zbod7ZpbpTw1fo7s4xDKYSyl8Q19XWFaulp8cpfbEPg="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/u/util-linux-libs-2.37.4-9.cm2.x86_64.rpm",
+    "hash": "sha256-wxO+hrh6t8+k45/mBrcj3a6hpkSkG8sakShB4hF87m0="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/w/which-2.21-8.cm2.x86_64.rpm",
+    "hash": "sha256-cvnjnOS2+DlZhGnAypznD7KyLM+Wv4AWMdwlyK8cEec="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/x/xz-5.2.5-1.cm2.x86_64.rpm",
+    "hash": "sha256-9kVKFBAfKarCzcPzKYWJm6Sq9C5mDt/iwSJQUoeOk60="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/x/xz-libs-5.2.5-1.cm2.x86_64.rpm",
+    "hash": "sha256-Ax53mnzhmGYsWyZtew38nuzpwMiIple2qbt3Md8AltA="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/z/zlib-1.2.13-2.cm2.x86_64.rpm",
+    "hash": "sha256-hiC8ZIN5x76SkbvyDARol/Tl9jpYLXf9EWtPunlAOws="
+  },
+  {
+    "url": "https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/Packages/z/zstd-libs-1.5.4-1.cm2.x86_64.rpm",
+    "hash": "sha256-sOSIRIp7lcnYTkzrrFXFEDZXJcIAChxii5sKq8xti64="
+  }
+]

--- a/packages/by-name/kata/kata-image/package.nix
+++ b/packages/by-name/kata/kata-image/package.nix
@@ -1,0 +1,199 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+{ lib
+, stdenv
+, stdenvNoCC
+, distro ? "cbl-mariner"
+, kata
+, bubblewrap
+, fakeroot
+, fetchFromGitHub
+, fetchurl
+, yq-go
+, tdnf
+, curl
+, util-linux
+, writeText
+, writeTextDir
+, createrepo_c
+, writeShellApplication
+, parted
+, cryptsetup
+, closureInfo
+, erofs-utils
+}:
+
+let
+  kata-version = "3.6.0";
+  src = fetchFromGitHub {
+    owner = "kata-containers";
+    repo = "kata-containers";
+    rev = kata-version;
+    hash = "sha256-Setg6qmkUVn57BQ3wqqNpzmfXeYhJJt9Q4AVFbGrCug=";
+  };
+  # toplevelNixDeps are packages that get installed to the rootfs of the image
+  # they are used to determine the (nix) closure of the rootfs
+  toplevelNixDeps = [ kata.kata-agent ];
+  nixClosure = builtins.toString (lib.strings.splitString "\n" (builtins.readFile "${closureInfo {rootPaths = toplevelNixDeps;}}/store-paths"));
+  rootfsExtraTree = stdenvNoCC.mkDerivation {
+    inherit src;
+    pname = "rootfs-extra-tree";
+    version = kata-version;
+
+    # https://github.com/microsoft/azurelinux/blob/59ce246f224f282b3e199d9a2dacaa8011b75a06/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh#L34-L41
+    # TODO(msanft): Use a more constrained policy.
+    buildPhase = ''
+      runHook preBuild
+
+      mkdir -p /build/rootfs/etc/kata-opa /build/rootfs/usr/lib/systemd/system /build/rootfs/nix/store
+      cp src/agent/kata-agent.service.in /build/rootfs/usr/lib/systemd/system/kata-agent.service
+      cp src/agent/kata-containers.target /build/rootfs/usr/lib/systemd/system/kata-containers.target
+      cp src/kata-opa/allow-all.rego /build/rootfs/etc/kata-opa/default-policy.rego
+      sed -i 's/@BINDIR@\/@AGENT_NAME@/\/usr\/bin\/kata-agent/g'  /build/rootfs/usr/lib/systemd/system/kata-agent.service
+      touch /build/rootfs/etc/machine-id
+
+      tar --sort=name --mtime="@$SOURCE_DATE_EPOCH" -cvf /build/rootfs-extra-tree.tar -C /build/rootfs .
+
+      mv /build/rootfs-extra-tree.tar $out
+
+      runHook postBuild
+    '';
+
+    dontInstall = true;
+  };
+  packageIndex = builtins.fromJSON (builtins.readFile ./package-index.json);
+  rpmSources = lib.forEach packageIndex
+    (p: lib.concatStringsSep "#" [ (fetchurl p) (builtins.baseNameOf p.url) ]);
+
+  mirror = stdenvNoCC.mkDerivation {
+    name = "mirror";
+    dontUnpack = true;
+    nativeBuildInputs = [ createrepo_c ];
+    buildPhase = ''
+      runHook preBuild
+
+      mkdir -p $out/packages
+      for source in ${builtins.concatStringsSep " " rpmSources}; do
+        path=$(echo $source | cut -d'#' -f1)
+        filename=$(echo $source | cut -d'#' -f2)
+        ln -s "$path" "$out/packages/$filename"
+      done
+
+      createrepo_c --revision 0 --set-timestamp-to-revision --basedir packages $out
+
+      runHook postBuild
+    '';
+  };
+
+  tdnfConf = writeText "tdnf.conf" ''
+    [main]
+    gpgcheck=1
+    installonly_limit=3
+    clean_requirements_on_remove=0
+    repodir=/etc/yum.repos.d
+    cachedir=/build/var/cache/tdnf
+  '';
+  vendor-reposdir = writeTextDir "yum.repos.d/cbl-mariner-2-vendor.repo" ''
+    [cbl-mariner-2.0-prod-base-x86_64-yum]
+    name=cbl-mariner-2.0-prod-base-x86_64-yum
+    baseurl=file://${mirror}
+    repo_gpgcheck=0
+    gpgcheck=0
+    enabled=1
+  '';
+  buildimage = writeShellApplication {
+    name = "buildimage";
+    runtimeInputs = [
+      parted
+      erofs-utils
+      cryptsetup
+    ];
+    text = builtins.readFile ./buildimage.sh;
+  };
+in
+
+stdenv.mkDerivation rec {
+  inherit src;
+  pname = "kata-image";
+  version = kata-version;
+
+  outputs = [ "out" "verity" ];
+
+  env = {
+    AGENT_SOURCE_BIN = "${lib.getExe kata.kata-agent}";
+    CONF_GUEST = "yes";
+    RUST_VERSION = "not-needed";
+  };
+
+  nativeBuildInputs = [
+    yq-go
+    curl
+    fakeroot
+    bubblewrap
+    util-linux
+    tdnf
+    buildimage
+  ];
+
+  sourceRoot = "${src.name}/tools/osbuilder/rootfs-builder";
+
+  buildPhase = ''
+    runHook preBuild
+
+    # use a fakeroot environment to build the rootfs as a tar
+    # this is required to create files with the correct ownership and permissions
+    # including suid
+    # Upstream build invokation:
+    # https://github.com/microsoft/azurelinux/blob/59ce246f224f282b3e199d9a2dacaa8011b75a06/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh#L18
+    mkdir -p /build/var/run
+    mkdir -p /build/var/tdnf
+    mkdir -p /build/var/lib/tdnf
+    mkdir -p /build/var/cache/tdnf
+    mkdir -p /build/root
+    unshare --map-root-user bwrap \
+      --bind /nix /nix \
+      --bind ${tdnfConf} /etc/tdnf/tdnf.conf \
+      --bind ${vendor-reposdir}/yum.repos.d /etc/yum.repos.d \
+      --bind /build /build \
+      --bind /build/var /var \
+      --dev-bind /dev/null /dev/null \
+      fakeroot bash -c "bash $(pwd)/rootfs.sh -r /build/root ${distro} && \
+        tar \
+          --exclude='./usr/lib/systemd/system/systemd-coredump@*' \
+          --exclude='./usr/lib/systemd/system/systemd-journald*' \
+          --exclude='./usr/lib/systemd/system/systemd-journald-dev-log*' \
+          --exclude='./usr/lib/systemd/system/systemd-journal-flush*' \
+          --exclude='./usr/lib/systemd/system/systemd-random-seed*' \
+          --exclude='./usr/lib/systemd/system/systemd-timesyncd*' \
+          --exclude='./usr/lib/systemd/system/systemd-tmpfiles-setup*' \
+          --exclude='./usr/lib/systemd/system/systemd-update-utmp*' \
+          --exclude='*systemd-bless-boot-generator*' \
+          --exclude='*systemd-fstab-generator*' \
+          --exclude='*systemd-getty-generator*' \
+          --exclude='*systemd-gpt-auto-generator*' \
+          --exclude='*systemd-tmpfiles-cleanup.timer*' \
+          --sort=name --mtime='UTC 1970-01-01' -C /build/root -c . -f /build/rootfs.tar"
+
+    # add the extra tree to the rootfs
+    tar --concatenate --file=/build/rootfs.tar ${rootfsExtraTree}
+    # add the closure to the rootfs
+    tar --hard-dereference --transform 's+^+./+' -cf /build/closure.tar --mtime="@$SOURCE_DATE_EPOCH" --sort=name ${nixClosure}
+    # combine the rootfs and the closure
+    tar --concatenate --file=/build/rootfs.tar /build/closure.tar
+
+    # convert tar to a squashfs image with dm-verity hash
+    ${lib.getExe buildimage} /build/rootfs.tar $out
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    # split outputs into raw image (out) and dm-verity data (verity)
+    mkdir -p $verity
+    mv $out/{dm_verity.txt,roothash,salt,hash_type,data_blocks,data_block_size,hash_blocks,hash_block_size,hash_algorithm} $verity/
+    mv $out/raw.img /build/raw.img
+    rm -rf $out
+    mv /build/raw.img $out
+  '';
+}

--- a/packages/by-name/rpm-pin-vendor/package.nix
+++ b/packages/by-name/rpm-pin-vendor/package.nix
@@ -34,14 +34,6 @@ let
     enabled=1
     gpgkey=https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-prod-base-x86_64/repodata/repomd.xml.key
   '';
-  # Contrast kata agent links with libseccomp from nix store
-  # this packages only exists to satisfy the image builder
-  packages = writeText "packages" ''
-    kata-packages-uvm
-    kata-packages-uvm-coco
-    systemd
-    libseccomp
-  '';
   update_lockfile = writeShellApplication {
     name = "update_lockfile";
     runtimeInputs = [ dnf4 jq wget nix fakeroot ];
@@ -54,6 +46,5 @@ runCommand "rpm-pin-vendor" { meta.mainProgram = "update_lockfile"; } ''
   cp ${lib.getExe update_lockfile} $out/bin/update_lockfile
   substituteInPlace $out/bin/update_lockfile \
     --replace-fail "@DNFCONFIG@" ${dnfConf} \
-    --replace-fail "@REPOSDIR@" ${reposdir}/yum.repos.d \
-    --replace-fail "@PACKAGESET@" ${packages}
+    --replace-fail "@REPOSDIR@" ${reposdir}/yum.repos.d
 ''

--- a/packages/by-name/rpm-pin-vendor/update_lockfile.sh
+++ b/packages/by-name/rpm-pin-vendor/update_lockfile.sh
@@ -8,7 +8,7 @@ shopt -s inherit_errexit
 DNF=${DNF:-dnf4}
 DNFCONFIG=${DNFCONFIG:-@DNFCONFIG@}
 REPOSDIR=${REPOSDIR:-@REPOSDIR@}
-PACKAGESET=${PACKAGESET:-@PACKAGESET@}
+PACKAGESET=("$@")
 OUT=${OUT:-$(mktemp -d)}
 
 dnfroot=$(mktemp -d)
@@ -23,6 +23,7 @@ mkdir -p "$persistdir"
 logdir="$dnfroot/log"
 mkdir -p "$logdir"
 
+echo "Installing RPMs: ${PACKAGESET[*]}" >&2
 echo "Writing rpms to $OUT" >&2
 
 function urllist() {
@@ -45,8 +46,7 @@ function urllist() {
     --urls \
     --resolve \
     --alldeps \
-    $(tr '\n' ' ' <"${PACKAGESET}") \
-    >"$OUT/packages.txt"
+    "${PACKAGESET[@]}" >"$OUT/packages.txt"
 }
 
 function download() {


### PR DESCRIPTION
This packages a CBL-Mariner-based UVM image, resembling what's used upstream by Kata. For now, it uses almost the same build instructions as the Microsoft image, but eventually, we'll might want to adapt it as per the specific requirements of AKS and bare-metal appliances.

It also enables the CI to update the RPM packages inside the root filesystem for both the AKS and bare-metal UVM images.