### PR TITLE
coordinator: enable returning seed to user

### DIFF
--- a/coordinator/internal/authority/recoveryapi.go
+++ b/coordinator/internal/authority/recoveryapi.go
@@ -19,7 +19,7 @@ var ErrAlreadyRecovered = errors.New("coordinator is already recovered")
 func (a *Authority) Recover(_ context.Context, req *recoveryapi.RecoverRequest) (*recoveryapi.RecoverResponse, error) {
 	a.logger.Info("Recover called")
 
-	err := a.recover(req.Seed, req.Salt)
+	err := a.initSeedEngine(req.Seed, req.Salt)
 	switch {
 	case errors.Is(err, ErrAlreadyRecovered):
 		return nil, status.Error(codes.FailedPrecondition, err.Error())

--- a/coordinator/internal/authority/userapi.go
+++ b/coordinator/internal/authority/userapi.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 
 	"github.com/edgelesssys/contrast/coordinator/history"
+	"github.com/edgelesssys/contrast/internal/ca"
+	"github.com/edgelesssys/contrast/internal/crypto"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
 	"google.golang.org/grpc/codes"
@@ -25,9 +27,8 @@ import (
 func (a *Authority) SetManifest(ctx context.Context, req *userapi.SetManifestRequest) (*userapi.SetManifestResponse, error) {
 	a.logger.Info("SetManifest called")
 
-	if err := a.validatePeer(ctx); err != nil {
-		a.logger.Warn("SetManifest peer validation failed", "err", err)
-		return nil, status.Errorf(codes.PermissionDenied, "validating peer: %v", err)
+	if err := a.syncState(); err != nil {
+		return nil, status.Errorf(codes.Internal, "syncing internal state: %v", err)
 	}
 
 	var m *manifest.Manifest
@@ -35,22 +36,118 @@ func (a *Authority) SetManifest(ctx context.Context, req *userapi.SetManifestReq
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshaling manifest: %v", err)
 	}
 
-	if len(m.Policies) != len(req.Policies) {
-		return nil, status.Error(codes.InvalidArgument, "request must contain exactly the policies referenced in the manifest")
+	var resp userapi.SetManifestResponse
+
+	oldState := a.state.Load()
+	if oldState == nil {
+		// First SetManifest call, initialize seed engine.
+		seedSalt, err := crypto.GenerateRandomBytes(64)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "generating random bytes: %v", err)
+		}
+		seed, salt := seedSalt[:32], seedSalt[32:]
+
+		// TODO(burgerdev): requires https://github.com/edgelesssys/contrast/commit/bae8e7f
+		seedShares, err := manifest.EncryptSeedShares(seed /*m.SeedshareOwnerPubKeys*/, nil)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "initializing seed engine: %v", err)
+		}
+		if err := a.initSeedEngine(seed, salt); err != nil {
+			return nil, status.Errorf(codes.Internal, "setting seed: %v", err)
+		}
+		resp.SeedSharesDoc = &userapi.SeedShareDocument{
+			Salt:       salt,
+			SeedShares: seedShares,
+		}
+	} else {
+		// Subsequent SetManifest call, check permissions of caller.
+		if err := a.validatePeer(ctx, oldState.manifest); err != nil {
+			a.logger.Warn("SetManifest peer validation failed", "err", err)
+			return nil, status.Errorf(codes.PermissionDenied, "validating peer: %v", err)
+		}
 	}
 
-	ca, err := a.setManifest(req.GetManifest(), req.GetPolicies())
+	// Store resources in History.
+
+	policyMap := make(map[[history.HashSize]byte][]byte)
+	for _, policy := range req.GetPolicies() {
+		policyHash, err := a.hist.SetPolicy(policy)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "setting policy: %v", err)
+		}
+		policyMap[policyHash] = policy
+	}
+
+	for hexRef := range m.Policies {
+		var ref [history.HashSize]byte
+		refSlice, err := hexRef.Bytes()
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid policy hash: %v", err)
+		}
+		copy(ref[:], refSlice)
+		if _, ok := policyMap[ref]; !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "no policy provided for hash %q", hexRef)
+		}
+	}
+
+	manifestHash, err := a.hist.SetManifest(req.GetManifest())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "setting manifest: %v", err)
 	}
 
-	resp := &userapi.SetManifestResponse{
-		RootCA: ca.GetRootCACert(),
-		MeshCA: ca.GetMeshCACert(),
+	// Advance state.
+
+	nextTransition := &history.Transition{
+		ManifestHash: manifestHash,
+	}
+	var oldLatest *history.LatestTransition
+	var oldGeneration int
+	if oldState != nil {
+		nextTransition.PreviousTransitionHash = oldState.latest.TransitionHash
+		oldLatest = oldState.latest
+		oldGeneration = oldState.generation
+	}
+	nextTransitionHash, err := a.hist.SetTransition(nextTransition)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "setting transition: %v", err)
+	}
+	nextLatest := &history.LatestTransition{TransitionHash: nextTransitionHash}
+
+	if err := a.hist.SetLatest(oldLatest, nextLatest); err != nil {
+		return nil, status.Errorf(codes.Internal, "setting latest: %v", err)
 	}
 
+	se := a.se.Load()
+	meshKey, err := se.DeriveMeshCAKey(nextTransitionHash)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "deriving mesh CA key: %v", err)
+	}
+	ca, err := ca.New(se.RootCAKey(), meshKey)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "creating CA: %v", err)
+	}
+
+	nextState := &state{
+		latest:     nextLatest,
+		manifest:   m,
+		ca:         ca,
+		generation: oldGeneration + 1,
+	}
+
+	if a.state.CompareAndSwap(oldState, nextState) {
+		a.metrics.manifestGeneration.Set(float64(nextState.generation))
+	}
+	// If the CompareAndSwap did not go through, this means that another SetManifest happened in
+	// the meantime. This is fine: we know that m.state must be a transition after ours because
+	// the SetLatest call succeeded. That other SetManifest call must have been operating on our
+	// nextState already, because it had to refer to our transition. Thus, we can forget about
+	// the state, except that we need to return the right CA for the manifest _our_ user set.
+
+	resp.RootCA = ca.GetRootCACert()
+	resp.MeshCA = ca.GetMeshCACert()
+
 	a.logger.Info("SetManifest succeeded")
-	return resp, nil
+	return &resp, nil
 }
 
 // GetManifests retrieves the current CA certificates, the manifest history and all policies.
@@ -114,15 +211,7 @@ func (a *Authority) GetManifests(_ context.Context, _ *userapi.GetManifestsReque
 	return resp, nil
 }
 
-func (a *Authority) validatePeer(ctx context.Context) error {
-	latest, err := a.latestManifest()
-	if err != nil && errors.Is(err, ErrNoManifest) {
-		// in the initial state, no peer validation is required
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("getting latest manifest: %w", err)
-	}
+func (a *Authority) validatePeer(ctx context.Context, latest *manifest.Manifest) error {
 	if len(latest.WorkloadOwnerKeyDigests) == 0 {
 		return errors.New("setting manifest is disabled")
 	}


### PR DESCRIPTION
This PR consolidates `Authority.setManifest` (authority) and `Authority.SetManifest` (userapi) after the refactoring in #583. This is more or less a move of the function body from one file to another, except that the generated seed could now be returned to the user (for that to work, however, bae8e7f needs to change the `Manifest` definition first). 

I tried to ensure that all test cases removed from `authority_test.go` are reflected in `userapi_test.go`, and it turned out we already covered most of it there. 