### PR TITLE
kubeclient: combine duplicate code for WaitFor* functions

### DIFF
--- a/e2e/getdents/getdents_test.go
+++ b/e2e/getdents/getdents_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/edgelesssys/contrast/cli/cmd"
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func TestGetDEnts(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, getdent))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, getdent))
 
 		pods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, getdent)
 		require.NoError(err)

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -171,7 +171,7 @@ func (ct *ContrastTest) Set(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	require.NoError(ct.Kubeclient.WaitForStatefulSet(ctx, ct.Namespace, "coordinator"))
+	require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
 
 	coordinator, cancelPortForward, err := ct.Kubeclient.PortForwardPod(ctx, ct.Namespace, "port-forwarder-coordinator", "1313")
 	require.NoError(err)
@@ -199,7 +199,7 @@ func (ct *ContrastTest) Verify(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
-	require.NoError(ct.Kubeclient.WaitForStatefulSet(ctx, ct.Namespace, "coordinator"))
+	require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
 
 	coordinator, cancelPortForward, err := ct.Kubeclient.PortForwardPod(ctx, ct.Namespace, "port-forwarder-coordinator", "1313")
 	require.NoError(err)
@@ -259,7 +259,7 @@ func (ct *ContrastTest) installRuntime(t *testing.T) {
 
 	require.NoError(ct.Kubeclient.Apply(ctx, unstructuredResources...))
 
-	require.NoError(ct.Kubeclient.WaitForDaemonset(ctx, ct.Namespace, "contrast-node-installer"))
+	require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.DaemonSet{}, ct.Namespace, "contrast-node-installer"))
 }
 
 func makeNamespace(t *testing.T) string {

--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -171,7 +171,7 @@ func (c *Kubeclient) Exec(ctx context.Context, namespace, pod string, argv []str
 
 // ExecDeployment executes a process in one of the deployment's pods.
 func (c *Kubeclient) ExecDeployment(ctx context.Context, namespace, deployment string, argv []string) (stdout string, stderr string, err error) {
-	if err := c.WaitForDeployment(ctx, namespace, deployment); err != nil {
+	if err := c.WaitFor(ctx, Deployment{}, namespace, deployment); err != nil {
 		return "", "", fmt.Errorf("deployment not ready: %w", err)
 	}
 

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -61,7 +61,7 @@ func TestOpenSSL(t *testing.T) {
 
 		require := require.New(t)
 
-		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, opensslFrontend))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 
 		frontendPods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, opensslFrontend)
 		require.NoError(err)
@@ -86,7 +86,7 @@ func TestOpenSSL(t *testing.T) {
 
 			require := require.New(t)
 
-			require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, opensslFrontend))
+			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 
 			addr, cancelPortForward, err := ct.Kubeclient.PortForwardPod(ctx, ct.Namespace, "port-forwarder-openssl-frontend", "443")
 			require.NoError(err)
@@ -108,7 +108,7 @@ func TestOpenSSL(t *testing.T) {
 
 		c := kubeclient.NewForTest(t)
 
-		require.NoError(c.WaitForDeployment(ctx, ct.Namespace, opensslBackend))
+		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
 
 		// Call the backend server from the frontend. If this command produces no TLS error, we verified that
 		// - the certificate in the frontend pod can be used as a client certificate
@@ -149,7 +149,7 @@ func TestOpenSSL(t *testing.T) {
 
 			// Restart one deployment so it has the new certificates.
 			require.NoError(c.RestartDeployment(ctx, ct.Namespace, deploymentToRestart))
-			require.NoError(c.WaitForDeployment(ctx, ct.Namespace, deploymentToRestart))
+			require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, deploymentToRestart))
 
 			// This should not succeed because the certificates have changed.
 			stdout, stderr, err := c.ExecDeployment(ctx, ct.Namespace, opensslFrontend, []string{"/bin/bash", "-c", opensslConnectCmd("openssl-backend:443", "mesh-ca.pem")})
@@ -169,7 +169,7 @@ func TestOpenSSL(t *testing.T) {
 				d = opensslFrontend
 			}
 			require.NoError(c.RestartDeployment(ctx, ct.Namespace, d))
-			require.NoError(c.WaitForDeployment(ctx, ct.Namespace, d))
+			require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, d))
 
 			// This should succeed since both workloads now have updated certificates.
 			stdout, stderr, err = c.ExecDeployment(ctx, ct.Namespace, opensslFrontend, []string{"/bin/bash", "-c", opensslConnectCmd("openssl-backend:443", "mesh-ca.pem")})

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -94,7 +94,7 @@ func TestRelease(t *testing.T) {
 		require.NoError(err)
 
 		require.NoError(k.Apply(ctx, resources...))
-		require.NoError(k.WaitForDaemonset(ctx, "kube-system", "contrast-node-installer"))
+		require.NoError(k.WaitFor(ctx, kubeclient.DaemonSet{}, "kube-system", "contrast-node-installer"))
 	}), "the runtime is required for subsequent tests to run")
 
 	var coordinatorIP string
@@ -109,7 +109,7 @@ func TestRelease(t *testing.T) {
 		require.NoError(err)
 
 		require.NoError(k.Apply(ctx, resources...))
-		require.NoError(k.WaitForStatefulSet(ctx, "default", "coordinator"))
+		require.NoError(k.WaitFor(ctx, kubeclient.StatefulSet{}, "default", "coordinator"))
 		coordinatorIP, err = k.WaitForLoadBalancer(ctx, "default", "coordinator")
 		require.NoError(err)
 	}), "the coordinator is required for subsequent tests to run")
@@ -159,10 +159,10 @@ func TestRelease(t *testing.T) {
 			require.NoError(k.Apply(ctx, resources...))
 		}
 
-		require.NoError(k.WaitForDeployment(ctx, "default", "vote-bot"))
-		require.NoError(k.WaitForDeployment(ctx, "default", "voting"))
-		require.NoError(k.WaitForDeployment(ctx, "default", "emoji"))
-		require.NoError(k.WaitForDeployment(ctx, "default", "web"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "vote-bot"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "voting"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "emoji"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "web"))
 	}), "applying the demo is required for subsequent tests to run")
 
 	t.Run("test-demo", func(t *testing.T) {

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -54,10 +54,10 @@ func TestIngressEgress(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
 
-		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, "vote-bot"))
-		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, "emoji"))
-		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, "voting"))
-		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, "web"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "vote-bot"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "emoji"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "voting"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "web"))
 	}), "deployments need to be ready for subsequent tests")
 
 	certs := map[string]*x509.CertPool{


### PR DESCRIPTION
The functions `WaitForDeployment`, `WaitForDaemonSet` and `WaitForStatefulSet` are combined into one `WaitFor` function, which takes the resource kind as an input and performs all the logic that the previous functions had.

Additionally, the context error is now checked when receiving from the watcher channel, which is closed when the context expires, so you don't get error messages like this: https://github.com/edgelesssys/contrast/actions/runs/9522518982/job/26252214876#step:12:118