### PR TITLE
cli: use manifest reference values for attestation

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -23,7 +23,7 @@ const (
 	settingsFilename     = "settings.json"
 	seedSharesFilename   = "seed-shares.json"
 	rulesFilename        = "rules.rego"
-	verifyDir            = "./verify"
+	verifyDir            = "verify"
 	cacheDirEnv          = "CONTRAST_CACHE_DIR"
 )
 

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -106,7 +106,10 @@ func runSet(cmd *cobra.Command, args []string) error {
 	}
 	log.Debug("Using KDS cache dir", "dir", kdsDir)
 
-	validateOptsGen := newCoordinatorValidateOptsGen(flags.policy)
+	validateOptsGen, err := newCoordinatorValidateOptsGen(m, flags.policy)
+	if err != nil {
+		return fmt.Errorf("generating validate opts: %w", err)
+	}
 	kdsCache := fsstore.New(kdsDir, log.WithGroup("kds-cache"))
 	kdsGetter := snp.NewCachedHTTPSGetter(kdsCache, snp.NeverGCTicker, log.WithGroup("kds-getter"))
 	validator := snp.NewValidator(validateOptsGen, kdsGetter, log.WithGroup("snp-validator"))

--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -26,8 +26,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/recoveryapi"
 	"github.com/edgelesssys/contrast/internal/userapi"
-	"github.com/google/go-sev-guest/abi"
-	"github.com/google/go-sev-guest/kds"
 	"github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/google/go-sev-guest/validate"
 	"github.com/prometheus/client_golang/prometheus"
@@ -101,36 +99,7 @@ func (m *Authority) SNPValidateOpts(report *sevsnp.Report) (*validate.Options, e
 		return nil, fmt.Errorf("hostdata %s not found in manifest", hostData)
 	}
 
-	trustedMeasurement, err := mnfst.ReferenceValues.TrustedMeasurement.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert TrustedMeasurement from manifest to byte slices: %w", err)
-	}
-	if trustedMeasurement == nil {
-		// This is required to prevent an empty measurement in the manifest from disabling the measurement check.
-		trustedMeasurement = make([]byte, 48)
-	}
-
-	return &validate.Options{
-		Measurement: trustedMeasurement,
-		GuestPolicy: abi.SnpPolicy{
-			Debug: false,
-			SMT:   true,
-		},
-		VMPL: new(int), // VMPL0
-		MinimumTCB: kds.TCBParts{
-			BlSpl:    mnfst.ReferenceValues.SNP.MinimumTCB.BootloaderVersion.UInt8(),
-			TeeSpl:   mnfst.ReferenceValues.SNP.MinimumTCB.TEEVersion.UInt8(),
-			SnpSpl:   mnfst.ReferenceValues.SNP.MinimumTCB.SNPVersion.UInt8(),
-			UcodeSpl: mnfst.ReferenceValues.SNP.MinimumTCB.MicrocodeVersion.UInt8(),
-		},
-		MinimumLaunchTCB: kds.TCBParts{
-			BlSpl:    mnfst.ReferenceValues.SNP.MinimumTCB.BootloaderVersion.UInt8(),
-			TeeSpl:   mnfst.ReferenceValues.SNP.MinimumTCB.TEEVersion.UInt8(),
-			SnpSpl:   mnfst.ReferenceValues.SNP.MinimumTCB.SNPVersion.UInt8(),
-			UcodeSpl: mnfst.ReferenceValues.SNP.MinimumTCB.MicrocodeVersion.UInt8(),
-		},
-		PermitProvisionalFirmware: true,
-	}, nil
+	return mnfst.SNPValidateOpts()
 }
 
 // ValidateCallback creates a certificate bundle for the verified client.

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -206,6 +206,7 @@ func (ct *ContrastTest) Verify(t *testing.T) {
 	defer cancelPortForward()
 
 	verify := cmd.NewVerifyCmd()
+	verify.Flags().String("workspace-dir", "", "") // Make verify aware of root flags
 	verify.SetArgs(append(
 		ct.commonArgs(),
 		"--coordinator-policy-hash", ct.coordinatorPolicyHash,

--- a/justfile
+++ b/justfile
@@ -162,7 +162,7 @@ verify cli=default_cli:
     policy=$(< ./{{ workspace_dir }}/coordinator-policy.sha256)
     t=$(date +%s)
     nix run .#{{ cli }} -- verify \
-        --workspace-dir ./{{ workspace_dir }}/verify \
+        --workspace-dir ./{{ workspace_dir }} \
         --coordinator-policy-hash "${policy}" \
         -c localhost:1314
     duration=$(( $(date +%s) - $t ))


### PR DESCRIPTION
This changes the Coordinator validate options to use the reference values from the local manifest in the `set` and `verify` command. The verify command takes an additional flag `--manifest` for this to provide the path to the manifest.

The default workspace directory for the `verify` command is no longer `./verify`, because the manifest lies in the current directory. Instead, the output files for the `verify` command are always written to the `verify` directory in the current workspace directory.