### PR TITLE
generate: add flag for aks reference values

### DIFF
--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -91,13 +91,13 @@ func newManifest(t *testing.T) (*manifest.Manifest, []byte, [][]byte) {
 	policy := []byte("=== SOME REGO HERE ===")
 	policyHash := sha256.Sum256(policy)
 	policyHashHex := manifest.NewHexString(policyHash[:])
-	mnfst := &manifest.Manifest{
-		Policies:                map[manifest.HexString][]string{policyHashHex: {"test"}},
-		WorkloadOwnerKeyDigests: []manifest.HexString{keyDigest},
-	}
+
+	mnfst := manifest.Default()
+	mnfst.Policies = map[manifest.HexString][]string{policyHashHex: {"test"}}
+	mnfst.WorkloadOwnerKeyDigests = []manifest.HexString{keyDigest}
 	mnfstBytes, err := json.Marshal(mnfst)
 	require.NoError(t, err)
-	return mnfst, mnfstBytes, [][]byte{policy}
+	return &mnfst, mnfstBytes, [][]byte{policy}
 }
 
 func requireGauge(t *testing.T, reg *prometheus.Registry, val int) {

--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -92,7 +92,7 @@ func newManifest(t *testing.T) (*manifest.Manifest, []byte, [][]byte) {
 	policyHash := sha256.Sum256(policy)
 	policyHashHex := manifest.NewHexString(policyHash[:])
 
-	mnfst := manifest.Default()
+	mnfst := manifest.DefaultAKS()
 	mnfst.Policies = map[manifest.HexString][]string{policyHashHex: {"test"}}
 	mnfst.WorkloadOwnerKeyDigests = []manifest.HexString{keyDigest}
 	mnfstBytes, err := json.Marshal(mnfst)

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -133,7 +133,12 @@ func (ct *ContrastTest) Init(t *testing.T, resources []any) {
 func (ct *ContrastTest) Generate(t *testing.T) {
 	require := require.New(t)
 
-	args := append(ct.commonArgs(), "--image-replacements", ct.ImageReplacementsFile, path.Join(ct.WorkDir, "resources.yaml"))
+	args := append(
+		ct.commonArgs(),
+		"--image-replacements", ct.ImageReplacementsFile,
+		"--reference-values", "aks",
+		path.Join(ct.WorkDir, "resources.yaml"),
+	)
 
 	generate := cmd.NewGenerateCmd()
 	generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags

--- a/internal/manifest/constants.go
+++ b/internal/manifest/constants.go
@@ -10,17 +10,23 @@ var trustedMeasurement = "000000000000000000000000000000000000000000000000000000
 func Default() Manifest {
 	return Manifest{
 		ReferenceValues: ReferenceValues{
-			SNP: SNPReferenceValues{
-				MinimumTCB: SNPTCB{
-					BootloaderVersion: toPtr(SVN(3)),
-					TEEVersion:        toPtr(SVN(0)),
-					SNPVersion:        toPtr(SVN(8)),
-					MicrocodeVersion:  toPtr(SVN(115)),
-				},
-			},
 			TrustedMeasurement: HexString(trustedMeasurement),
 		},
 	}
+}
+
+// DefaultAKS returns a default manifest with AKS reference values.
+func DefaultAKS() Manifest {
+	mnfst := Default()
+	mnfst.ReferenceValues.SNP = SNPReferenceValues{
+		MinimumTCB: SNPTCB{
+			BootloaderVersion: toPtr(SVN(3)),
+			TEEVersion:        toPtr(SVN(0)),
+			SNPVersion:        toPtr(SVN(8)),
+			MicrocodeVersion:  toPtr(SVN(115)),
+		},
+	}
+	return mnfst
 }
 
 func toPtr[T any](t T) *T {

--- a/internal/manifest/constants.go
+++ b/internal/manifest/constants.go
@@ -12,13 +12,17 @@ func Default() Manifest {
 		ReferenceValues: ReferenceValues{
 			SNP: SNPReferenceValues{
 				MinimumTCB: SNPTCB{
-					BootloaderVersion: 3,
-					TEEVersion:        0,
-					SNPVersion:        8,
-					MicrocodeVersion:  115,
+					BootloaderVersion: toPtr(SVN(3)),
+					TEEVersion:        toPtr(SVN(0)),
+					SNPVersion:        toPtr(SVN(8)),
+					MicrocodeVersion:  toPtr(SVN(115)),
 				},
 			},
 			TrustedMeasurement: HexString(trustedMeasurement),
 		},
 	}
+}
+
+func toPtr[T any](t T) *T {
+	return &t
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -38,18 +38,18 @@ type SNPReferenceValues struct {
 
 // SNPTCB represents a set of SNP TCB values.
 type SNPTCB struct {
-	BootloaderVersion SVN
-	TEEVersion        SVN
-	SNPVersion        SVN
-	MicrocodeVersion  SVN
+	BootloaderVersion *SVN
+	TEEVersion        *SVN
+	SNPVersion        *SVN
+	MicrocodeVersion  *SVN
 }
 
 // SVN is a SNP secure version number.
 type SVN uint8
 
 // UInt8 returns the uint8 value of the SVN.
-func (s SVN) UInt8() uint8 {
-	return uint8(s)
+func (s *SVN) UInt8() uint8 {
+	return uint8(*s)
 }
 
 // MarshalJSON marshals the SVN to JSON.
@@ -137,6 +137,10 @@ func (m *Manifest) SNPValidateOpts() (*validate.Options, error) {
 		trustedMeasurement = make([]byte, 48)
 	}
 
+	if err = checkNullFields(m.ReferenceValues.SNP.MinimumTCB); err != nil {
+		return nil, err
+	}
+
 	return &validate.Options{
 		Measurement: trustedMeasurement,
 		GuestPolicy: abi.SnpPolicy{
@@ -158,4 +162,17 @@ func (m *Manifest) SNPValidateOpts() (*validate.Options, error) {
 		},
 		PermitProvisionalFirmware: true,
 	}, nil
+}
+
+func checkNullFields(tcb SNPTCB) error {
+	if tcb.BootloaderVersion == nil {
+		return fmt.Errorf("field BootloaderVersion in manifest cannot be empty")
+	} else if tcb.TEEVersion == nil {
+		return fmt.Errorf("field TEEVersion in manifest cannot be empty")
+	} else if tcb.SNPVersion == nil {
+		return fmt.Errorf("field SNPVersion in manifest cannot be empty")
+	} else if tcb.MicrocodeVersion == nil {
+		return fmt.Errorf("field MicrocodeVersion in manifest cannot be empty")
+	}
+	return nil
 }

--- a/justfile
+++ b/justfile
@@ -79,6 +79,7 @@ generate cli=default_cli:
     nix run .#{{ cli }} -- generate \
         --workspace-dir ./{{ workspace_dir }} \
         --image-replacements ./{{ workspace_dir }}/just.containerlookup \
+        --reference-values aks \
         ./{{ workspace_dir }}/deployment/*.yml
     duration=$(( $(date +%s) - $t ))
     echo "Generated policies in $duration seconds."


### PR DESCRIPTION
This allows for fields in the manifest to have the value `"null"`, in which case the attestation will fail when trying to parse the validation options from the manifest. This is helpful when generating the manifest for the first time with `contrast generate` where the SNP reference values are now left empty (`"null"`) by default. The default reference values used for AKS can then optionally be generated with the `--reference-values aks` flag. 