### PR TITLE
verify: verify active manifest at Coordinator

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -168,7 +168,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
 	}
-	if err := os.WriteFile(flags.manifestPath, manifestData, 0o644); err != nil {
+	if err := os.WriteFile(flags.manifestPath, append(manifestData, '\n'), 0o644); err != nil {
 		return fmt.Errorf("failed to write manifest: %w", err)
 	}
 

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -99,7 +100,7 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	}
 	log.Debug("Got response")
 
-	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Successfully verified coordinator")
+	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Successfully verified Coordinator CVM based on reference values from manifest")
 
 	filelist := map[string][]byte{
 		coordRootPEMFilename: resp.RootCA,
@@ -118,6 +119,13 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "✔️ Wrote Coordinator configuration and keys to %s\n", filepath.Join(flags.workspaceDir, verifyDir))
+
+	currentManifest := resp.Manifests[len(resp.Manifests)-1]
+	if !bytes.Equal(currentManifest, manifestBytes) {
+		return fmt.Errorf("manifest active at Coordinator does not match expected manifest")
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Manifest active at Coordinator matches expected manifest")
 	fmt.Fprintln(cmd.OutOrStdout(), "  Please verify the manifest history and policies")
 
 	return nil


### PR DESCRIPTION
The `verify` command already takes the manifest file as an input. On `verify`, the CLI will now check if the local manifest matches the active manifest on the Coordinator.