### PR TITLE
manifest: check for empty trusted measurement

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -132,7 +132,7 @@ func (m *Manifest) SNPValidateOpts() (*validate.Options, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert TrustedMeasurement from manifest to byte slices: %w", err)
 	}
-	if trustedMeasurement == nil {
+	if len(trustedMeasurement) == 0 {
 		// This is required to prevent an empty measurement in the manifest from disabling the measurement check.
 		trustedMeasurement = make([]byte, 48)
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -163,6 +163,15 @@ func TestSNPValidateOpts(t *testing.T) {
 			tm: HexString("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
 		},
 		{
+			tcb: SNPTCB{
+				BootloaderVersion: toPtr(SVN(0)),
+				TEEVersion:        toPtr(SVN(1)),
+				SNPVersion:        toPtr(SVN(2)),
+				MicrocodeVersion:  toPtr(SVN(3)),
+			},
+			tm: HexString(""),
+		},
+		{
 			tcb:     SNPTCB{},
 			wantErr: true,
 		},
@@ -193,7 +202,11 @@ func TestSNPValidateOpts(t *testing.T) {
 
 			trustedMeasurement, err := tc.tm.Bytes()
 			assert.NoError(err)
-			assert.Equal(trustedMeasurement, opts.Measurement)
+			if len(tc.tm.String()) == 0 {
+				assert.Equal(make([]byte, 48), opts.Measurement)
+			} else {
+				assert.Equal(trustedMeasurement, opts.Measurement)
+			}
 
 			tcbParts := kds.TCBParts{
 				BlSpl:    tc.tcb.BootloaderVersion.UInt8(),


### PR DESCRIPTION
Previously, if the TrustedMeasurement field in the manifest was left empty, no error would be produced and the attestation would simply skip the measurement check. The correct way to check for the measurement would be to check if it is empty and not `nil`. In that case, the value is overridden with 48 zero bytes and the attestation should fail.