### PR TITLE
cli: derive runtime class name from launch digest

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -34,8 +35,6 @@ var (
 	defaultGenpolicySettings []byte
 	//go:embed assets/genpolicy-rules.rego
 	defaultRules []byte
-	// This value is injected at build time.
-	runtimeHandler = "contrast-cc"
 	// ReleaseImageReplacements contains the image replacements used by contrast.
 	//go:embed assets/image-replacements.txt
 	ReleaseImageReplacements []byte
@@ -44,6 +43,10 @@ var (
 	// It is intentionally left empty for dev builds.
 	DefaultCoordinatorPolicyHash = ""
 )
+
+func runtimeHandler(digest string) string {
+	return fmt.Sprintf("contrast-cc-%s", digest[:32])
+}
 
 func cachedir(subdir string) (string, error) {
 	dir := os.Getenv(cacheDirEnv)

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -339,13 +339,14 @@ func injectServiceMesh(resources []any) error {
 }
 
 func runtimeClassNamePatcher() func(*applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
+	handler := runtimeHandler(manifest.TrustedMeasurement)
 	return func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
-		if spec.RuntimeClassName == nil || *spec.RuntimeClassName == runtimeHandler {
+		if spec.RuntimeClassName == nil || *spec.RuntimeClassName == handler {
 			return spec
 		}
 
 		if strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc") || *spec.RuntimeClassName == "kata-cc-isolation" {
-			spec.RuntimeClassName = &runtimeHandler
+			spec.RuntimeClassName = &handler
 		}
 		return spec
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/edgelesssys/contrast/cli/cmd"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/spf13/cobra"
 )
 
@@ -30,8 +31,6 @@ func execute() error {
 
 var (
 	version          = "0.0.0-dev"
-	runtimeHandler   = "contrast-cc"
-	launchDigest     = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 	genpolicyVersion = "0.0.0-dev"
 )
 
@@ -40,8 +39,8 @@ func newRootCmd() *cobra.Command {
 	var versionsBuilder strings.Builder
 	versionsWriter := tabwriter.NewWriter(&versionsBuilder, 0, 0, 4, ' ', 0)
 	fmt.Fprintf(versionsWriter, "%s\n\n", version)
-	fmt.Fprintf(versionsWriter, "\truntime handler:\t%s\n", runtimeHandler)
-	fmt.Fprintf(versionsWriter, "\tlaunch digest:\t%s\n", launchDigest)
+	fmt.Fprintf(versionsWriter, "\truntime handler:\tcontrast-cc-%s\n", manifest.TrustedMeasurement[:32])
+	fmt.Fprintf(versionsWriter, "\tlaunch digest:\t%s\n", manifest.TrustedMeasurement)
 	fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", genpolicyVersion)
 	fmt.Fprintf(versionsWriter, "\timage versions:\n")
 	imageReplacements := strings.Trim(string(cmd.ReleaseImageReplacements), "\n")

--- a/internal/manifest/constants.go
+++ b/internal/manifest/constants.go
@@ -3,14 +3,14 @@
 
 package manifest
 
-// This value is injected at build time.
-var trustedMeasurement = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+// TrustedMeasurement contains the expected launch digest and is injected at build time.
+var TrustedMeasurement = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
 // Default returns a default manifest.
 func Default() Manifest {
 	return Manifest{
 		ReferenceValues: ReferenceValues{
-			TrustedMeasurement: HexString(trustedMeasurement),
+			TrustedMeasurement: HexString(TrustedMeasurement),
 		},
 	}
 }

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -19,8 +19,7 @@ let
 
     ldflags = [
       "-s"
-      "-X github.com/edgelesssys/contrast/internal/manifest.trustedMeasurement=${launchDigest}"
-      "-X github.com/edgelesssys/contrast/cli/cmd.runtimeHandler=${runtimeHandler}"
+      "-X github.com/edgelesssys/contrast/internal/manifest.TrustedMeasurement=${launchDigest}"
       "-X github.com/edgelesssys/contrast/internal/kuberesource.runtimeHandler=${runtimeHandler}"
     ];
 
@@ -78,11 +77,8 @@ buildGoModule rec {
     "-s"
     "-w"
     "-X main.version=v${version}"
-    "-X main.runtimeHandler=${runtimeHandler}"
-    "-X main.launchDigest=${launchDigest}"
     "-X main.genpolicyVersion=${genpolicy.version}"
-    "-X github.com/edgelesssys/contrast/internal/manifest.trustedMeasurement=${launchDigest}"
-    "-X github.com/edgelesssys/contrast/cli/cmd.runtimeHandler=${runtimeHandler}"
+    "-X github.com/edgelesssys/contrast/internal/manifest.TrustedMeasurement=${launchDigest}"
     "-X github.com/edgelesssys/contrast/internal/kuberesource.runtimeHandler=${runtimeHandler}"
   ];
 


### PR DESCRIPTION
Instead of injecting the runtime handler into the CLI, we can directly derive it from the trusted measurement.