### PR TITLE
packages/runtime-class-files: use version of kata-igvm

### DIFF
--- a/packages/by-name/contrast-node-installer-image/package.nix
+++ b/packages/by-name/contrast-node-installer-image/package.nix
@@ -49,7 +49,7 @@ let
 
   cloud-hypervisor = ociLayerTar {
     files = [
-      { source = runtime-class-files.cloud-hypervisor-bin; destination = "/opt/edgeless/bin/cloud-hypervisor-snp"; }
+      { source = runtime-class-files.cloud-hypervisor-exe; destination = "/opt/edgeless/bin/cloud-hypervisor-snp"; }
     ];
   };
 

--- a/packages/by-name/runtime-class-files/package.nix
+++ b/packages/by-name/runtime-class-files/package.nix
@@ -1,22 +1,20 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ stdenvNoCC
+{ lib
+, stdenvNoCC
 , microsoft
 , igvmmeasure
 , debugRuntime ? false
 }:
 
 let
-  rootfs = microsoft.kata-image;
   igvm = if debugRuntime then microsoft.kata-igvm.debug else microsoft.kata-igvm;
-  cloud-hypervisor-bin = "${microsoft.cloud-hypervisor}/bin/cloud-hypervisor";
-  containerd-shim-contrast-cc-v2 = "${microsoft.kata-runtime}/bin/containerd-shim-kata-v2";
 in
 
 stdenvNoCC.mkDerivation {
   name = "runtime-class-files";
-  version = "1714998420";
+  inherit (microsoft.kata-igvm) version;
 
   dontUnpack = true;
 
@@ -30,6 +28,9 @@ stdenvNoCC.mkDerivation {
   '';
 
   passthru = {
-    inherit debugRuntime rootfs igvm cloud-hypervisor-bin containerd-shim-contrast-cc-v2;
+    inherit debugRuntime igvm;
+    rootfs = microsoft.kata-image;
+    cloud-hypervisor-exe = lib.getExe microsoft.cloud-hypervisor;
+    containerd-shim-contrast-cc-v2 = lib.getExe microsoft.kata-runtime;
   };
 }


### PR DESCRIPTION
Previously we used the timestamp of the binary backup from our S3 bucket. Not that we build all the components from source, we can use the correct versioning from kata-image. Also renaming the cl attr as it no longer is binary-based.