### PR TITLE
release: update contrast-releases.json on main branch; minor improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,11 +383,11 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/edgelesssys/contrast/milestones |
             jq -r '.[] | .title' | \
-            grep -xqF "${NEXT_MINOR}" && exit 0
+            grep -xqF "v${NEXT_MINOR}" && exit 0
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/edgelesssys/contrast/milestones \
-            -f title="${NEXT_MINOR}" \
+            -f title="v${NEXT_MINOR}" \
             -f state='open'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,16 +166,22 @@ jobs:
           git add docs/versioned_docs/version-${{ needs.process-inputs.outputs.MAJOR_MINOR }}
           git commit -m "docs: update release download urls"
           git clean -fx :/
-      - name: Download updated contrast releases file (from release branch)
+      - name: Download release artifacts (from release branch)
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e #v4.1.7
         with:
-          name: contrast-releases.json
-          path: ./contrast-main/packages
+          name: contrast-release-artifacts
+          path: ./contrast-main
+      - name: Update contrast-releases.json with new release
+        working-directory: contrast-main
+        env:
+          VERSION: ${{ inputs.version }}
+        run: nix run .#scripts.update-contrast-releases
       - name: Commit updated contrast-releases.json
         working-directory: contrast-main
         run: |
           git add ./packages/contrast-releases.json
           git commit -m "packages/contrast-releases: add ${{ needs.process-inputs.outputs.MAJOR_MINOR_PATCH }}"
+          git clean -fx :/
       - name: Bump flake version to post release patch pre-version
         if: inputs.kind == 'minor'
         id: bump
@@ -286,17 +292,15 @@ jobs:
       - name: Build CLI
         run: |
           nix build -L .#cli-release
-      - name: Update contrast-releases.json with new release
-        env:
-          VERSION: ${{ inputs.version }}
-        run: nix run .#scripts.update-contrast-releases
-      - name: Upload updated contrast-releases.json (for main branch PR)
+      - name: Upload release artifacts (for main branch PR)
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: contrast-releases.json
-          path: ./packages/contrast-releases.json
-      - name: Clean up git tree
-        run: git clean -f :/
+          name: contrast-release-artifacts
+          path: |
+            result-cli/bin/contrast
+            workspace/coordinator.yml
+            workspace/runtime.yml
+            workspace/emojivoto-demo.zip
       - name: Create draft release
         uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0 # v2.0.6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,14 @@ jobs:
         run: |
           echo "WORKING_BRANCH=$(git branch --show-current)" | tee -a "$GITHUB_ENV"
       - name: Verify minor version bump
-        if: ${{ inputs.kind == 'minor' }}
+        if: inputs.kind == 'minor'
         run: |
           if [[ ! "${FULL_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Version must be in the form of vX.Y.Z"
             exit 1
           fi
       - name: Verify patch version bump
-        if: ${{ inputs.kind == 'patch' }}
+        if: inputs.kind == 'patch'
         run: |
           if [[ ! "${FULL_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[1-9]+$ ]]; then
             echo "Version must be in the form of vX.Y.Z, where Z > 0"
@@ -141,7 +141,7 @@ jobs:
           git config --global user.name "edgelessci"
           git config --global user.email "edgelessci@users.noreply.github.com"
       - name: Create docs release
-        if: ${{ inputs.kind == 'minor' }}
+        if: inputs.kind == 'minor'
         working-directory: contrast-main/docs
         run: |
           nix run .#yarn install
@@ -177,7 +177,7 @@ jobs:
           git add ./packages/contrast-releases.json
           git commit -m "packages/contrast-releases: add ${{ needs.process-inputs.outputs.MAJOR_MINOR_PATCH }}"
       - name: Bump flake version to post release patch pre-version
-        if: ${{ inputs.kind == 'minor' }}
+        if: inputs.kind == 'minor'
         id: bump
         uses: ./contrast-working/.github/actions/bump_version # Run action from working branch!
         with:
@@ -359,7 +359,7 @@ jobs:
 
   create-github-stuff:
     name: Create backport label and milestone
-    if: ${{ inputs.kind == 'minor' }}
+    if: inputs.kind == 'minor'
     needs: process-inputs
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
Fixes the bug observed in https://github.com/edgelesssys/contrast/commit/9b3cdb2638d56e2b3feb710a35fcfe800b5dd54c (https://github.com/edgelesssys/contrast/pull/622). Previously, we would update the json file on the release branch and then send it to the main branch update. But as we never commit the updated file there, patch releases would always overwrite the minor version.