### PR TITLE
manifest: validate manifest fields

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -132,6 +132,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to unmarshal manifest: %w", err)
 	}
 	manifest.Policies = policyMap
+	if err := manifest.Validate(); err != nil {
+		return fmt.Errorf("validating manifest: %w", err)
+	}
 
 	if flags.disableUpdates {
 		manifest.WorkloadOwnerKeyDigests = nil

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -81,6 +81,9 @@ func runSet(cmd *cobra.Command, args []string) error {
 	if err := json.Unmarshal(manifestBytes, &m); err != nil {
 		return fmt.Errorf("failed to unmarshal manifest: %w", err)
 	}
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("validating manifest: %w", err)
+	}
 
 	workloadOwnerKey, err := loadWorkloadOwnerKey(flags.workloadOwnerKeyPath, m, log)
 	if err != nil {

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -65,6 +65,9 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if err := json.Unmarshal(manifestBytes, &m); err != nil {
 		return fmt.Errorf("failed to unmarshal manifest: %w", err)
 	}
+	if err := m.Validate(); err != nil {
+		return fmt.Errorf("validating manifest: %w", err)
+	}
 
 	kdsDir, err := cachedir("kds")
 	if err != nil {


### PR DESCRIPTION
This adds a function `Validate()` to the manifest to check if every field in the manifest struct contains a reasonable value or if any required fields are missing.