### PR TITLE
generate: translate genpolicy logs, show warnings

### DIFF
--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenpolicyLogPrefixReg(t *testing.T) {
+	testCases := []struct {
+		logLine      string
+		wantMatch    bool
+		wantLevel    string
+		wantPosition string
+		wantMessage  string
+	}{
+		{
+			logLine:      `[2024-06-26T09:09:40Z INFO  genpolicy::registry] ============================================`,
+			wantMatch:    true,
+			wantLevel:    "INFO",
+			wantPosition: "genpolicy::registry",
+			wantMessage:  "============================================",
+		},
+		{
+			logLine:      `[2024-06-26T09:09:40Z INFO  genpolicy::registry] Pulling manifest and config for "mcr.microsoft.com/oss/kubernetes/pause:3.6"`,
+			wantMatch:    true,
+			wantLevel:    "INFO",
+			wantPosition: "genpolicy::registry",
+			wantMessage:  `Pulling manifest and config for "mcr.microsoft.com/oss/kubernetes/pause:3.6"`,
+		},
+		{
+			logLine:      `[2024-06-26T09:09:41Z INFO  genpolicy::registry] Using cache file`,
+			wantMatch:    true,
+			wantLevel:    "INFO",
+			wantPosition: "genpolicy::registry",
+			wantMessage:  "Using cache file",
+		},
+		{
+			logLine:      `[2024-06-26T09:09:41Z INFO  genpolicy::registry] dm-verity root hash: 1e306eb31693964ac837ac74bc57b50c87c549f58b0da2789e3915f923f21b81`,
+			wantMatch:    true,
+			wantLevel:    "INFO",
+			wantPosition: "genpolicy::registry",
+			wantMessage:  "dm-verity root hash: 1e306eb31693964ac837ac74bc57b50c87c549f58b0da2789e3915f923f21b81",
+		},
+		{
+			logLine:      `[2024-06-26T09:09:44Z WARN  genpolicy::registry] Using cache file`,
+			wantMatch:    true,
+			wantLevel:    "WARN",
+			wantPosition: "genpolicy::registry",
+			wantMessage:  "Using cache file",
+		},
+		{
+			logLine:   `Success!"`,
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			assert := assert.New(t)
+
+			match := genpolicyLogPrefixReg.FindStringSubmatch(tc.logLine)
+
+			if !tc.wantMatch {
+				assert.Nil(match)
+				return
+			}
+			assert.Len(match, 4)
+			assert.Equal(tc.wantLevel, match[1])
+			assert.Equal(tc.wantPosition, match[2])
+			assert.Equal(tc.wantMessage, match[3])
+		})
+	}
+}


### PR DESCRIPTION
Previously, we would collect the output with `RUST_LOG=info`, but only print it in case the invocation failed, thus swallowing any warnings. This PR introduces a log translator, that parses the output of genpolicy line by line and filters the output with regard to the currently configured log level. As a consequence, warnings are now shown by default, and when we configure debug logging in the Contrast CLI, the info logging of genpolicy is shown. However, in case genpolicy fails and the CLI debug level is info, we will now get slightly less output.

Example output (CLI loglevel info):

```
✔️ Patched targets
time=2024-06-26T08:03:50.284+02:00 level=WARN msg="Skipping symlink with long link name (NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem, 48 bytes, NetLock_Arany_=Class_Gold=_Ftanstvny.pem, 40 bytes): etc/ssl/certs/988a38cb.0"
time=2024-06-26T08:03:50.284+02:00 level=WARN msg="Skipping symlink with long link name (/usr/share/ca-certificates/mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt, 83 bytes, /usr/share/ca-certificates/mozilla/NetLock_Arany_=Class_Gold=_Ftanstvny.crt, 75 bytes): etc/ssl/certs/NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem"
time=2024-06-26T08:04:28.788+02:00 level=WARN msg="Failed to parse user as u32, using uid = 0 - error invalid digit found in string" position=genpolicy::registry
✔️ Generated workload policy annotations
✔️ Updated manifest workspace/manifest.json
```