### PR TITLE
cli: add recover command

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -19,6 +19,7 @@ const (
 	coordRootPEMFilename = "coordinator-root-ca.pem"
 	meshCAPEMFilename    = "mesh-ca.pem"
 	workloadOwnerPEM     = "workload-owner.pem"
+	seedshareOwnerPEM    = "seedshare-owner.pem"
 	manifestFilename     = "manifest.json"
 	settingsFilename     = "settings.json"
 	seedSharesFilename   = "seed-shares.json"

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -1,0 +1,229 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/attestation/snp"
+	"github.com/edgelesssys/contrast/internal/fsstore"
+	"github.com/edgelesssys/contrast/internal/grpc/dialer"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/recoveryapi"
+	"github.com/edgelesssys/contrast/internal/userapi"
+	"github.com/spf13/cobra"
+)
+
+// NewRecoverCmd creates the contrast recover subcommand.
+func NewRecoverCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recover [flags]",
+		Short: "recover a contrast deployment after restart",
+		Long: `Recover a contrast deployment after restart.
+
+The state of the Coordinator is stored protected on a persistent volume.
+After a restart, the Coordinator requires the seed to derive the signing
+key and verify the state integrity.
+
+The recover command is used to provide the seed to the Coordinator.`,
+		RunE: withTelemetry(runRecover),
+	}
+
+	cmd.Flags().StringP("manifest", "m", manifestFilename, "path to manifest (.json) file")
+	cmd.Flags().StringP("coordinator", "c", "", "endpoint the coordinator can be reached at")
+	must(cobra.MarkFlagRequired(cmd.Flags(), "coordinator"))
+	cmd.Flags().String("coordinator-policy-hash", DefaultCoordinatorPolicyHash, "override the expected policy hash of the coordinator")
+	cmd.Flags().String("workload-owner-key", workloadOwnerPEM,
+		"path to workload owner key (.pem) file (can be passed more than once)")
+	cmd.Flags().String("seedshare-owner-key", seedshareOwnerPEM, "private key file to decrypt the seed share")
+	cmd.Flags().String("seed", seedSharesFilename, "file with the encrypted seed shares")
+
+	return cmd
+}
+
+func runRecover(cmd *cobra.Command, _ []string) error {
+	flags, err := parseRecoverFlags(cmd)
+	if err != nil {
+		return fmt.Errorf("parsing flags: %w", err)
+	}
+
+	log, err := newCLILogger(cmd)
+	if err != nil {
+		return err
+	}
+	log.Debug("Starting recovery")
+
+	manifestBytes, err := os.ReadFile(flags.manifestPath)
+	if err != nil {
+		return fmt.Errorf("failed to read manifest file: %w", err)
+	}
+	var m manifest.Manifest
+	if err := json.Unmarshal(manifestBytes, &m); err != nil {
+		return fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+	workloadOwnerKey, err := loadWorkloadOwnerKey(flags.workloadOwnerKeyPath, nil, log)
+	if err != nil {
+		return fmt.Errorf("loading workload owner key: %w", err)
+	}
+	seed, salt, err := decryptedSeedFromShares(flags.seedSharesFilename, flags.seedShareOwnerKeyPath)
+	if err != nil {
+		return fmt.Errorf("decrypting seed: %w", err)
+	}
+
+	kdsDir, err := cachedir("kds")
+	if err != nil {
+		return fmt.Errorf("getting cache dir: %w", err)
+	}
+	log.Debug("Using KDS cache dir", "dir", kdsDir)
+
+	validateOptsGen, err := newCoordinatorValidateOptsGen(m, flags.policy)
+	if err != nil {
+		return fmt.Errorf("generating validate opts: %w", err)
+	}
+	kdsCache := fsstore.New(kdsDir, log.WithGroup("kds-cache"))
+	kdsGetter := snp.NewCachedHTTPSGetter(kdsCache, snp.NeverGCTicker, log.WithGroup("kds-getter"))
+	validator := snp.NewValidator(validateOptsGen, kdsGetter, log.WithGroup("snp-validator"))
+	dialer := dialer.NewWithKey(atls.NoIssuer, validator, &net.Dialer{}, workloadOwnerKey)
+
+	log.Debug("Dialing coordinator", "endpoint", flags.coordinator)
+	conn, err := dialer.Dial(cmd.Context(), flags.coordinator)
+	if err != nil {
+		return fmt.Errorf("dialing coordinator: %w", err)
+	}
+	defer conn.Close()
+
+	client := recoveryapi.NewRecoveryAPIClient(conn)
+	req := &recoveryapi.RecoverRequest{
+		Seed: seed,
+		Salt: salt,
+	}
+	if _, err := client.Recover(cmd.Context(), req); err != nil {
+		return fmt.Errorf("recovering: %w", err)
+	}
+	log.Debug("Got response")
+
+	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Successfully recovered the Coordinator")
+	return nil
+}
+
+type recoverFlags struct {
+	coordinator           string
+	policy                []byte
+	seedSharesFilename    string
+	seedShareOwnerKeyPath string
+	workloadOwnerKeyPath  string
+	manifestPath          string
+	workspaceDir          string
+}
+
+func decryptedSeedFromShares(seedSharesPath, seedShareOwnerKeyPath string) ([]byte, []byte, error) {
+	key, err := loadSeedshareOwnerKey(seedShareOwnerKeyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	pubHexStr := manifest.MarshalSeedShareOwnerKey(&key.PublicKey).String()
+	var seedShareDoc userapi.SeedShareDocument
+	seedShareBytes, err := os.ReadFile(seedSharesPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading seed shares: %w", err)
+	}
+	if err := json.Unmarshal(seedShareBytes, &seedShareDoc); err != nil {
+		return nil, nil, fmt.Errorf("unmarshaling seed shares: %w", err)
+	}
+	for _, share := range seedShareDoc.SeedShares {
+		if share.PublicKey != pubHexStr {
+			continue
+		}
+		seed, err := manifest.DecryptSeedShare(key, share)
+		if err != nil {
+			return nil, nil, fmt.Errorf("decrypting seed share: %w", err)
+		}
+		return seed, seedShareDoc.Salt, nil
+	}
+	return nil, nil, fmt.Errorf("no matching seed share found")
+}
+
+func parseRecoverFlags(cmd *cobra.Command) (*recoverFlags, error) {
+	coordinator, err := cmd.Flags().GetString("coordinator")
+	if err != nil {
+		return nil, err
+	}
+	policy, err := decodeCoordinatorPolicyHash(cmd.Flags())
+	if err != nil {
+		return nil, err
+	}
+	seed, err := cmd.Flags().GetString("seed")
+	if err != nil {
+		return nil, err
+	}
+	seedShareOwnerKeyPath, err := cmd.Flags().GetString("seedshare-owner-key")
+	if err != nil {
+		return nil, err
+	}
+	workloadOwnerKeyPath, err := cmd.Flags().GetString("workload-owner-key")
+	if err != nil {
+		return nil, err
+	}
+	manifestPath, err := cmd.Flags().GetString("manifest")
+	if err != nil {
+		return nil, err
+	}
+	workspaceDir, err := cmd.Flags().GetString("workspace-dir")
+	if err != nil {
+		return nil, err
+	}
+
+	if workspaceDir != "" {
+		// Prepend default paths with workspaceDir
+		if !cmd.Flags().Changed("manifest") {
+			manifestPath = filepath.Join(workspaceDir, manifestFilename)
+		}
+		if !cmd.Flags().Changed("workload-owner-key") {
+			workloadOwnerKeyPath = filepath.Join(workspaceDir, workloadOwnerKeyPath)
+		}
+		if !cmd.Flags().Changed("seedshare-owner-key") {
+			seedShareOwnerKeyPath = filepath.Join(workspaceDir, seedShareOwnerKeyPath)
+		}
+		if !cmd.Flags().Changed("seed") {
+			seed = filepath.Join(workspaceDir, seedSharesFilename)
+		}
+	}
+
+	return &recoverFlags{
+		coordinator:           coordinator,
+		policy:                policy,
+		seedSharesFilename:    seed,
+		seedShareOwnerKeyPath: seedShareOwnerKeyPath,
+		workloadOwnerKeyPath:  workloadOwnerKeyPath,
+		manifestPath:          manifestPath,
+		workspaceDir:          workspaceDir,
+	}, nil
+}
+
+func loadSeedshareOwnerKey(path string) (*rsa.PrivateKey, error) {
+	keyBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading seedshare owner key: %w", err)
+	}
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		return nil, fmt.Errorf("decoding seedshare owner key: no key found")
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		return nil, fmt.Errorf("decoding seedshare owner key: invalid key type %q", block.Type)
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing seedshare owner key: %w", err)
+	}
+	return key, nil
+}

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -159,9 +159,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("marshaling seed shares: %w", err)
 		}
-		// TODO(katexochen): feat#recovery add file once feature is ready.
-		_ = seedShareFile
-		// filelist[seedSharesFilename] = seedShareFile
+		filelist[seedSharesFilename] = seedShareFile
 	}
 
 	if err := writeFilelist(flags.workspaceDir, filelist); err != nil {

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -85,7 +85,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("validating manifest: %w", err)
 	}
 
-	workloadOwnerKey, err := loadWorkloadOwnerKey(flags.workloadOwnerKeyPath, m, log)
+	workloadOwnerKey, err := loadWorkloadOwnerKey(flags.workloadOwnerKeyPath, &m, log)
 	if err != nil {
 		return fmt.Errorf("loading workload owner key: %w", err)
 	}
@@ -240,7 +240,7 @@ func policyMapToBytesList(m []deployment) [][]byte {
 	return policies
 }
 
-func loadWorkloadOwnerKey(path string, manifst manifest.Manifest, log *slog.Logger) (*ecdsa.PrivateKey, error) {
+func loadWorkloadOwnerKey(path string, manifst *manifest.Manifest, log *slog.Logger) (*ecdsa.PrivateKey, error) {
 	key, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -259,20 +259,25 @@ func loadWorkloadOwnerKey(path string, manifst manifest.Manifest, log *slog.Logg
 	if err != nil {
 		return nil, fmt.Errorf("parsing workload owner key: %w", err)
 	}
-	pubKey, err := x509.MarshalPKIXPublicKey(&workloadOwnerKey.PublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling public key: %w", err)
+
+	// Check workload owner key configuration in manifest on set.
+	if manifst != nil {
+		pubKey, err := x509.MarshalPKIXPublicKey(&workloadOwnerKey.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling public key: %w", err)
+		}
+		ownerKeyHash := sha256.Sum256(pubKey)
+		ownerKeyHex := manifest.NewHexString(ownerKeyHash[:])
+		if len(manifst.WorkloadOwnerKeyDigests) == 0 {
+			log.Warn("No workload owner keys in manifest. Further manifest updates will be rejected by the Coordinator")
+			return workloadOwnerKey, nil
+		}
+		log.Debug("Workload owner keys in manifest", "keys", manifst.WorkloadOwnerKeyDigests)
+		if !slices.Contains(manifst.WorkloadOwnerKeyDigests, ownerKeyHex) {
+			log.Warn("Workload owner key not found in manifest. This may lock you out from further updates")
+		}
 	}
-	ownerKeyHash := sha256.Sum256(pubKey)
-	ownerKeyHex := manifest.NewHexString(ownerKeyHash[:])
-	if len(manifst.WorkloadOwnerKeyDigests) == 0 {
-		log.Warn("No workload owner keys in manifest. Further manifest updates will be rejected by the coordinator")
-		return workloadOwnerKey, nil
-	}
-	log.Debug("Workload owner keys in manifest", "keys", manifst.WorkloadOwnerKeyDigests)
-	if !slices.Contains(manifst.WorkloadOwnerKeyDigests, ownerKeyHex) {
-		log.Warn("Workload owner key not found in manifest. This may lock you out from further updates")
-	}
+
 	return workloadOwnerKey, nil
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -69,6 +69,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewGenerateCmd(),
 		cmd.NewSetCmd(),
 		cmd.NewVerifyCmd(),
+		cmd.NewRecoverCmd(),
 	)
 
 	return root


### PR DESCRIPTION
This introduces a new command `recover` that let's you recover the Coordinator state after a restart.

TODO: link doc page about recovery.