### PR TITLE
release: publish emojivoto as yml instead of zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,8 +274,7 @@ jobs:
           mkdir -p workspace deployment
           nix run .#scripts.write-coordinator-yaml -- "${coordinatorImgTagged}" > workspace/coordinator.yml
           nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --namespace kube-system runtime > workspace/runtime.yml
-          nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --add-load-balancers emojivoto-sm-ingress > deployment/emojivoto-demo.yml
-          zip -r workspace/emojivoto-demo.zip deployment/emojivoto-demo.yml
+          nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --add-load-balancers emojivoto-sm-ingress > workspace/emojivoto-demo.yml
       - name: Update coordinator policy hash
         run: |
           yq < workspace/coordinator.yml \
@@ -300,7 +299,7 @@ jobs:
             result-cli/bin/contrast
             workspace/coordinator.yml
             workspace/runtime.yml
-            workspace/emojivoto-demo.zip
+            workspace/emojivoto-demo.yml
       - name: Create draft release
         uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0 # v2.0.6
         with:
@@ -312,7 +311,7 @@ jobs:
             result-cli/bin/contrast
             workspace/coordinator.yml
             workspace/runtime.yml
-            workspace/emojivoto-demo.zip
+            workspace/emojivoto-demo.yml
       - name: Reset temporary changes
         run: |
           git reset --hard ${{ needs.process-inputs.outputs.WORKING_BRANCH }}

--- a/docs/docs/examples/emojivoto.md
+++ b/docs/docs/examples/emojivoto.md
@@ -35,17 +35,11 @@ where their votes are processed without leaking to the platform provider or work
 
 ### Downloading the deployment
 
-The emojivoto deployment files are part of a zip file in the Contrast release. You can download the
+The emojivoto deployment files are part of Contrast release. You can download the
 latest deployment by running:
 
 ```sh
-curl -fLO https://github.com/edgelesssys/contrast/releases/latest/download/emojivoto-demo.zip
-```
-
-After that, unzip the `emojivoto-demo.zip` file to extract the `deployment/` directory.
-
-```sh
-unzip emojivoto-demo.zip
+curl -fLO https://github.com/edgelesssys/contrast/releases/latest/download/emojivoto-demo.yml --create-dirs --output-dir deployment
 ```
 
 ### Deploy the Contrast runtime

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -116,13 +116,9 @@ func TestRelease(t *testing.T) {
 
 	require.True(t, t.Run("unpack-deployment", func(t *testing.T) {
 		require := require.New(t)
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "unzip", "emojivoto-demo.zip")
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		require.NoError(err, "output:\n%s", string(out))
+		require.NoError(os.Mkdir(path.Join(dir, "deployment"), 0o777))
+		require.NoError(os.Rename(path.Join(dir, "emojivoto-demo.yml"), path.Join(dir, "deployment", "emojivoto-demo.yml")))
 
 		infos, err := os.ReadDir(path.Join(dir, "deployment"))
 		require.NoError(err)

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -9,7 +9,8 @@
 
 let
   json = builtins.fromJSON (builtins.readFile ./contrast-releases.json);
-  findVersion = list: version: lib.lists.findFirst (obj: obj.version == version) { hash = "unknown"; } list;
+  listOrEmpty = list: field: if builtins.hasAttr field json then list.${field} else [ ];
+  findVersion = field: version: lib.lists.findFirst (obj: obj.version == version) { hash = "unknown"; } (listOrEmpty json field);
 
   buildContrastRelease = { version, hash }: {
     name = builtins.replaceStrings [ "." ] [ "-" ] version;
@@ -23,24 +24,32 @@ let
         coordinator = fetchurl {
           inherit version;
           url = "https://github.com/edgelesssys/contrast/releases/download/${version}/coordinator.yml";
-          inherit (findVersion json."coordinator.yml" version) hash;
+          inherit (findVersion "coordinator.yml" version) hash;
         };
 
         runtime = fetchurl {
           inherit version;
           url = "https://github.com/edgelesssys/contrast/releases/download/${version}/runtime.yml";
-          inherit (findVersion json."runtime.yml" version) hash;
+          inherit (findVersion "runtime.yml" version) hash;
           # runtime.yml was introduced in release v0.6.0
           passthru.exists = (builtins.compareVersions "v0.6.0" version) <= 0;
         };
 
-        emojivoto = fetchurl {
+        emojivoto-zip = fetchurl {
           # fetchurl instead of fetchzip since the hashes in contrast-release.json are computed from the zip file
           inherit version;
           url = "https://github.com/edgelesssys/contrast/releases/download/${version}/emojivoto-demo.zip";
-          inherit (findVersion json."emojivoto-demo.zip" version) hash;
+          inherit (findVersion "emojivoto-demo.zip" version) hash;
           # emojivoto-demo.zip was introduced in version v0.5.0
-          passthru.exists = (builtins.compareVersions "v0.5.0" version) <= 0;
+          passthru.exists = (builtins.compareVersions "v0.5.0" version) <= 0 && (builtins.compareVersions version "v0.8.0") < 0;
+        };
+
+        emojivoto = fetchurl {
+          inherit version;
+          url = "https://github.com/edgelesssys/contrast/releases/download/${version}/emojivoto-demo.yml";
+          inherit (findVersion "emojivoto-demo.yml" version) hash;
+          # emojivoto-demo.yml was changed from zip to yml in version v0.8.0
+          passthru.exists = (builtins.compareVersions "v0.8.0" version) <= 0;
         };
       in
       runCommand version
@@ -53,8 +62,11 @@ let
           install -m 644 ${coordinator} $out/coordinator.yml
         '' + lib.optionalString runtime.exists ''
           install -m 644 ${runtime} $out/runtime.yml
+        '' + lib.optionalString emojivoto-zip.exists ''
+          unzip ${emojivoto-zip} -d $out
         '' + lib.optionalString emojivoto.exists ''
-          unzip ${emojivoto} -d $out
+          mkdir -p $out/deployment
+          install -m 644 ${emojivoto} $out/deployment/emojivoto-demo.yml
         '');
   };
   releases = builtins.listToAttrs (builtins.map buildContrastRelease json.contrast);


### PR DESCRIPTION
This changes the released Emojivoto deployment from a zip file to a single YAML file.