### PR TITLE
ci: improve debug logging for e2e tests

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -498,7 +498,7 @@ func generatePolicyForFile(ctx context.Context, genpolicyPath, regoPath, policyP
 		fmt.Sprintf("--yaml-file=%s", yamlPath),
 	}
 	genpolicy := exec.CommandContext(ctx, genpolicyPath, args...)
-	genpolicy.Env = append(genpolicy.Env, "RUST_LOG=info")
+	genpolicy.Env = append(genpolicy.Env, "RUST_LOG=info", "RUST_BACKTRACE=1")
 
 	logFilter := newLogTranslator(logger)
 	defer logFilter.stop()

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -143,6 +143,7 @@ func (ct *ContrastTest) Generate(t *testing.T) {
 
 	generate := cmd.NewGenerateCmd()
 	generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags
+	generate.Flags().String("log-level", "debug", "")
 	generate.SetArgs(args)
 	generate.SetOut(io.Discard)
 	errBuf := &bytes.Buffer{}


### PR DESCRIPTION
Improve debug logging for by setting `RUST_BACKTRACE=1` for genpolicy and using `--log-level debug` in e2e tests.