### PR TITLE
generate: check for existing public key in manifest

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -65,8 +65,8 @@ subcommands.`,
 	cmd.Flags().String("reference-values", "", "set the default reference values used for attestation (one of: aks)")
 	cmd.Flags().StringArrayP("add-workload-owner-key", "w", []string{workloadOwnerPEM},
 		"add a workload owner key from a PEM file to the manifest (pass more than once to add multiple keys)")
-	cmd.Flags().StringArray("seedshare-owner-key", []string{seedshareOwnerPEM},
-		"path to seedshare owner key (.pem) file (can be passed more than once)")
+	cmd.Flags().StringArray("add-seedshare-owner-key", []string{seedshareOwnerPEM},
+		"add a seedshare owner key from a PEM file to the manifest (pass more than once to add multiple keys)")
 	cmd.Flags().BoolP("disable-updates", "d", false, "prevent further updates of the manifest")
 	cmd.Flags().String("image-replacements", "", "path to image replacements file")
 	cmd.Flags().Bool("skip-initializer", false, "skip injection of Contrast Initializer")
@@ -564,7 +564,7 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 	if err != nil {
 		return nil, err
 	}
-	seedshareOwnerKeys, err := cmd.Flags().GetStringArray("seedshare-owner-key")
+	seedshareOwnerKeys, err := cmd.Flags().GetStringArray("add-seedshare-owner-key")
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +593,7 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 		if !cmd.Flags().Changed("add-workload-owner-key") {
 			workloadOwnerKeys = []string{filepath.Join(workspaceDir, workloadOwnerKeys[0])}
 		}
-		if !cmd.Flags().Changed("seedshare-owner-key") {
+		if !cmd.Flags().Changed("add-seedshare-owner-key") {
 			seedshareOwnerKeys = []string{filepath.Join(workspaceDir, seedshareOwnerKeys[0])}
 		}
 	}

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -397,7 +397,10 @@ func addSeedshareOwnerKeyToManifest(manifst *manifest.Manifest, keyPath string) 
 	if err != nil {
 		return fmt.Errorf("extracting seed share public key: %w", err)
 	}
-	manifst.SeedshareOwnerPubKeys = append(manifst.SeedshareOwnerPubKeys, publicKey)
+	if !slices.Contains(manifst.SeedshareOwnerPubKeys, publicKey) {
+		manifst.SeedshareOwnerPubKeys = append(manifst.SeedshareOwnerPubKeys, publicKey)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If you call `generate` twice with the same seed share owner public key, the public key would just have been appended to the list instead of checking if the public key is already present in the manifest. Now, calling `generate` twice will result in the same manifest.