### PR TITLE
resourcegen: deploy platform-specific node-installer 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,8 +273,9 @@ jobs:
         run: |
           mkdir -p workspace deployment
           nix run .#scripts.write-coordinator-yaml -- "${coordinatorImgTagged}" > workspace/coordinator.yml
-          nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --namespace kube-system runtime > workspace/runtime.yml
-          nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --add-load-balancers emojivoto-sm-ingress > workspace/emojivoto-demo.yml
+          nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --namespace kube-system --platform AKS-CLH-SNP runtime > deployment/runtime.yml
+          nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --add-load-balancers emojivoto-sm-ingress > deployment/emojivoto-demo.yml
+          zip -r workspace/emojivoto-demo.zip deployment/emojivoto-demo.yml
       - name: Update coordinator policy hash
         run: |
           yq < workspace/coordinator.yml \

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
 	"github.com/edgelesssys/contrast/internal/kubeapi"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/node-installer/platforms"
 	ksync "github.com/katexochen/sync/api/client"
 	"github.com/stretchr/testify/require"
 )
@@ -296,7 +297,8 @@ func (ct *ContrastTest) commonArgs() []string {
 func (ct *ContrastTest) installRuntime(t *testing.T) {
 	require := require.New(t)
 
-	resources := kuberesource.Runtime()
+	resources, err := kuberesource.Runtime(platforms.AKSCloudHypervisorSNP)
+	require.NoError(err)
 	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
 	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
 

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.22.0
 
 toolchain go1.22.4
 
+replace github.com/edgelesssys/contrast/node-installer => ./node-installer
+
 require (
 	filippo.io/keygen v0.0.0-20230306160926-5201437acf8e
+	github.com/edgelesssys/contrast/node-installer v0.0.0-00010101000000-000000000000
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/go-sev-guest v0.11.1
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -6,6 +6,7 @@ package kuberesource
 import (
 	"fmt"
 
+	"github.com/edgelesssys/contrast/node-installer/platforms"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -26,16 +27,19 @@ func CoordinatorBundle() []any {
 }
 
 // Runtime returns a set of resources for registering and installing the runtime.
-func Runtime() []any {
+func Runtime(platform platforms.Platform) ([]any, error) {
 	ns := ""
 
 	runtimeClass := ContrastRuntimeClass().RuntimeClassApplyConfiguration
-	nodeInstaller := NodeInstaller(ns).DaemonSetApplyConfiguration
+	nodeInstaller, err := NodeInstaller(ns, platform)
+	if err != nil {
+		return nil, fmt.Errorf("creating node installer: %w", err)
+	}
 
 	return []any{
 		runtimeClass,
-		nodeInstaller,
-	}
+		nodeInstaller.DaemonSetApplyConfiguration,
+	}, nil
 }
 
 // OpenSSL returns a set of resources for testing with OpenSSL.

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # Undeploy, rebuild, deploy.
-default target=default_deploy_target platform=default_platform cli=default_cli: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy (node-installer platform) runtime (apply "runtime") (deploy target cli) set verify (wait-for-workload target)
+default target=default_deploy_target platform=default_platform cli=default_cli: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy (node-installer platform) (runtime platform) (apply "runtime") (deploy target cli) set verify (wait-for-workload target)
 
 # Build and push a container image.
 push target:
@@ -69,12 +69,12 @@ e2e target=default_deploy_target: coordinator initializer openssl port-forwarder
 deploy target=default_deploy_target cli=default_cli: (populate target) (generate cli) (apply target)
 
 # Populate the workspace with a runtime class deployment
-runtime:
+runtime platform=default_platform:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ./{{ workspace_dir }}/runtime
     nix shell .#contrast --command resourcegen \
-      --image-replacements ./{{ workspace_dir }}/just.containerlookup --namespace kube-system \
+      --image-replacements ./{{ workspace_dir }}/just.containerlookup --namespace kube-system --platform {{ platform }} \
       runtime > ./{{ workspace_dir }}/runtime/runtime.yml
 
 # Populate the workspace with a Kubernetes deployment

--- a/node-installer/node-installer.go
+++ b/node-installer/node-installer.go
@@ -26,21 +26,15 @@ func main() {
 	shouldRestartContainerd := flag.Bool("restart", true, "Restart containerd after the runtime installation to make the changes effective.")
 	flag.Parse()
 
-	var platform platforms.Platform
 	if len(os.Args) < 2 {
-		// For now, fall back to the default platform (AKS Cloud Hypervisor SNP) if no platform is specified.
-		platform = platforms.AKSCloudHypervisorSNP
-		// TODO(msanft): Remove this fallback once the node-installer deployment is platform-aware.
-		// fmt.Println("Usage: node-installer <platform>")
-		// os.Exit(1)
-	} else {
-		var err error
+		fmt.Println("Usage: node-installer <platform>")
+		os.Exit(1)
+	}
 
-		platform, err = platforms.FromString(os.Args[1])
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	platform, err := platforms.FromString(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	fetcher := asset.NewDefaultFetcher()

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -51,12 +51,11 @@ buildGoModule rec {
         (path.append root "go.mod")
         (path.append root "go.sum")
         (path.append root "cli/cmd/assets/image-replacements.txt")
+        (path.append root "node-installer")
         (fileset.difference
           (fileset.fileFilter (file: hasSuffix ".go" file.name) root)
-          (fileset.unions [
-            (path.append root "service-mesh")
-            (path.append root "node-installer")
-          ]))
+          (path.append root "service-mesh")
+        )
       ];
     };
 


### PR DESCRIPTION
This is the follow-up mentioned in https://github.com/edgelesssys/contrast/commit/b324c2f29113a4e449bb2d358e46d4e1232f3ecd which adds the proper templating support for the runtime deployment to the resourcegen tool. The tool now takes a platform flag, which is used to define which node-installer should be included in the runtime deployment.

As the runtime deployment now provides the node-installer with the correct platform flag, the fallback to AKS-CLH-SNP is not required anymore and can be removed.