### PR TITLE
manifest: validate seed share owner pubkeys

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -167,7 +167,11 @@ func (m *Manifest) Validate() error {
 		}
 	}
 
-	// TODO(davidweisse): validate SeedshareOwnerPubKeys field once it is being used.
+	for _, key := range m.SeedshareOwnerPubKeys {
+		if _, err := ParseSeedShareOwnerKey(key); err != nil {
+			return fmt.Errorf("invalid seed share owner public key: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -169,7 +169,7 @@ func (m *Manifest) Validate() error {
 
 	for _, key := range m.SeedshareOwnerPubKeys {
 		if _, err := ParseSeedShareOwnerKey(key); err != nil {
-			return fmt.Errorf("invalid seed share owner public key: %w", err)
+			return fmt.Errorf("invalid seed share owner public key %s: %w", key, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This tries to parse the seed share owner keys when validating the manifest.