### PR TITLE
ca: include SubjectKeyId and AuthorityKeyId in certificates

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -155,7 +155,7 @@ func TestOpenSSL(t *testing.T) {
 			stdout, stderr, err := c.ExecDeployment(ctx, ct.Namespace, opensslFrontend, []string{"/bin/bash", "-c", opensslConnectCmd("openssl-backend:443", "mesh-ca.pem")})
 			t.Log("openssl with wrong certificates:", stdout)
 			require.Error(err)
-			require.Contains(stderr, "certificate signature failure")
+			require.Contains(stderr, "self-signed certificate in certificate chain")
 
 			// Connect from backend to fronted, because the frontend does not require client certs.
 			// This should succeed because the root cert did not change.
@@ -190,6 +190,6 @@ func TestMain(m *testing.M) {
 
 func opensslConnectCmd(addr, caCert string) string {
 	return fmt.Sprintf(
-		`openssl s_client -connect %s -verify_return_error -CAfile /tls-config/%s -cert /tls-config/certChain.pem -key /tls-config/key.pem </dev/null`,
+		`openssl s_client -connect %s -verify_return_error -x509_strict -CAfile /tls-config/%s -cert /tls-config/certChain.pem -key /tls-config/key.pem </dev/null`,
 		addr, caCert)
 }


### PR DESCRIPTION
We accidentally used the certificate templates instead of the final certificates for signing intermediate and leaf, which caused the `*KeyId` fields to be missing. These fields are mandatory in TLSv3, and our certs did not pass strict verification accordingly.

This PR also adds additional tests for the recovery scenario, enforces `x509_strict` on the OpenSSL tests and removes unnecessary CA and template fields.