### PR TITLE
flake: add more packages to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,12 +35,15 @@
       devShells = {
         default = pkgs.mkShell {
           packages = with pkgs; [
+            azure-cli
+            crane
             delve
             go
             golangci-lint
             gopls
             gotools
             just
+            kubectl
           ];
           shellHook = ''
             alias make=just


### PR DESCRIPTION
These packages are used in some Just targets. To make onboarding easier they should be part of the devshell.