### PR TITLE
cli: move workload & seedshare owner key handling into manifest

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -8,10 +8,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -395,23 +393,11 @@ func addSeedshareOwnerKeyToManifest(manifst *manifest.Manifest, keyPath string) 
 	if err != nil {
 		return fmt.Errorf("reading seedshare owner key: %w", err)
 	}
-	block, _ := pem.Decode(keyData)
-	if block == nil {
-		return errors.New("failed to decode PEM block")
-	}
-	var publicKey manifest.HexString
-	switch block.Type {
-	case "RSA PRIVATE KEY":
-		privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("parsing RSA private key: %w", err)
-		}
-		publicKey = manifest.MarshalSeedShareOwnerKey(&privateKey.PublicKey)
-	default:
-		return fmt.Errorf("unsupported PEM block type: %s", block.Type)
+	publicKey, err := manifest.ExtractSeedshareOwnerPublicKey(keyData)
+	if err != nil {
+		return fmt.Errorf("extracting seed share public key: %w", err)
 	}
 	manifst.SeedshareOwnerPubKeys = append(manifst.SeedshareOwnerPubKeys, publicKey)
-
 	return nil
 }
 

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -374,25 +374,9 @@ func addWorkloadOwnerKeyToManifest(manifst *manifest.Manifest, keyPath string) e
 	if err != nil {
 		return fmt.Errorf("reading workload owner key: %w", err)
 	}
-	block, _ := pem.Decode(keyData)
-	if block == nil {
-		return errors.New("failed to decode PEM block")
-	}
-	var publicKey []byte
-	switch block.Type {
-	case "PUBLIC KEY":
-		publicKey = block.Bytes
-	case "EC PRIVATE KEY":
-		privateKey, err := x509.ParseECPrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("parsing EC private key: %w", err)
-		}
-		publicKey, err = x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
-		if err != nil {
-			return fmt.Errorf("marshaling public key: %w", err)
-		}
-	default:
-		return fmt.Errorf("unsupported PEM block type: %s", block.Type)
+	publicKey, err := manifest.ExtractWorkloadOwnerPublicKey(keyData)
+	if err != nil {
+		return fmt.Errorf("reading workload owner key: %w", err)
 	}
 
 	hash := sha256.Sum256(publicKey)

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -7,10 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -533,7 +529,7 @@ func generateWorkloadOwnerKey(flags *generateFlags) error {
 	}
 	keyPath := flags.workloadOwnerKeys[0]
 
-	if err := createFileWithDefault(keyPath, newECDSAKeyPair); err != nil {
+	if err := createFileWithDefault(keyPath, manifest.NewWorkloadOwnerKey); err != nil {
 		return fmt.Errorf("creating default workload owner key file: %w", err)
 	}
 	return nil
@@ -547,31 +543,10 @@ func generateSeedshareOwnerKey(flags *generateFlags) error {
 	}
 	keyPath := flags.seedshareOwnerKeys[0]
 
-	if err := createFileWithDefault(keyPath, newRSAKeyPair); err != nil {
+	if err := createFileWithDefault(keyPath, manifest.NewSeedShareOwnerPrivateKey); err != nil {
 		return fmt.Errorf("creating default seedshare owner key file: %w", err)
 	}
 	return nil
-}
-
-func newECDSAKeyPair() ([]byte, error) {
-	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf("generating private key: %w", err)
-	}
-	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling private key: %w", err)
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes}), nil
-}
-
-func newRSAKeyPair() ([]byte, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		return nil, fmt.Errorf("generating private key: %w", err)
-	}
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
-	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privateKeyBytes}), nil
 }
 
 type generateFlags struct {

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
@@ -243,17 +242,7 @@ func loadWorkloadOwnerKey(path string, manifst *manifest.Manifest, log *slog.Log
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
-	if err != nil {
-		return nil, fmt.Errorf("reading workload owner key: %w", err)
-	}
-	pemBlock, _ := pem.Decode(key)
-	if pemBlock == nil {
-		return nil, fmt.Errorf("decoding workload owner key: %w", err)
-	}
-	if pemBlock.Type != "EC PRIVATE KEY" {
-		return nil, fmt.Errorf("workload owner key is not an EC private key")
-	}
-	workloadOwnerKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+	workloadOwnerKey, err := manifest.ParseWorkloadOwnerPrivateKey(key)
 	if err != nil {
 		return nil, fmt.Errorf("parsing workload owner key: %w", err)
 	}

--- a/internal/manifest/crypto.go
+++ b/internal/manifest/crypto.go
@@ -140,6 +140,20 @@ func ParseWorkloadOwnerPrivateKey(keyBytes []byte) (*ecdsa.PrivateKey, error) {
 	return workloadOwnerKey, nil
 }
 
+// HashWorkloadOwnerKey converts a public key into the format for Manifest.WorkloadOwnerKeyDigests.
+func HashWorkloadOwnerKey(pubKey *ecdsa.PublicKey) HexString {
+	keyData, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		// According to the docs for MarshalPKIXPublicKey, an error should only
+		// occur for unsupported key types. *ecdsa.PublicKey is a supported key
+		// type.
+		panic(fmt.Errorf("failed to marshal key: %w", err))
+	}
+
+	ownerKeyHash := sha256.Sum256(keyData)
+	return NewHexString(ownerKeyHash[:])
+}
+
 // ExtractWorkloadOwnerPublicKey extracts the public key for a workload owner and returns it as serialized DER.
 //
 // This function supports PEM-encoded public and private keys.

--- a/internal/manifest/crypto.go
+++ b/internal/manifest/crypto.go
@@ -50,6 +50,22 @@ func ExtractSeedshareOwnerPublicKey(keyData []byte) (HexString, error) {
 	}
 }
 
+// ParseSeedshareOwnerPrivateKey decodes a PEM-encoded seed share private key.
+func ParseSeedshareOwnerPrivateKey(keyData []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(keyData)
+	if block == nil {
+		return nil, fmt.Errorf("decoding seedshare owner key: no key found")
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		return nil, fmt.Errorf("decoding seedshare owner key: invalid key type %q", block.Type)
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing seedshare owner key: %w", err)
+	}
+	return key, nil
+}
+
 // MarshalSeedShareOwnerKey converts a public key into the format for userapi.SetManifestRequest.
 func MarshalSeedShareOwnerKey(pubKey *rsa.PublicKey) HexString {
 	return NewHexString(x509.MarshalPKCS1PublicKey(pubKey))

--- a/internal/manifest/crypto.go
+++ b/internal/manifest/crypto.go
@@ -124,6 +124,22 @@ func NewWorkloadOwnerKey() ([]byte, error) {
 	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes}), nil
 }
 
+// ParseWorkloadOwnerPrivateKey parses a PEM-encoded private key.
+func ParseWorkloadOwnerPrivateKey(keyBytes []byte) (*ecdsa.PrivateKey, error) {
+	pemBlock, _ := pem.Decode(keyBytes)
+	if pemBlock == nil {
+		return nil, fmt.Errorf("decoding workload owner key: no key found")
+	}
+	if pemBlock.Type != "EC PRIVATE KEY" {
+		return nil, fmt.Errorf("workload owner key is not an EC private key")
+	}
+	workloadOwnerKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing workload owner key: %w", err)
+	}
+	return workloadOwnerKey, nil
+}
+
 // ExtractWorkloadOwnerPublicKey extracts the public key for a workload owner and returns it as serialized DER.
 //
 // This function supports PEM-encoded public and private keys.


### PR DESCRIPTION
This PR removes code related to workload and seedshare key handling from the CLI subcommands and consolidates it into the manifest package. This PR also adds some unit tests for the new functions.