### PR TITLE
docs: use --reference-values aks flag on generate

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -159,7 +159,7 @@ After that, it will generate the execution policies and add them as annotations 
 A `manifest.json` with the reference values of your deployment will be created.
 
 ```sh
-contrast generate resources/
+contrast generate --reference-values aks resources/
 ```
 
 :::warning
@@ -177,7 +177,7 @@ You can disable the Initializer injection completely by specifying the
 `--skip-initializer` flag in the `generate` command.
 
 ```sh
-contrast generate --skip-initializer resources/
+contrast generate --reference-values aks --skip-initializer resources/
 ```
 
 </TabItem>

--- a/docs/docs/examples/emojivoto.md
+++ b/docs/docs/examples/emojivoto.md
@@ -70,7 +70,7 @@ annotations to your deployment files. A `manifest.json` file with the reference 
 of your deployment will be created:
 
 ```sh
-contrast generate deployment/
+contrast generate --reference-values aks deployment/
 ```
 
 :::note[Runtime class and Initializer]


### PR DESCRIPTION
Without the --reference-values flag, the generate command will produce an invalid manifest.