### PR TITLE
e2e: add readiness probes to emojivoto pods

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -79,8 +79,6 @@ type serviceMeshMode string
 const (
 	// ServiceMeshIngressEgress sets the service mesh mode to ingress and egress.
 	ServiceMeshIngressEgress serviceMeshMode = "service-mesh-ingress-egress"
-	// ServiceMeshEgress sets the service mesh mode to egress.
-	ServiceMeshEgress serviceMeshMode = "service-mesh-egress"
 	// ServiceMeshDisabled disables the service mesh.
 	ServiceMeshDisabled serviceMeshMode = "service-mesh-disabled"
 )

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -54,8 +54,6 @@ func main() {
 			subResources = kuberesource.Emojivoto(kuberesource.ServiceMeshDisabled)
 		case "emojivoto-sm-ingress":
 			subResources = kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
-		case "emojivoto-sm-egress":
-			subResources = kuberesource.Emojivoto(kuberesource.ServiceMeshEgress)
 		default:
 			log.Fatalf("Error: unknown set: %s\n", set)
 		}

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -190,7 +190,7 @@ func GenpolicyRegressionTests() map[string]*applyappsv1.DeploymentApplyConfigura
 // Emojivoto returns resources for deploying Emojivoto application.
 func Emojivoto(smMode serviceMeshMode) []any {
 	ns := ""
-	var emojiSvcImage, emojiVotingSvcImage, emojiWebImage, emojiWebVoteBotImage, emojiSvcHost, votingSvcHost, smWebIngress, smWebEgress string
+	var emojiSvcImage, emojiVotingSvcImage, emojiWebImage, emojiWebVoteBotImage, emojiSvcHost, votingSvcHost string
 	switch smMode {
 	case ServiceMeshDisabled:
 		emojiSvcImage = "ghcr.io/3u13r/emojivoto-emoji-svc:coco-1"
@@ -206,16 +206,6 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		emojiWebVoteBotImage = "ghcr.io/3u13r/emojivoto-web:coco-1"
 		emojiSvcHost = "127.137.0.1:8081"
 		votingSvcHost = "127.137.0.2:8081"
-		smWebIngress = "web#8080#false"
-		smWebEgress = "emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080"
-	case ServiceMeshEgress:
-		emojiSvcImage = "ghcr.io/3u13r/emojivoto-emoji-svc:coco-1"
-		emojiVotingSvcImage = "ghcr.io/3u13r/emojivoto-voting-svc:coco-1"
-		emojiWebImage = "docker.io/buoyantio/emojivoto-web:v11"
-		emojiWebVoteBotImage = emojiWebImage
-		emojiSvcHost = "127.137.0.1:8081"
-		votingSvcHost = "127.137.0.2:8081"
-		smWebEgress = "emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080"
 	default:
 		panic(fmt.Sprintf("unknown service mesh mode: %s", smMode))
 	}
@@ -487,8 +477,8 @@ func Emojivoto(smMode serviceMeshMode) []any {
 	emoji.WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""})
 	voting.WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""})
 	web.WithAnnotations(map[string]string{
-		smIngressConfigAnnotationKey: smWebIngress,
-		smEgressConfigAnnotationKey:  smWebEgress,
+		smIngressConfigAnnotationKey: "web#8080#false",
+		smEgressConfigAnnotationKey:  "emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080",
 	})
 
 	return resources


### PR DESCRIPTION
We sometimes see EOF or other connectivity problems in e2e tests, which suggest server unavailability. It turns out that we don't have a lot of readiness probes in the emojivoto demo, so the `WaitFor` calls in the e2e test are not quite sufficient to ensure availability. My suspicion is that this started getting visible after #573, which had the (side) effect of serializing container startup.

* Adds HTTP readiness probe to the Emojivoto frontend.
* Adds TCP readiness probes to the Emojivoto backends. 
  - Ideally, these would be gRPC probes, but the demo does not register a health server.  
  - Next preferred would be HTTP probes on the metrics endpoint, but the service mesh enforces mTLS and I can't easily change that because we rely on that in tests.
* Removes the egress-only service mesh variant, which is not actively used and somewhat broken since we introduced sidecar injection. Not necessary for the purpose of the PR, but I was touching these files anyway.

