### PR TITLE
ci: add an e2e test for policy changes

### DIFF
--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -1,0 +1,62 @@
+name: e2e policy
+
+on:
+    workflow_dispatch:
+    pull_request:
+      paths-ignore:
+        - docs/**
+        - rfc/**
+
+env:
+  container_registry: ghcr.io/edgelesssys
+  azure_resource_group: contrast-ci
+  DO_NOT_TRACK: 1
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Azure
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+        with:
+          creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
+      - uses: nicknovitski/nix-develop@a2060d116a50b36dfab02280af558e73ab52427d # v1.1.0
+      - name: Create justfile.env
+        run: |
+          cat <<EOF > justfile.env
+          container_registry=${{ env.container_registry }}
+          azure_resource_group=${{ env.azure_resource_group }}
+          EOF
+      - name: Get credentials for CI cluster
+        run: |
+          just get-credentials
+      - name: Set sync environemnt
+        run: |
+          sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a $GITHUB_ENV
+          sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
+          echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a $GITHUB_ENV
+      - name: Build and prepare deployments
+        run: |
+          just coordinator initializer port-forwarder service-mesh-proxy node-installer
+      - name: E2E Test
+        run: |
+          nix shell .#contrast.e2e --command policy.test -test.v workspace/just.containerlookup
+      - name: Undeploy
+        if: always() && inputs.skip-undeploy != 'true'
+        run: |
+          just undeploy

--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -1,4 +1,4 @@
-name: e2e malicious pod
+name: e2e test malicious pod
 
 on:
   workflow_dispatch:

--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -2,6 +2,12 @@ name: e2e policy
 
 on:
     workflow_dispatch:
+      inputs:
+        skip-undeploy:
+          description: "Skip undeploy"
+          required: false
+          type: boolean
+          default: false
     pull_request:
       paths-ignore:
         - docs/**
@@ -52,10 +58,13 @@ jobs:
           echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a $GITHUB_ENV
       - name: Build and prepare deployments
         run: |
-          just coordinator initializer port-forwarder service-mesh-proxy node-installer
+          just coordinator initializer openssl port-forwarder node-installer
       - name: E2E Test
         run: |
-          nix shell .#contrast.e2e --command policy.test -test.v workspace/just.containerlookup
+          nix shell .#contrast.e2e --command policy.test -test.v \
+            --image-replacements workspace/just.containerlookup \
+            --namespace-file workspace/e2e.namespace \
+            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
       - name: Undeploy
         if: always() && inputs.skip-undeploy != 'true'
         run: |

--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -1,18 +1,18 @@
 name: e2e malicious pod
 
 on:
-    workflow_dispatch:
-      inputs:
-        skip-undeploy:
-          description: "Skip undeploy"
-          required: false
-          type: boolean
-          default: false
-    pull_request:
-      paths-ignore:
-        - dev-docs/**
-        - docs/**
-        - rfc/**
+  workflow_dispatch:
+    inputs:
+      skip-undeploy:
+        description: "Skip undeploy"
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    paths-ignore:
+      - dev-docs/**
+      - docs/**
+      - rfc/**
 
 env:
   container_registry: ghcr.io/edgelesssys

--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -69,4 +69,4 @@ jobs:
       - name: Undeploy
         if: always() && inputs.skip-undeploy != 'true'
         run: |
-          just undeploy
+          kubectl delete ns $(cat workspace/e2e.namespace) --timeout 5m

--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -10,6 +10,7 @@ on:
           default: false
     pull_request:
       paths-ignore:
+        - dev-docs/**
         - docs/**
         - rfc/**
 

--- a/.github/workflows/e2e_policy.yml
+++ b/.github/workflows/e2e_policy.yml
@@ -1,4 +1,4 @@
-name: e2e policy
+name: e2e malicious pod
 
 on:
     workflow_dispatch:

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -24,6 +24,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -100,19 +101,18 @@ func TestPolicy(t *testing.T) {
 		require.NoError(err)
 
 		// remove everything from the openssl-frontend
-		newResources := r[:0]
+		newResources := make([]*unstructured.Unstructured, 0, len(r))
 		for _, resource := range r {
 			name := resource.GetName()
 			require.NoError(err)
-			if name == opensslFrontend || name == "port-forwarder-"+opensslFrontend {
+			if strings.Contains(name, opensslFrontend) {
 				continue
 			}
 			newResources = append(newResources, resource)
 		}
 
 		// write the new resources yaml
-		r = newResources
-		resourceBytes, err = kuberesource.EncodeUnstructured(r)
+		resourceBytes, err = kuberesource.EncodeUnstructured(newResources)
 		require.NoError(err)
 		require.NoError(os.WriteFile(path.Join(ct.WorkDir, "resources.yaml"), resourceBytes, 0o644))
 

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package policy
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/stretchr/testify/require"
+)
+
+var imageReplacementsFile, namespaceFile string
+var skipUndeploy bool
+
+func TestPolicy(t *testing.T) {
+	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, skipUndeploy)
+
+	// NOTE: curently this probably is overkill, but its a helpful start
+	resources := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
+	resources = append(resources, kuberesource.CoordinatorBundle()...)
+	resources = kuberesource.AddPortForwarders(resources)
+
+	ct.Init(t, resources)
+
+	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+
+	require.True(t, t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
+	require.True(t, t.Run("contrast verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
+}
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
+	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
+	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	flag.Parse()
+
+	os.Exit(m.Run())
+}

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -69,8 +69,6 @@ func TestPolicy(t *testing.T) {
 		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
 		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 
-		time.Sleep(5 * time.Second)
-
 		// get the attestation failures before removing a policy
 		initialFailures := getFailures(ctx, t, ct)
 
@@ -132,7 +130,6 @@ func TestPolicy(t *testing.T) {
 			require.NoError(err)
 			require.NotEmpty(pods, "pod not found: %s/%s", ct.Namespace, opensslFrontend)
 			require.NotEmpty(pods[0].Status.InitContainerStatuses, "pod doesn't contain init container statuses: %s/%s", ct.Namespace, opensslFrontend)
-			t.Log("container state:", pods[0].Status.InitContainerStatuses[0].State.String())
 			ready = pods[0].Status.InitContainerStatuses[0].State.Running != nil
 		}
 		newFailures := getFailures(ctx, t, ct)

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -1,39 +1,93 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//go:build e2e
+///go:build e2e
 
 package policy
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
 	"flag"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
 
-var imageReplacementsFile, namespaceFile string
-var skipUndeploy bool
+const opensslBackend = "openssl-backend"
+const opensslFrontend = "openssl-frontend"
+
+var (
+	imageReplacementsFile, namespaceFile string
+	skipUndeploy                         bool
+)
 
 func TestPolicy(t *testing.T) {
 	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, skipUndeploy)
 
-	// NOTE: curently this probably is overkill, but its a helpful start
-	resources := kuberesource.Emojivoto(kuberesource.ServiceMeshIngressEgress)
-	resources = append(resources, kuberesource.CoordinatorBundle()...)
+	resources := kuberesource.OpenSSL()
+
+	coordinator := kuberesource.CoordinatorBundle()
+	resources = append(resources, coordinator...)
 	resources = kuberesource.AddPortForwarders(resources)
 
 	ct.Init(t, resources)
 
+	// initial deployment with pod allowed
 	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
 
 	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
 
 	require.True(t, t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
 	require.True(t, t.Run("contrast verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
+
+	t.Run("pod cannot join after it was removed from the manifest", func(t *testing.T) {
+		require := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		c := kubeclient.NewForTest(t)
+
+		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
+
+		// parse the manifest
+		manifestBytes, err := os.ReadFile(ct.WorkDir + "/manifest.json")
+		require.NoError(err)
+		var m manifest.Manifest
+		require.NoError(json.Unmarshal(manifestBytes, &m))
+		t.Log("original manifest:", string(manifestBytes))
+
+		// Replace all policy hashes with random ones.
+		// This is needed because `ct.Set` fails if the
+		// number of policy hashes doesn't match the current deployment
+		newPolicies := make(map[manifest.HexString][]string)
+		for range m.Policies {
+			hash := make([]byte, 32)
+			rand.Read(hash)
+			newPolicies[manifest.NewHexString(hash)] = []string{""}
+		}
+		m.Policies = newPolicies
+
+		// write the new manifest
+		manifestBytes, err = json.Marshal(m)
+		require.NoError(err)
+		require.NoError(os.WriteFile(ct.WorkDir+"/manifest.json", manifestBytes, 0o644))
+		t.Log("new manifest:", string(manifestBytes))
+
+		// set the new manifest
+		ct.Set(t)
+
+		// restart a deployment - this should fail since the manifest disallows the hash
+		require.Error(c.RestartDeployment(ctx, ct.Namespace, opensslBackend))
+	})
 }
 
 func TestMain(m *testing.M) {

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//go:build e2e
+///go:build e2e
 
 package policy
 
@@ -82,14 +82,11 @@ func TestPolicy(t *testing.T) {
 		require.NoError(json.Unmarshal(manifestBytes, &m))
 
 		// Remove a policy from the manifest.
-		newPolicies := make(map[manifest.HexString][]string)
 		for policyHash := range m.Policies {
 			if slices.Contains(m.Policies[policyHash], opensslFrontend) {
-				continue
+				delete(m.Policies, policyHash)
 			}
-			newPolicies[policyHash] = m.Policies[policyHash]
 		}
-		m.Policies = newPolicies
 
 		// write the new manifest
 		manifestBytes, err = json.Marshal(m)

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-///go:build e2e
+//go:build e2e
 
 package policy
 

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -1,28 +1,35 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-///go:build e2e
+//go:build e2e
 
 package policy
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"flag"
 	"os"
+	"path"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
+	"github.com/edgelesssys/contrast/internal/kubeapi"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const opensslBackend = "openssl-backend"
 const opensslFrontend = "openssl-frontend"
+const coordinator = "coordinator"
 
 var (
 	imageReplacementsFile, namespaceFile string
@@ -34,9 +41,13 @@ func TestPolicy(t *testing.T) {
 
 	resources := kuberesource.OpenSSL()
 
-	coordinator := kuberesource.CoordinatorBundle()
-	resources = append(resources, coordinator...)
+	coordinatorBundle := kuberesource.CoordinatorBundle()
+	resources = append(resources, coordinatorBundle...)
 	resources = kuberesource.AddPortForwarders(resources)
+	// resources = kuberesource.PatchCoordinatorMetrics(resources, 8080)
+
+	// TODO: Set all resources, wait for them, get counter from init container, remove policy, restart pod, get counter again and compare
+	// counter should go up
 
 	ct.Init(t, resources)
 
@@ -57,36 +68,75 @@ func TestPolicy(t *testing.T) {
 		c := kubeclient.NewForTest(t)
 
 		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
+		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
+		// require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, coordinator))
+
+		// get the attestation failures before removing a policy
+		coordPods, err := ct.Kubeclient.PodsFromOwner(ctx, ct.Namespace, "StatefulSet", coordinator)
+		require.NotEmpty(coordPods, "pod not found: %s/%s", ct.Namespace, coordinator)
+		coordIp := coordPods[0].Status.PodIP
+		t.Log("coordinator IP:", coordIp)
+		backendPods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, opensslBackend)
+		require.NotEmpty(backendPods, "pod not found: %s/%s", ct.Namespace, opensslBackend)
+		metricsString, _, err := c.Exec(ctx, ct.Namespace, backendPods[0].Name, []string{"curl", coordIp + ":9102/metrics"})
+		require.NoError(err)
+		metrics, err := parsePrometheus(metricsString)
+		require.NoError(err)
+		var initialAttestationFailures int
+		for k, v := range metrics {
+			if k == "contrast_meshapi_attestation_failures" {
+				t.Log("metric:", v.GetMetric()[0])
+				initialAttestationFailures = int(v.GetMetric()[0].GetCounter().GetValue())
+			}
+		}
+		t.Log("Initial failures:", initialAttestationFailures)
 
 		// parse the manifest
-		manifestBytes, err := os.ReadFile(ct.WorkDir + "/manifest.json")
+		manifestBytes, err := os.ReadFile(path.Join(ct.WorkDir, "manifest.json"))
 		require.NoError(err)
 		var m manifest.Manifest
 		require.NoError(json.Unmarshal(manifestBytes, &m))
 		t.Log("original manifest:", string(manifestBytes))
 
-		// Replace all policy hashes with random ones.
-		// This is needed because `ct.Set` fails if the
-		// number of policy hashes doesn't match the current deployment
+		// Remove a policy from the manifest.
 		newPolicies := make(map[manifest.HexString][]string)
-		for range m.Policies {
-			hash := make([]byte, 32)
-			rand.Read(hash)
-			newPolicies[manifest.NewHexString(hash)] = []string{""}
+		for policyHash := range m.Policies {
+			if slices.Contains(m.Policies[policyHash], opensslBackend) {
+				continue
+			}
+			newPolicies[policyHash] = m.Policies[policyHash]
 		}
 		m.Policies = newPolicies
 
 		// write the new manifest
 		manifestBytes, err = json.Marshal(m)
 		require.NoError(err)
-		require.NoError(os.WriteFile(ct.WorkDir+"/manifest.json", manifestBytes, 0o644))
+		require.NoError(os.WriteFile(path.Join(ct.WorkDir, "manifest.json"), manifestBytes, 0o644))
 		t.Log("new manifest:", string(manifestBytes))
+
+		resourceBytes, err := os.ReadFile(path.Join(ct.WorkDir, "resources.yaml"))
+		require.NoError(err)
+		r, err := kubeapi.UnmarshalUnstructuredK8SResource(resourceBytes)
+		require.NoError(err)
+		for i, resource := range r {
+			name, found, err := unstructured.NestedString(resource.Object, "metadata", "name")
+			require.NoError(err)
+			t.Log("iterating ", name)
+			if found {
+				if name == opensslFrontend || name == "port-forwarder-"+opensslFrontend {
+					r = slices.Delete(r, i, i)
+				}
+			}
+		}
+		resourceBytes, err = kuberesource.EncodeUnstructured(r)
+		require.NoError(err)
+		require.NoError(os.WriteFile(path.Join(ct.WorkDir, "resources.yaml"), resourceBytes, 0o644))
 
 		// set the new manifest
 		ct.Set(t)
 
 		// restart a deployment - this should fail since the manifest disallows the hash
-		require.Error(c.RestartDeployment(ctx, ct.Namespace, opensslBackend))
+		require.Error(c.RestartDeployment(ctx, ct.Namespace, opensslFrontend))
 	})
 }
 
@@ -97,4 +147,9 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	os.Exit(m.Run())
+}
+
+func parsePrometheus(input string) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	return parser.TextToMetricFamilies(strings.NewReader(input))
 }

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//go:build e2e
+///go:build e2e
 
 package policy
 
@@ -163,11 +163,15 @@ func getFailures(ctx context.Context, t *testing.T, ct *contrasttest.ContrastTes
 	// parse the logs
 	metrics, err := (&expfmt.TextParser{}).TextToMetricFamilies(strings.NewReader(metricsString))
 	require.NoError(err)
-	var failures int
+	failures := -1
 	for k, v := range metrics {
 		if k == "contrast_meshapi_attestation_failures" {
 			failures = int(v.GetMetric()[0].GetCounter().GetValue())
 		}
+	}
+	if failures == -1 {
+		// metric not found
+		t.Error("metric \"contrast_meshapi_attestation_failures\" not found")
 	}
 	return failures
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/katexochen/sync v0.0.0-20240617152407-6a8003240db0
 	github.com/prometheus/client_golang v1.19.1
-	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.48.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
@@ -68,6 +67,7 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.25.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/katexochen/sync v0.0.0-20240617152407-6a8003240db0
 	github.com/prometheus/client_golang v1.19.1
+	github.com/prometheus/client_model v0.5.0
+	github.com/prometheus/common v0.48.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
@@ -66,8 +68,6 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.25.0 // indirect

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -37,6 +37,7 @@ let
       "e2e/openssl"
       "e2e/servicemesh"
       "e2e/release"
+      "e2e/policy"
     ];
   };
 


### PR DESCRIPTION
Add an e2e test that confirms that a pod cannot join again after it was removed from the policy and manifest.

A successful test run can be found [here](https://github.com/edgelesssys/contrast/actions/runs/9778895950/job/26996776008?pr=672).