### PR TITLE
treefmt: switch from nixpkgs-fmt to nixfmt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,78 +16,83 @@
   };
 
   outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , treefmt-nix
-    , ...
-    }: flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ (import ./overlays/nixpkgs.nix) ];
-      };
-      inherit (pkgs) lib;
-      treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-      ourPkgs = import ./packages { inherit pkgs lib; };
-    in
     {
-      devShells = {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            azure-cli
-            crane
-            delve
-            go
-            golangci-lint
-            gopls
-            gotools
-            just
-            kubectl
-          ];
-          shellHook = ''
-            alias make=just
-            export DO_NOT_TRACK=1
-          '';
+      self,
+      nixpkgs,
+      flake-utils,
+      treefmt-nix,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import ./overlays/nixpkgs.nix) ];
         };
-        docs = pkgs.mkShell {
-          packages = with pkgs; [
-            yarn
-          ];
-          shellHook = ''
-            yarn install
-          '';
-        };
-      } // (
-        let
-          toDemoShell = version: contrast-release:
-            lib.nameValuePair "demo-${version}" (pkgs.mkShell {
-              packages = [ contrast-release ];
+        inherit (pkgs) lib;
+        treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+        ourPkgs = import ./packages { inherit pkgs lib; };
+      in
+      {
+        devShells =
+          {
+            default = pkgs.mkShell {
+              packages = with pkgs; [
+                azure-cli
+                crane
+                delve
+                go
+                golangci-lint
+                gopls
+                gotools
+                just
+                kubectl
+              ];
               shellHook = ''
-                cd "$(mktemp -d)"
-                [[ -e ${contrast-release}/runtime.yml ]] && install -m644 ${contrast-release}/runtime.yml .
-                [[ -e ${contrast-release}/coordinator.yml ]] && install -m644 ${contrast-release}/coordinator.yml .
-                [[ -d ${contrast-release}/deployment ]] && install -m644 -Dt ./deployment ${contrast-release}/deployment/*
+                alias make=just
                 export DO_NOT_TRACK=1
               '';
-            });
-        in
-        lib.mapAttrs' toDemoShell ourPkgs.contrast-releases
-      );
+            };
+            docs = pkgs.mkShell {
+              packages = with pkgs; [ yarn ];
+              shellHook = ''
+                yarn install
+              '';
+            };
+          }
+          // (
+            let
+              toDemoShell =
+                version: contrast-release:
+                lib.nameValuePair "demo-${version}" (
+                  pkgs.mkShell {
+                    packages = [ contrast-release ];
+                    shellHook = ''
+                      cd "$(mktemp -d)"
+                      [[ -e ${contrast-release}/runtime.yml ]] && install -m644 ${contrast-release}/runtime.yml .
+                      [[ -e ${contrast-release}/coordinator.yml ]] && install -m644 ${contrast-release}/coordinator.yml .
+                      [[ -d ${contrast-release}/deployment ]] && install -m644 -Dt ./deployment ${contrast-release}/deployment/*
+                      export DO_NOT_TRACK=1
+                    '';
+                  }
+                );
+            in
+            lib.mapAttrs' toDemoShell ourPkgs.contrast-releases
+          );
 
-      formatter = treefmtEval.config.build.wrapper;
+        formatter = treefmtEval.config.build.wrapper;
 
-      checks = {
-        formatting = treefmtEval.config.build.check self;
-      };
+        checks = {
+          formatting = treefmtEval.config.build.check self;
+        };
 
-      legacyPackages = pkgs // ourPkgs;
-    });
+        legacyPackages = pkgs // ourPkgs;
+      }
+    );
 
   nixConfig = {
-    extra-substituters = [
-      "https://edgelesssys.cachix.org"
-    ];
+    extra-substituters = [ "https://edgelesssys.cachix.org" ];
     extra-trusted-public-keys = [
       "edgelesssys.cachix.org-1:erQG/S1DxpvJ4zuEFvjWLx/4vujoKxAJke6lK2tWeB0="
     ];

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -10,18 +10,18 @@ final: prev: {
   #     hash = "";
   #   };
   # });
-  go_1_22 = prev.go_1_22.overrideAttrs (finalAttrs: _prevAttrs: {
-    version = "1.22.4";
-    src = final.fetchurl {
-      url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-      hash = "sha256-/tcgZ45yinyjC6jR3tHKr+J9FgKPqwIyuLqOIgCPt4Q=";
-    };
-  });
+  go_1_22 = prev.go_1_22.overrideAttrs (
+    finalAttrs: _prevAttrs: {
+      version = "1.22.4";
+      src = final.fetchurl {
+        url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+        hash = "sha256-/tcgZ45yinyjC6jR3tHKr+J9FgKPqwIyuLqOIgCPt4Q=";
+      };
+    }
+  );
 
   # Add the required extensions to the Azure CLI.
   azure-cli = prev.azure-cli.override {
-    withExtensions = with final.azure-cli.extensions; [
-      aks-preview
-    ];
+    withExtensions = with final.azure-cli.extensions; [ aks-preview ];
   };
 }

--- a/packages/by-name/buildGoTest/package.nix
+++ b/packages/by-name/buildGoTest/package.nix
@@ -6,79 +6,84 @@
 args':
 
 let
-  args = args' // { "doCheck" = false; };
+  args = args' // {
+    "doCheck" = false;
+  };
 in
-buildGoModule ({
-  # copy of buildGoModule.buildPhase with the following changes:
-  # - use `go test -c -o $GOPATH/bin/` instead of `go install` to build the binary of a test package
-  # original:
-  # https://github.com/NixOS/nixpkgs/blob/c44815411ae47dd8bbbb92d60c3a83abff28a9f3/pkgs/build-support/go/module.nix#L188-L266
-  buildPhase = ''
-    runHook preBuild
+buildGoModule (
+  {
+    # copy of buildGoModule.buildPhase with the following changes:
+    # - use `go test -c -o $GOPATH/bin/` instead of `go install` to build the binary of a test package
+    # original:
+    # https://github.com/NixOS/nixpkgs/blob/c44815411ae47dd8bbbb92d60c3a83abff28a9f3/pkgs/build-support/go/module.nix#L188-L266
+    buildPhase = ''
+      runHook preBuild
 
-    exclude='\(/_\|examples\|Godeps\|testdata'
-    if [[ -n "$excludedPackages" ]]; then
-      IFS=' ' read -r -a excludedArr <<<$excludedPackages
-      printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
-      excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
-      exclude+='\|'"$excludedAlternates"
-    fi
-    exclude+='\)'
-
-    buildGoDir() {
-      local cmd="$1" dir="$2"
-
-      . $TMPDIR/buildFlagsArray
-
-      declare -a flags
-      flags+=($buildFlags "''${buildFlagsArray[@]}")
-      flags+=(''${tags:+-tags=''${tags// /,}})
-      flags+=(''${ldflags:+-ldflags="$ldflags"})
-      flags+=("-p" "$NIX_BUILD_CORES")
-
-      if [ "$cmd" = "test" ]; then
-        flags+=(-vet=off)
-        flags+=($checkFlags)
+      exclude='\(/_\|examples\|Godeps\|testdata'
+      if [[ -n "$excludedPackages" ]]; then
+        IFS=' ' read -r -a excludedArr <<<$excludedPackages
+        printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
+        excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
+        exclude+='\|'"$excludedAlternates"
       fi
+      exclude+='\)'
 
-      local OUT
-      if ! OUT="$(go $cmd -c -o $GOPATH/bin/ "''${flags[@]}" $dir 2>&1)"; then
-        if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
-          echo "$OUT" >&2
-          return 1
+      buildGoDir() {
+        local cmd="$1" dir="$2"
+
+        . $TMPDIR/buildFlagsArray
+
+        declare -a flags
+        flags+=($buildFlags "''${buildFlagsArray[@]}")
+        flags+=(''${tags:+-tags=''${tags// /,}})
+        flags+=(''${ldflags:+-ldflags="$ldflags"})
+        flags+=("-p" "$NIX_BUILD_CORES")
+
+        if [ "$cmd" = "test" ]; then
+          flags+=(-vet=off)
+          flags+=($checkFlags)
         fi
-      fi
-      if [ -n "$OUT" ]; then
-        echo "$OUT" >&2
-      fi
-      return 0
-    }
 
-    getGoDirs() {
-      local type;
-      type="$1"
-      if [ -n "$subPackages" ]; then
-        echo "$subPackages" | sed "s,\(^\| \),\1./,g"
+        local OUT
+        if ! OUT="$(go $cmd -c -o $GOPATH/bin/ "''${flags[@]}" $dir 2>&1)"; then
+          if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
+            echo "$OUT" >&2
+            return 1
+          fi
+        fi
+        if [ -n "$OUT" ]; then
+          echo "$OUT" >&2
+        fi
+        return 0
+      }
+
+      getGoDirs() {
+        local type;
+        type="$1"
+        if [ -n "$subPackages" ]; then
+          echo "$subPackages" | sed "s,\(^\| \),\1./,g"
+        else
+          find . -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort --unique | grep -v "$exclude"
+        fi
+      }
+
+      if (( "''${NIX_DEBUG:-0}" >= 1 )); then
+        buildFlagsArray+=(-x)
+      fi
+
+      if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
+        declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
       else
-        find . -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort --unique | grep -v "$exclude"
+        touch $TMPDIR/buildFlagsArray
       fi
-    }
-
-    if (( "''${NIX_DEBUG:-0}" >= 1 )); then
-      buildFlagsArray+=(-x)
-    fi
-
-    if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
-      declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
-    else
-      touch $TMPDIR/buildFlagsArray
-    fi
-    if [ -z "$enableParallelBuilding" ]; then
-        export NIX_BUILD_CORES=1
-    fi
-    for pkg in $(getGoDirs ""); do
-      echo "Building subPackage $pkg"
-      buildGoDir test "$pkg"
-    done
-  '';
-} // args)
+      if [ -z "$enableParallelBuilding" ]; then
+          export NIX_BUILD_CORES=1
+      fi
+      for pkg in $(getGoDirs ""); do
+        echo "Building subPackage $pkg"
+        buildGoDir test "$pkg"
+      done
+    '';
+  }
+  // args
+)

--- a/packages/by-name/cli-release/package.nix
+++ b/packages/by-name/cli-release/package.nix
@@ -1,20 +1,23 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, contrast
-, microsoft
-, genpolicy ? microsoft.genpolicy
+{
+  lib,
+  contrast,
+  microsoft,
+  genpolicy ? microsoft.genpolicy,
 }:
 
-(contrast.overrideAttrs (_finalAttrs: previousAttrs: {
-  prePatch = ''
-    install -D ${lib.getExe genpolicy} cli/cmd/assets/genpolicy
-    install -D ${contrast.settings}/genpolicy-settings.json cli/cmd/assets/genpolicy-settings.json
-    install -D ${contrast.rules}/genpolicy-rules.rego cli/cmd/assets/genpolicy-rules.rego
-  '';
+(contrast.overrideAttrs (
+  _finalAttrs: previousAttrs: {
+    prePatch = ''
+      install -D ${lib.getExe genpolicy} cli/cmd/assets/genpolicy
+      install -D ${contrast.settings}/genpolicy-settings.json cli/cmd/assets/genpolicy-settings.json
+      install -D ${contrast.rules}/genpolicy-rules.rego cli/cmd/assets/genpolicy-rules.rego
+    '';
 
-  ldflags = previousAttrs.ldflags ++ [
-    "-X github.com/edgelesssys/contrast/cli/cmd.DefaultCoordinatorPolicyHash=${builtins.readFile ../../../cli/cmd/assets/coordinator-policy-hash}"
-  ];
-})).cli
+    ldflags = previousAttrs.ldflags ++ [
+      "-X github.com/edgelesssys/contrast/cli/cmd.DefaultCoordinatorPolicyHash=${builtins.readFile ../../../cli/cmd/assets/coordinator-policy-hash}"
+    ];
+  }
+)).cli

--- a/packages/by-name/contrast-docs/package.nix
+++ b/packages/by-name/contrast-docs/package.nix
@@ -1,13 +1,14 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, fetchYarnDeps
-, mkYarnPackage
-, contrast
+{
+  lib,
+  fetchYarnDeps,
+  mkYarnPackage,
+  contrast,
 
   # Configure the base URL when deploying previews under a subpath
-, docusaurusBaseUrl ? ""
+  docusaurusBaseUrl ? "",
 }:
 
 mkYarnPackage rec {
@@ -22,12 +23,14 @@ mkYarnPackage rec {
     hash = "sha256-BZpAyCgstviGDSKjmTj2eP7qevtkraoVd1NJTK9Ynug=";
   };
 
-  configurePhase = ''
-    cp -r $node_modules node_modules
-    chmod +w node_modules
-  '' + lib.optionalString (docusaurusBaseUrl != "") ''
-    sed -i "s|baseUrl: '/contrast/',|baseUrl: '${docusaurusBaseUrl}',|" docusaurus.config.js
-  '';
+  configurePhase =
+    ''
+      cp -r $node_modules node_modules
+      chmod +w node_modules
+    ''
+    + lib.optionalString (docusaurusBaseUrl != "") ''
+      sed -i "s|baseUrl: '/contrast/',|baseUrl: '${docusaurusBaseUrl}',|" docusaurus.config.js
+    '';
 
   buildPhase = ''
     export HOME=$(mktemp -d)

--- a/packages/by-name/contrast-node-installer/package.nix
+++ b/packages/by-name/contrast-node-installer/package.nix
@@ -1,9 +1,10 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, buildGoModule
-, contrast
+{
+  lib,
+  buildGoModule,
+  contrast,
 }:
 
 buildGoModule {
@@ -33,9 +34,7 @@ buildGoModule {
   subPackages = [ "." ];
 
   CGO_ENABLED = 0;
-  ldflags = [
-    "-s"
-  ];
+  ldflags = [ "-s" ];
 
   preCheck = ''
     export CGO_ENABLED=1

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -1,18 +1,26 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, buildGoModule
-, buildGoTest
-, microsoft
-, genpolicy ? microsoft.genpolicy
-, contrast
-, installShellFiles
+{
+  lib,
+  buildGoModule,
+  buildGoTest,
+  microsoft,
+  genpolicy ? microsoft.genpolicy,
+  contrast,
+  installShellFiles,
 }:
 
 let
   e2e = buildGoTest {
-    inherit (contrast) version src proxyVendor vendorHash prePatch CGO_ENABLED;
+    inherit (contrast)
+      version
+      src
+      proxyVendor
+      vendorHash
+      prePatch
+      CGO_ENABLED
+      ;
     pname = "${contrast.pname}-e2e";
 
     tags = [ "e2e" ];
@@ -23,14 +31,26 @@ let
       "-X github.com/edgelesssys/contrast/internal/kuberesource.runtimeHandler=${runtimeHandler}"
     ];
 
-    subPackages = [ "e2e/genpolicy" "e2e/getdents" "e2e/openssl" "e2e/servicemesh" "e2e/release" ];
+    subPackages = [
+      "e2e/genpolicy"
+      "e2e/getdents"
+      "e2e/openssl"
+      "e2e/servicemesh"
+      "e2e/release"
+    ];
   };
 
   launchDigest = builtins.readFile "${microsoft.runtime-class-files}/launch-digest.hex";
 
-  runtimeHandler = lib.removeSuffix "\n" (builtins.readFile "${microsoft.runtime-class-files}/runtime-handler");
+  runtimeHandler = lib.removeSuffix "\n" (
+    builtins.readFile "${microsoft.runtime-class-files}/runtime-handler"
+  );
 
-  packageOutputs = [ "coordinator" "initializer" "cli" ];
+  packageOutputs = [
+    "coordinator"
+    "initializer"
+    "cli"
+  ];
 in
 
 buildGoModule rec {
@@ -53,10 +73,9 @@ buildGoModule rec {
         (path.append root "go.sum")
         (path.append root "cli/cmd/assets/image-replacements.txt")
         (path.append root "node-installer")
-        (fileset.difference
-          (fileset.fileFilter (file: hasSuffix ".go" file.name) root)
-          (path.append root "service-mesh")
-        )
+        (fileset.difference (fileset.fileFilter (file: hasSuffix ".go" file.name) root) (
+          path.append root "service-mesh"
+        ))
       ];
     };
 

--- a/packages/by-name/igvm-signing-keygen/package.nix
+++ b/packages/by-name/igvm-signing-keygen/package.nix
@@ -1,9 +1,10 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, python3
-, writeTextFile
+{
+  lib,
+  python3,
+  writeTextFile,
 }:
 
 python3.pkgs.buildPythonApplication {

--- a/packages/by-name/igvmmeasure/package.nix
+++ b/packages/by-name/igvmmeasure/package.nix
@@ -1,9 +1,10 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, fetchFromGitHub
-, rustPlatform
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
 }:
 
 rustPlatform.buildRustPackage rec {

--- a/packages/by-name/kata/contrast-node-installer-image/package.nix
+++ b/packages/by-name/kata/contrast-node-installer-image/package.nix
@@ -1,38 +1,67 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, ociLayerTar
-, ociImageManifest
-, ociImageLayout
-, contrast-node-installer
-, kata
-, pkgsStatic
-, writers
+{
+  lib,
+  ociLayerTar,
+  ociImageManifest,
+  ociImageLayout,
+  contrast-node-installer,
+  kata,
+  pkgsStatic,
+  writers,
 }:
 
 let
   node-installer = ociLayerTar {
     files = [
-      { source = lib.getExe contrast-node-installer; destination = "/bin/node-installer"; }
-      { source = "${pkgsStatic.util-linux}/bin/nsenter"; destination = "/bin/nsenter"; }
+      {
+        source = lib.getExe contrast-node-installer;
+        destination = "/bin/node-installer";
+      }
+      {
+        source = "${pkgsStatic.util-linux}/bin/nsenter";
+        destination = "/bin/nsenter";
+      }
     ];
   };
 
-  launch-digest = lib.removeSuffix "\n" (builtins.readFile "${kata.runtime-class-files}/launch-digest.hex");
-  runtime-handler = lib.removeSuffix "\n" (builtins.readFile "${kata.runtime-class-files}/runtime-handler");
+  launch-digest = lib.removeSuffix "\n" (
+    builtins.readFile "${kata.runtime-class-files}/launch-digest.hex"
+  );
+  runtime-handler = lib.removeSuffix "\n" (
+    builtins.readFile "${kata.runtime-class-files}/runtime-handler"
+  );
 
   installer-config = ociLayerTar {
     files = [
       {
         source = writers.writeJSON "contrast-node-install.json" {
           files = [
-            { url = "file:///opt/edgeless/share/kata-containers.img"; path = "/opt/edgeless/${runtime-handler}/share/kata-containers.img"; }
-            { url = "file:///opt/edgeless/share/kata-kernel"; path = "/opt/edgeless/${runtime-handler}/share/kata-kernel"; }
-            { url = "file:///opt/edgeless/bin/qemu-system-x86_64"; path = "/opt/edgeless/${runtime-handler}/bin/qemu-system-x86_64"; }
-            { url = "file:///opt/edgeless/share/OVMF_CODE.fd"; path = "/opt/edgeless/${runtime-handler}/share/OVMF_CODE.fd"; }
-            { url = "file:///opt/edgeless/share/OVMF_VARS.fd"; path = "/opt/edgeless/${runtime-handler}/share/OVMF_VARS.fd"; }
-            { url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2"; path = "/opt/edgeless/${runtime-handler}/bin/containerd-shim-contrast-cc-v2"; }
+            {
+              url = "file:///opt/edgeless/share/kata-containers.img";
+              path = "/opt/edgeless/${runtime-handler}/share/kata-containers.img";
+            }
+            {
+              url = "file:///opt/edgeless/share/kata-kernel";
+              path = "/opt/edgeless/${runtime-handler}/share/kata-kernel";
+            }
+            {
+              url = "file:///opt/edgeless/bin/qemu-system-x86_64";
+              path = "/opt/edgeless/${runtime-handler}/bin/qemu-system-x86_64";
+            }
+            {
+              url = "file:///opt/edgeless/share/OVMF_CODE.fd";
+              path = "/opt/edgeless/${runtime-handler}/share/OVMF_CODE.fd";
+            }
+            {
+              url = "file:///opt/edgeless/share/OVMF_VARS.fd";
+              path = "/opt/edgeless/${runtime-handler}/share/OVMF_VARS.fd";
+            }
+            {
+              url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2";
+              path = "/opt/edgeless/${runtime-handler}/bin/containerd-shim-contrast-cc-v2";
+            }
           ];
           runtimeHandlerName = runtime-handler;
           inherit (kata.runtime-class-files) debugRuntime;
@@ -44,58 +73,75 @@ let
 
   kata-container-img = ociLayerTar {
     files = [
-      { source = kata.runtime-class-files.image; destination = "/opt/edgeless/share/kata-containers.img"; }
-      { source = kata.runtime-class-files.kernel; destination = "/opt/edgeless/share/kata-kernel"; }
+      {
+        source = kata.runtime-class-files.image;
+        destination = "/opt/edgeless/share/kata-containers.img";
+      }
+      {
+        source = kata.runtime-class-files.kernel;
+        destination = "/opt/edgeless/share/kata-kernel";
+      }
     ];
   };
 
   ovmf = ociLayerTar {
     files = [
-      { source = kata.runtime-class-files.ovmf-code; destination = "/opt/edgeless/share/OVMF_CODE.fd"; }
-      { source = kata.runtime-class-files.ovmf-vars; destination = "/opt/edgeless/share/OVMF_VARS.fd"; }
+      {
+        source = kata.runtime-class-files.ovmf-code;
+        destination = "/opt/edgeless/share/OVMF_CODE.fd";
+      }
+      {
+        source = kata.runtime-class-files.ovmf-vars;
+        destination = "/opt/edgeless/share/OVMF_VARS.fd";
+      }
     ];
   };
 
   qemu = ociLayerTar {
     files = [
-      { source = kata.runtime-class-files.qemu-bin; destination = "/opt/edgeless/bin/qemu-system-x86_64"; }
+      {
+        source = kata.runtime-class-files.qemu-bin;
+        destination = "/opt/edgeless/bin/qemu-system-x86_64";
+      }
     ];
   };
 
   containerd-shim = ociLayerTar {
-    files = [{ source = kata.runtime-class-files.containerd-shim-contrast-cc-v2; destination = "/opt/edgeless/bin/containerd-shim-contrast-cc-v2"; }];
+    files = [
+      {
+        source = kata.runtime-class-files.containerd-shim-contrast-cc-v2;
+        destination = "/opt/edgeless/bin/containerd-shim-contrast-cc-v2";
+      }
+    ];
   };
 
-  manifest = ociImageManifest
-    {
-      layers = [
-        node-installer
-        installer-config
-        kata-container-img
-        ovmf
-        qemu
-        containerd-shim
-      ];
-      extraConfig = {
-        "config" = {
-          "Env" = [
-            "PATH=/bin:/usr/bin"
-            "CONFIG_DIR=/config"
-            "HOST_MOUNT=/host"
-          ];
-          "Entrypoint" = [ "/bin/node-installer" ];
-        };
-      };
-      extraManifest = {
-        "annotations" = {
-          "org.opencontainers.image.title" = "contrast-node-installer-kata";
-          "org.opencontainers.image.description" = "Contrast Node Installer (Kata)";
-          "systems.edgeless.contrast.snp-launch-digest" = launch-digest;
-        };
+  manifest = ociImageManifest {
+    layers = [
+      node-installer
+      installer-config
+      kata-container-img
+      ovmf
+      qemu
+      containerd-shim
+    ];
+    extraConfig = {
+      "config" = {
+        "Env" = [
+          "PATH=/bin:/usr/bin"
+          "CONFIG_DIR=/config"
+          "HOST_MOUNT=/host"
+        ];
+        "Entrypoint" = [ "/bin/node-installer" ];
       };
     };
+    extraManifest = {
+      "annotations" = {
+        "org.opencontainers.image.title" = "contrast-node-installer-kata";
+        "org.opencontainers.image.description" = "Contrast Node Installer (Kata)";
+        "systems.edgeless.contrast.snp-launch-digest" = launch-digest;
+      };
+    };
+  };
 in
 
-ociImageLayout {
-  manifests = [ manifest ];
-}
+ociImageLayout { manifests = [ manifest ]; }

--- a/packages/by-name/kata/genpolicy/package.nix
+++ b/packages/by-name/kata/genpolicy/package.nix
@@ -1,16 +1,17 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, fetchurl
-, kata
-, rustPlatform
-, openssl
-, pkg-config
-, protobuf
-, libiconv
-, zlib
-, cmake
+{
+  lib,
+  fetchurl,
+  kata,
+  rustPlatform,
+  openssl,
+  pkg-config,
+  protobuf,
+  libiconv,
+  zlib,
+  cmake,
 }:
 
 rustPlatform.buildRustPackage rec {

--- a/packages/by-name/kata/kata-agent/package.nix
+++ b/packages/by-name/kata/kata-agent/package.nix
@@ -1,18 +1,19 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, rustPlatform
-, kata
-, cmake
-, pkg-config
-, protobuf
-, withSeccomp ? true
-, libseccomp
-, lvm2
-, openssl
-, withAgentPolicy ? true
-, withStandardOCIRuntime ? false
+{
+  lib,
+  rustPlatform,
+  kata,
+  cmake,
+  pkg-config,
+  protobuf,
+  withSeccomp ? true,
+  libseccomp,
+  lvm2,
+  openssl,
+  withAgentPolicy ? true,
+  withStandardOCIRuntime ? false,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -36,16 +37,18 @@ rustPlatform.buildRustPackage rec {
     protobuf
   ];
 
-  buildInputs = [
-    openssl
-    openssl.dev
-    lvm2.dev
-    rustPlatform.bindgenHook
-  ] ++ lib.optionals withSeccomp [
-    libseccomp.dev
-    libseccomp.lib
-    libseccomp
-  ];
+  buildInputs =
+    [
+      openssl
+      openssl.dev
+      lvm2.dev
+      rustPlatform.bindgenHook
+    ]
+    ++ lib.optionals withSeccomp [
+      libseccomp.dev
+      libseccomp.lib
+      libseccomp
+    ];
 
   # Build.rs writes to src
   postConfigure = ''

--- a/packages/by-name/kata/kata-image/package.nix
+++ b/packages/by-name/kata/kata-image/package.nix
@@ -1,33 +1,38 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, stdenv
-, stdenvNoCC
-, distro ? "cbl-mariner"
-, kata
-, bubblewrap
-, fakeroot
-, fetchurl
-, yq-go
-, tdnf
-, curl
-, util-linux
-, writeText
-, writeTextDir
-, createrepo_c
-, writeShellApplication
-, parted
-, cryptsetup
-, closureInfo
-, erofs-utils
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  distro ? "cbl-mariner",
+  kata,
+  bubblewrap,
+  fakeroot,
+  fetchurl,
+  yq-go,
+  tdnf,
+  curl,
+  util-linux,
+  writeText,
+  writeTextDir,
+  createrepo_c,
+  writeShellApplication,
+  parted,
+  cryptsetup,
+  closureInfo,
+  erofs-utils,
 }:
 
 let
   # toplevelNixDeps are packages that get installed to the rootfs of the image
   # they are used to determine the (nix) closure of the rootfs
   toplevelNixDeps = [ kata.kata-agent ];
-  nixClosure = builtins.toString (lib.strings.splitString "\n" (builtins.readFile "${closureInfo {rootPaths = toplevelNixDeps;}}/store-paths"));
+  nixClosure = builtins.toString (
+    lib.strings.splitString "\n" (
+      builtins.readFile "${closureInfo { rootPaths = toplevelNixDeps; }}/store-paths"
+    )
+  );
   rootfsExtraTree = stdenvNoCC.mkDerivation {
     pname = "rootfs-extra-tree";
     inherit (kata.kata-runtime) src version;
@@ -54,8 +59,13 @@ let
     dontInstall = true;
   };
   packageIndex = builtins.fromJSON (builtins.readFile ./package-index.json);
-  rpmSources = lib.forEach packageIndex
-    (p: lib.concatStringsSep "#" [ (fetchurl p) (builtins.baseNameOf p.url) ]);
+  rpmSources = lib.forEach packageIndex (
+    p:
+    lib.concatStringsSep "#" [
+      (fetchurl p)
+      (builtins.baseNameOf p.url)
+    ]
+  );
 
   mirror = stdenvNoCC.mkDerivation {
     name = "mirror";
@@ -108,7 +118,10 @@ stdenv.mkDerivation rec {
   pname = "kata-image";
   inherit (kata.kata-runtime) src version;
 
-  outputs = [ "out" "verity" ];
+  outputs = [
+    "out"
+    "verity"
+  ];
 
   env = {
     AGENT_SOURCE_BIN = "${lib.getExe kata.kata-agent}";

--- a/packages/by-name/kata/kata-kernel-uvm/package.nix
+++ b/packages/by-name/kata/kata-kernel-uvm/package.nix
@@ -1,10 +1,11 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ fetchurl
-, linuxManualConfig
-, stdenvNoCC
-, fetchzip
+{
+  fetchurl,
+  linuxManualConfig,
+  stdenvNoCC,
+  fetchzip,
 }:
 
 let

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -1,10 +1,11 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ buildGoModule
-, fetchFromGitHub
-, yq-go
-, git
+{
+  buildGoModule,
+  fetchFromGitHub,
+  yq-go,
+  git,
 }:
 
 buildGoModule rec {

--- a/packages/by-name/kata/runtime-class-files/package.nix
+++ b/packages/by-name/kata/runtime-class-files/package.nix
@@ -1,10 +1,11 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ stdenvNoCC
-, kata
-, fetchzip
-, OVMF
+{
+  stdenvNoCC,
+  kata,
+  fetchzip,
+  OVMF,
 }:
 
 let
@@ -48,6 +49,13 @@ stdenvNoCC.mkDerivation {
   '';
 
   passthru = {
-    inherit kernel image qemu-bin containerd-shim-contrast-cc-v2 ovmf-code ovmf-vars;
+    inherit
+      kernel
+      image
+      qemu-bin
+      containerd-shim-contrast-cc-v2
+      ovmf-code
+      ovmf-vars
+      ;
   };
 }

--- a/packages/by-name/microsoft/cloud-hypervisor/package.nix
+++ b/packages/by-name/microsoft/cloud-hypervisor/package.nix
@@ -1,15 +1,16 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, openssl
-, patchelf
-, withIGVM ? true
-, withSEVSNP ? true
-, withTDX ? false
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  patchelf,
+  withIGVM ? true,
+  withSEVSNP ? true,
+  withTDX ? false,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -40,16 +41,21 @@ rustPlatform.buildRustPackage rec {
 
   separateDebugInfo = true;
 
-  nativeBuildInputs = [ pkg-config patchelf ];
+  nativeBuildInputs = [
+    pkg-config
+    patchelf
+  ];
   buildInputs = [ openssl ];
 
   buildNoDefaultFeatures = true;
-  buildFeatures = [
-    "mshv"
-    "kvm"
-  ] ++ lib.optional withIGVM [ "igvm" ]
-  ++ lib.optional withSEVSNP [ "snp" ]
-  ++ lib.optional withTDX [ "tdx" ];
+  buildFeatures =
+    [
+      "mshv"
+      "kvm"
+    ]
+    ++ lib.optional withIGVM [ "igvm" ]
+    ++ lib.optional withSEVSNP [ "snp" ]
+    ++ lib.optional withTDX [ "tdx" ];
 
   OPENSSL_NO_VENDOR = true;
 
@@ -67,7 +73,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/microsoft/cloud-hypervisor";
     description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM";
     changelog = "https://github.com/microsoft/cloud-hypervisor/releases/tag/msft/v${version}";
-    license = with lib.licenses; [ asl20 bsd3 ];
+    license = with lib.licenses; [
+      asl20
+      bsd3
+    ];
     mainProgram = "cloud-hypervisor";
   };
 }

--- a/packages/by-name/microsoft/contrast-node-installer-image/package.nix
+++ b/packages/by-name/microsoft/contrast-node-installer-image/package.nix
@@ -1,36 +1,59 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, ociLayerTar
-, ociImageManifest
-, ociImageLayout
-, contrast-node-installer
-, microsoft
-, pkgsStatic
-, writers
+{
+  lib,
+  ociLayerTar,
+  ociImageManifest,
+  ociImageLayout,
+  contrast-node-installer,
+  microsoft,
+  pkgsStatic,
+  writers,
 }:
 
 let
   node-installer = ociLayerTar {
     files = [
-      { source = lib.getExe contrast-node-installer; destination = "/bin/node-installer"; }
-      { source = "${pkgsStatic.util-linux}/bin/nsenter"; destination = "/bin/nsenter"; }
+      {
+        source = lib.getExe contrast-node-installer;
+        destination = "/bin/node-installer";
+      }
+      {
+        source = "${pkgsStatic.util-linux}/bin/nsenter";
+        destination = "/bin/nsenter";
+      }
     ];
   };
 
-  launch-digest = lib.removeSuffix "\n" (builtins.readFile "${microsoft.runtime-class-files}/launch-digest.hex");
-  runtime-handler = lib.removeSuffix "\n" (builtins.readFile "${microsoft.runtime-class-files}/runtime-handler");
+  launch-digest = lib.removeSuffix "\n" (
+    builtins.readFile "${microsoft.runtime-class-files}/launch-digest.hex"
+  );
+  runtime-handler = lib.removeSuffix "\n" (
+    builtins.readFile "${microsoft.runtime-class-files}/runtime-handler"
+  );
 
   installer-config = ociLayerTar {
     files = [
       {
         source = writers.writeJSON "contrast-node-install.json" {
           files = [
-            { url = "file:///opt/edgeless/share/kata-containers.img"; path = "/opt/edgeless/${runtime-handler}/share/kata-containers.img"; }
-            { url = "file:///opt/edgeless/share/kata-containers-igvm.img"; path = "/opt/edgeless/${runtime-handler}/share/kata-containers-igvm.img"; }
-            { url = "file:///opt/edgeless/bin/cloud-hypervisor-snp"; path = "/opt/edgeless/${runtime-handler}/bin/cloud-hypervisor-snp"; }
-            { url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2"; path = "/opt/edgeless/${runtime-handler}/bin/containerd-shim-contrast-cc-v2"; }
+            {
+              url = "file:///opt/edgeless/share/kata-containers.img";
+              path = "/opt/edgeless/${runtime-handler}/share/kata-containers.img";
+            }
+            {
+              url = "file:///opt/edgeless/share/kata-containers-igvm.img";
+              path = "/opt/edgeless/${runtime-handler}/share/kata-containers-igvm.img";
+            }
+            {
+              url = "file:///opt/edgeless/bin/cloud-hypervisor-snp";
+              path = "/opt/edgeless/${runtime-handler}/bin/cloud-hypervisor-snp";
+            }
+            {
+              url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2";
+              path = "/opt/edgeless/${runtime-handler}/bin/containerd-shim-contrast-cc-v2";
+            }
           ];
           runtimeHandlerName = runtime-handler;
           inherit (microsoft.runtime-class-files) debugRuntime;
@@ -42,50 +65,61 @@ let
 
   kata-container-img = ociLayerTar {
     files = [
-      { source = microsoft.runtime-class-files.rootfs; destination = "/opt/edgeless/share/kata-containers.img"; }
-      { source = microsoft.runtime-class-files.igvm; destination = "/opt/edgeless/share/kata-containers-igvm.img"; }
+      {
+        source = microsoft.runtime-class-files.rootfs;
+        destination = "/opt/edgeless/share/kata-containers.img";
+      }
+      {
+        source = microsoft.runtime-class-files.igvm;
+        destination = "/opt/edgeless/share/kata-containers-igvm.img";
+      }
     ];
   };
 
   cloud-hypervisor = ociLayerTar {
     files = [
-      { source = microsoft.runtime-class-files.cloud-hypervisor-exe; destination = "/opt/edgeless/bin/cloud-hypervisor-snp"; }
+      {
+        source = microsoft.runtime-class-files.cloud-hypervisor-exe;
+        destination = "/opt/edgeless/bin/cloud-hypervisor-snp";
+      }
     ];
   };
 
   containerd-shim = ociLayerTar {
-    files = [{ source = microsoft.runtime-class-files.containerd-shim-contrast-cc-v2; destination = "/opt/edgeless/bin/containerd-shim-contrast-cc-v2"; }];
+    files = [
+      {
+        source = microsoft.runtime-class-files.containerd-shim-contrast-cc-v2;
+        destination = "/opt/edgeless/bin/containerd-shim-contrast-cc-v2";
+      }
+    ];
   };
 
-  manifest = ociImageManifest
-    {
-      layers = [
-        node-installer
-        installer-config
-        kata-container-img
-        cloud-hypervisor
-        containerd-shim
-      ];
-      extraConfig = {
-        "config" = {
-          "Env" = [
-            "PATH=/bin:/usr/bin"
-            "CONFIG_DIR=/config"
-            "HOST_MOUNT=/host"
-          ];
-          "Entrypoint" = [ "/bin/node-installer" ];
-        };
-      };
-      extraManifest = {
-        "annotations" = {
-          "org.opencontainers.image.title" = "contrast-node-installer-microsoft";
-          "org.opencontainers.image.description" = "Contrast Node Installer (Microsoft)";
-          "systems.edgeless.contrast.snp-launch-digest" = launch-digest;
-        };
+  manifest = ociImageManifest {
+    layers = [
+      node-installer
+      installer-config
+      kata-container-img
+      cloud-hypervisor
+      containerd-shim
+    ];
+    extraConfig = {
+      "config" = {
+        "Env" = [
+          "PATH=/bin:/usr/bin"
+          "CONFIG_DIR=/config"
+          "HOST_MOUNT=/host"
+        ];
+        "Entrypoint" = [ "/bin/node-installer" ];
       };
     };
+    extraManifest = {
+      "annotations" = {
+        "org.opencontainers.image.title" = "contrast-node-installer-microsoft";
+        "org.opencontainers.image.description" = "Contrast Node Installer (Microsoft)";
+        "systems.edgeless.contrast.snp-launch-digest" = launch-digest;
+      };
+    };
+  };
 in
 
-ociImageLayout {
-  manifests = [ manifest ];
-}
+ociImageLayout { manifests = [ manifest ]; }

--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -1,18 +1,19 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, fetchFromGitHub
-, fetchpatch
-, applyPatches
-, stdenvNoCC
-, rustPlatform
-, openssl
-, pkg-config
-, libiconv
-, zlib
-, cmake
-, protobuf
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  applyPatches,
+  stdenvNoCC,
+  rustPlatform,
+  openssl,
+  pkg-config,
+  libiconv,
+  zlib,
+  cmake,
+  protobuf,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -67,7 +68,11 @@ rustPlatform.buildRustPackage rec {
       name = "${pname}-${version}-settings";
       inherit src sourceRoot;
 
-      phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+      phases = [
+        "unpackPhase"
+        "patchPhase"
+        "installPhase"
+      ];
       installPhase = ''
         runHook preInstall
         install -D genpolicy-settings.json $out/genpolicy-settings.json
@@ -90,7 +95,11 @@ rustPlatform.buildRustPackage rec {
       name = "${pname}-${version}-rules";
       inherit src sourceRoot;
 
-      phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+      phases = [
+        "unpackPhase"
+        "patchPhase"
+        "installPhase"
+      ];
       installPhase = ''
         runHook preInstall
         install -D rules.rego $out/genpolicy-rules.rego

--- a/packages/by-name/microsoft/kata-agent/package.nix
+++ b/packages/by-name/microsoft/kata-agent/package.nix
@@ -1,18 +1,19 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, cmake
-, pkg-config
-, protobuf
-, withSeccomp ? true
-, libseccomp
-, lvm2
-, openssl
-, withAgentPolicy ? true
-, withStandardOCIRuntime ? false
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  protobuf,
+  withSeccomp ? true,
+  libseccomp,
+  lvm2,
+  openssl,
+  withAgentPolicy ? true,
+  withStandardOCIRuntime ? false,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -42,16 +43,18 @@ rustPlatform.buildRustPackage rec {
     protobuf
   ];
 
-  buildInputs = [
-    openssl
-    openssl.dev
-    lvm2.dev
-    rustPlatform.bindgenHook
-  ] ++ lib.optionals withSeccomp [
-    libseccomp.dev
-    libseccomp.lib
-    libseccomp
-  ];
+  buildInputs =
+    [
+      openssl
+      openssl.dev
+      lvm2.dev
+      rustPlatform.bindgenHook
+    ]
+    ++ lib.optionals withSeccomp [
+      libseccomp.dev
+      libseccomp.lib
+      libseccomp
+    ];
 
   # Build.rs writes to src
   postConfigure = ''

--- a/packages/by-name/microsoft/kata-igvm/package.nix
+++ b/packages/by-name/microsoft/kata-igvm/package.nix
@@ -1,22 +1,24 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, stdenv
-, microsoft
-, igvm-tooling
-, igvm-signing-keygen
+{
+  lib,
+  stdenv,
+  microsoft,
+  igvm-tooling,
+  igvm-signing-keygen,
 }:
 
 stdenv.mkDerivation rec {
   pname = "kata-igvm";
   inherit (microsoft.genpolicy) src version;
 
-  outputs = [ "out" "debug" ];
-
-  nativeBuildInputs = [
-    igvm-tooling
+  outputs = [
+    "out"
+    "debug"
   ];
+
+  nativeBuildInputs = [ igvm-tooling ];
 
   sourceRoot = "${src.name}/tools/osbuilder/igvm-builder";
 

--- a/packages/by-name/microsoft/kata-image/package.nix
+++ b/packages/by-name/microsoft/kata-image/package.nix
@@ -1,27 +1,28 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, stdenv
-, stdenvNoCC
-, distro ? "cbl-mariner"
-, microsoft
-, bubblewrap
-, fakeroot
-, fetchFromGitHub
-, fetchurl
-, yq-go
-, tdnf
-, curl
-, util-linux
-, writeText
-, writeTextDir
-, createrepo_c
-, writeShellApplication
-, parted
-, cryptsetup
-, closureInfo
-, erofs-utils
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  distro ? "cbl-mariner",
+  microsoft,
+  bubblewrap,
+  fakeroot,
+  fetchFromGitHub,
+  fetchurl,
+  yq-go,
+  tdnf,
+  curl,
+  util-linux,
+  writeText,
+  writeTextDir,
+  createrepo_c,
+  writeShellApplication,
+  parted,
+  cryptsetup,
+  closureInfo,
+  erofs-utils,
 }:
 
 let
@@ -35,7 +36,11 @@ let
   # toplevelNixDeps are packages that get installed to the rootfs of the image
   # they are used to determine the (nix) closure of the rootfs
   toplevelNixDeps = [ microsoft.kata-agent ];
-  nixClosure = builtins.toString (lib.strings.splitString "\n" (builtins.readFile "${closureInfo {rootPaths = toplevelNixDeps;}}/store-paths"));
+  nixClosure = builtins.toString (
+    lib.strings.splitString "\n" (
+      builtins.readFile "${closureInfo { rootPaths = toplevelNixDeps; }}/store-paths"
+    )
+  );
   rootfsExtraTree = stdenvNoCC.mkDerivation {
     inherit src;
     pname = "rootfs-extra-tree";
@@ -62,8 +67,13 @@ let
     dontInstall = true;
   };
   packageIndex = builtins.fromJSON (builtins.readFile ./package-index.json);
-  rpmSources = lib.forEach packageIndex
-    (p: lib.concatStringsSep "#" [ (fetchurl p) (builtins.baseNameOf p.url) ]);
+  rpmSources = lib.forEach packageIndex (
+    p:
+    lib.concatStringsSep "#" [
+      (fetchurl p)
+      (builtins.baseNameOf p.url)
+    ]
+  );
 
   mirror = stdenvNoCC.mkDerivation {
     name = "mirror";
@@ -117,7 +127,10 @@ stdenv.mkDerivation rec {
   pname = "kata-image";
   version = kata-version;
 
-  outputs = [ "out" "verity" ];
+  outputs = [
+    "out"
+    "verity"
+  ];
 
   env = {
     AGENT_SOURCE_BIN = "${lib.getExe microsoft.kata-agent}";

--- a/packages/by-name/microsoft/kata-kernel-uvm/package.nix
+++ b/packages/by-name/microsoft/kata-kernel-uvm/package.nix
@@ -1,10 +1,11 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ fetchurl
-, microsoft
-, linuxManualConfig
-, patchutils
+{
+  fetchurl,
+  microsoft,
+  linuxManualConfig,
+  patchutils,
 }:
 
 let
@@ -18,7 +19,10 @@ let
     hash = "sha256-3vuwCOZHgmy0tV9tcgpIRjLxXa4EwNuWIbt9UkRUcDE=";
     downloadToTemp = true;
     recursiveHash = true;
-    nativeBuildInputs = [ tarfs_make patchutils ];
+    nativeBuildInputs = [
+      tarfs_make
+      patchutils
+    ];
     # create a diff where files under fs/tarfs are added to the kernel build
     # "a" is the kernel source tree without tarfs
     # "b" is the kernel source tree with tarfs
@@ -41,9 +45,15 @@ linuxManualConfig {
   };
   kernelPatches = [
     # this patches the existing Makefile and Kconfig to know about CONFIG_TARFS_FS and fs/tarfs
-    { name = "build_tarfs"; patch = ./0001-kernel-uvm-6-1-build-tarfs.patch; }
+    {
+      name = "build_tarfs";
+      patch = ./0001-kernel-uvm-6-1-build-tarfs.patch;
+    }
     # this adds fs/tarfs
-    { name = "tarfs"; patch = tarfs_patch; }
+    {
+      name = "tarfs";
+      patch = tarfs_patch;
+    }
   ];
   configfile = fetchurl {
     url = "https://raw.githubusercontent.com/microsoft/azurelinux/59ce246f224f282b3e199d9a2dacaa8011b75a06/SPECS/kernel-uvm/config";

--- a/packages/by-name/microsoft/kata-runtime/package.nix
+++ b/packages/by-name/microsoft/kata-runtime/package.nix
@@ -1,10 +1,11 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ buildGoModule
-, fetchFromGitHub
-, yq-go
-, git
+{
+  buildGoModule,
+  fetchFromGitHub,
+  yq-go,
+  git,
 }:
 
 buildGoModule rec {

--- a/packages/by-name/microsoft/runtime-class-files/package.nix
+++ b/packages/by-name/microsoft/runtime-class-files/package.nix
@@ -1,11 +1,12 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, stdenvNoCC
-, microsoft
-, igvmmeasure
-, debugRuntime ? false
+{
+  lib,
+  stdenvNoCC,
+  microsoft,
+  igvmmeasure,
+  debugRuntime ? false,
 }:
 
 let

--- a/packages/by-name/ociImageConfig/package.nix
+++ b/packages/by-name/ociImageConfig/package.nix
@@ -2,40 +2,55 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # application/vnd.oci.image.config.v1+json
-{ lib, runCommand, writers, nix }:
+{
+  lib,
+  runCommand,
+  writers,
+  nix,
+}:
 {
   # layers is a list of ociLayerTar
-  layers ? [ ]
+  layers ? [ ],
   # extraConfig is a set of extra configuration options
-, extraConfig ? { }
+  extraConfig ? { },
 }:
 
 let
   diffIDs = lib.lists.map (layer: builtins.readFile (layer + "/DiffID")) layers;
-  config = {
-    architecture = "amd64";
-    os = "linux";
-  } // extraConfig // {
-    rootfs = { type = "layers"; diff_ids = diffIDs; };
-  };
+  config =
+    {
+      architecture = "amd64";
+      os = "linux";
+    }
+    // extraConfig
+    // {
+      rootfs = {
+        type = "layers";
+        diff_ids = diffIDs;
+      };
+    };
   configJSON = writers.writeJSON "image-config.json" config;
 in
 
 runCommand "oci-image-config"
-{
-  buildInputs = [ nix ];
-  platformJSON = builtins.toJSON { inherit (config) architecture; inherit (config) os; };
-  inherit configJSON;
-} ''
-  # write the config to a file under blobs/sha256
-  mkdir -p $out/blobs/sha256
-  sha256=$(nix-hash --type sha256 --flat $configJSON)
-  cp $configJSON "$out/blobs/sha256/$sha256"
+  {
+    buildInputs = [ nix ];
+    platformJSON = builtins.toJSON {
+      inherit (config) architecture;
+      inherit (config) os;
+    };
+    inherit configJSON;
+  }
+  ''
+    # write the config to a file under blobs/sha256
+    mkdir -p $out/blobs/sha256
+    sha256=$(nix-hash --type sha256 --flat $configJSON)
+    cp $configJSON "$out/blobs/sha256/$sha256"
 
-  # create a symlink to the image config
-  ln -s "$out/blobs/sha256/$sha256" "$out/image-config.json"
-  # write the platform.json
-  echo "$platformJSON" > "$out/platform.json"
-  # write the media descriptor
-  echo -n "{\"mediaType\": \"application/vnd.oci.image.config.v1+json\", \"size\": $(stat -c %s $configJSON), \"digest\": \"sha256:$sha256\"}" > $out/media-descriptor.json
-''
+    # create a symlink to the image config
+    ln -s "$out/blobs/sha256/$sha256" "$out/image-config.json"
+    # write the platform.json
+    echo "$platformJSON" > "$out/platform.json"
+    # write the media descriptor
+    echo -n "{\"mediaType\": \"application/vnd.oci.image.config.v1+json\", \"size\": $(stat -c %s $configJSON), \"digest\": \"sha256:$sha256\"}" > $out/media-descriptor.json
+  ''

--- a/packages/by-name/ociImageLayout/package.nix
+++ b/packages/by-name/ociImageLayout/package.nix
@@ -2,45 +2,51 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # OCI image layout. Can be pushed to a registry or used as a local image.
-{ lib
-, runCommand
-, writers
-, nix
+{
+  lib,
+  runCommand,
+  writers,
+  nix,
 }:
 
 {
   # manifests is a list of ociImageManifest
-  manifests ? [ ]
+  manifests ? [ ],
   # extraIndex is a set of additional fields to add to the index.json
-, extraIndex ? { }
+  extraIndex ? { },
 }:
 
 let
-  manifestDescriptors = lib.lists.map (manifest: builtins.fromJSON (builtins.readFile (manifest + "/media-descriptor.json"))) manifests;
+  manifestDescriptors = lib.lists.map (
+    manifest: builtins.fromJSON (builtins.readFile (manifest + "/media-descriptor.json"))
+  ) manifests;
   index = writers.writeJSON "index.json" (
     {
       schemaVersion = 2;
       mediaType = "application/vnd.oci.image.index.v1+json";
-    } // extraIndex // {
+    }
+    // extraIndex
+    // {
       manifests = manifestDescriptors;
     }
   );
 in
 
 runCommand "oci-image-layout"
-{
-  buildInputs = [ nix ];
-  blobDirs = lib.lists.map (manifest: manifest + "/blobs/sha256") manifests;
-  inherit index;
-} ''
-  # add the index.json, image-layout file and all blobs to the output
-  srcs=($blobDirs)
-  mkdir -p $out/blobs/sha256
-  cp $index $out/index.json
-  echo '{"imageLayoutVersion": "1.0.0"}' > $out/image-layout
-  for src in $srcs; do
-    for blob in $(ls $src); do
-      ln -s "$(realpath $src/$blob)" "$out/blobs/sha256/$blob"
+  {
+    buildInputs = [ nix ];
+    blobDirs = lib.lists.map (manifest: manifest + "/blobs/sha256") manifests;
+    inherit index;
+  }
+  ''
+    # add the index.json, image-layout file and all blobs to the output
+    srcs=($blobDirs)
+    mkdir -p $out/blobs/sha256
+    cp $index $out/index.json
+    echo '{"imageLayoutVersion": "1.0.0"}' > $out/image-layout
+    for src in $srcs; do
+      for blob in $(ls $src); do
+        ln -s "$(realpath $src/$blob)" "$out/blobs/sha256/$blob"
+      done
     done
-  done
-''
+  ''

--- a/packages/by-name/ociImageManifest/package.nix
+++ b/packages/by-name/ociImageManifest/package.nix
@@ -2,50 +2,58 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 # application/vnd.oci.image.manifest.v1+json
-{ lib
-, ociImageConfig
-, runCommand
-, writers
-, nix
+{
+  lib,
+  ociImageConfig,
+  runCommand,
+  writers,
+  nix,
 }:
 {
   # layers is a list of ociLayerTar
-  layers ? [ ]
+  layers ? [ ],
   # extraConfig is a set of extra configuration options
-, extraConfig ? { }
+  extraConfig ? { },
   # extraManifest is a set of extra manifest options
-, extraManifest ? { }
+  extraManifest ? { },
 }:
 
 let
   config = ociImageConfig { inherit layers extraConfig; };
   configDescriptor = builtins.fromJSON (builtins.readFile (config + "/media-descriptor.json"));
   configPlatform = builtins.fromJSON (builtins.readFile (config + "/platform.json"));
-  layerDescriptors = lib.lists.map (layer: builtins.fromJSON (builtins.readFile (layer + "/media-descriptor.json"))) layers;
-  manifest = writers.writeJSON "image-manifest.json" ({
-    schemaVersion = 2;
-    mediaType = "application/vnd.oci.image.manifest.v1+json";
-  } // extraManifest // {
-    config = configDescriptor;
-    layers = layerDescriptors;
-  });
+  layerDescriptors = lib.lists.map (
+    layer: builtins.fromJSON (builtins.readFile (layer + "/media-descriptor.json"))
+  ) layers;
+  manifest = writers.writeJSON "image-manifest.json" (
+    {
+      schemaVersion = 2;
+      mediaType = "application/vnd.oci.image.manifest.v1+json";
+    }
+    // extraManifest
+    // {
+      config = configDescriptor;
+      layers = layerDescriptors;
+    }
+  );
 in
 
 runCommand "oci-image-manifest"
-{
-  blobDirs = lib.lists.map (layer: layer + "/blobs/sha256") (layers ++ [ config ]);
-  platformJSON = builtins.toJSON configPlatform;
-  buildInputs = [ nix ];
-  inherit manifest;
-} ''
-  mkdir -p $out/blobs/sha256
-  sha256=$(nix-hash --type sha256 --flat $manifest)
-  cp $manifest "$out/blobs/sha256/$sha256"
-  ln -s "$out/blobs/sha256/$sha256" "$out/image-manifest.json"
-  echo -n "{\"mediaType\": \"application/vnd.oci.image.manifest.v1+json\", \"size\": $(stat -c %s $manifest), \"digest\": \"sha256:$sha256\", \"platform\": $platformJSON}" > $out/media-descriptor.json
-  for src in $blobDirs; do
-    for blob in $(ls $src); do
-      ln -s "$src/$blob" "$out/blobs/sha256/$blob"
+  {
+    blobDirs = lib.lists.map (layer: layer + "/blobs/sha256") (layers ++ [ config ]);
+    platformJSON = builtins.toJSON configPlatform;
+    buildInputs = [ nix ];
+    inherit manifest;
+  }
+  ''
+    mkdir -p $out/blobs/sha256
+    sha256=$(nix-hash --type sha256 --flat $manifest)
+    cp $manifest "$out/blobs/sha256/$sha256"
+    ln -s "$out/blobs/sha256/$sha256" "$out/image-manifest.json"
+    echo -n "{\"mediaType\": \"application/vnd.oci.image.manifest.v1+json\", \"size\": $(stat -c %s $manifest), \"digest\": \"sha256:$sha256\", \"platform\": $platformJSON}" > $out/media-descriptor.json
+    for src in $blobDirs; do
+      for blob in $(ls $src); do
+        ln -s "$src/$blob" "$out/blobs/sha256/$blob"
+      done
     done
-  done
-''
+  ''

--- a/packages/by-name/ociLayerTar/package.nix
+++ b/packages/by-name/ociLayerTar/package.nix
@@ -4,64 +4,77 @@
 # application/vnd.oci.image.layer.v1.tar
 # application/vnd.oci.image.layer.v1.tar+gzip
 # application/vnd.oci.image.layer.v1.tar+zstd
-{ lib, runCommandLocal, nix, gzip, zstd }:
+{
+  lib,
+  runCommandLocal,
+  nix,
+  gzip,
+  zstd,
+}:
 {
   # files is a list of objects with the following attributes:
   #   source: the path to the file or directory to include in the layer
   #   destination: the path to place the file or directory in the layer
-  files ? [ ]
+  files ? [ ],
   # compression is the compression algorithm to use, either "gzip" or "zstd"
-, compression ? "gzip"
+  compression ? "gzip",
 }:
 
 runCommandLocal "ociLayer"
-{
-  fileSources = lib.lists.map (file: file.source) files;
-  fileDestinations = lib.lists.map (file: file.destination or file.source) files;
-  outPath = "layer" + (
-    if compression == "gzip" then ".tar.gz"
-    else if compression == "zstd" then ".tar.zst"
-    else ".tar"
-  );
-  mediaType = "application/vnd.oci.image.layer.v1.tar" + (if compression == "" then "" else "+" + compression);
-  nativeBuildInputs = [ nix ]
-    ++ lib.optional (compression == "gzip") gzip
-    ++ lib.optional (compression == "zstd") zstd;
-  inherit compression;
-} ''
-  set -o pipefail
-  srcs=($fileSources)
-  dests=($fileDestinations)
-  mkdir -p ./root $out
+  {
+    fileSources = lib.lists.map (file: file.source) files;
+    fileDestinations = lib.lists.map (file: file.destination or file.source) files;
+    outPath =
+      "layer"
+      + (
+        if compression == "gzip" then
+          ".tar.gz"
+        else if compression == "zstd" then
+          ".tar.zst"
+        else
+          ".tar"
+      );
+    mediaType =
+      "application/vnd.oci.image.layer.v1.tar" + (if compression == "" then "" else "+" + compression);
+    nativeBuildInputs = [
+      nix
+    ] ++ lib.optional (compression == "gzip") gzip ++ lib.optional (compression == "zstd") zstd;
+    inherit compression;
+  }
+  ''
+    set -o pipefail
+    srcs=($fileSources)
+    dests=($fileDestinations)
+    mkdir -p ./root $out
 
-  # Copy files into the tree (./root/)
-  for i in ''${!srcs[@]}; do
-      mkdir -p "./root/$(dirname ''${dests[$i]})"
-      cp -rT "''${srcs[i]}" "./root/''${dests[$i]}"
-  done
+    # Copy files into the tree (./root/)
+    for i in ''${!srcs[@]}; do
+        mkdir -p "./root/$(dirname ''${dests[$i]})"
+        cp -rT "''${srcs[i]}" "./root/''${dests[$i]}"
+    done
 
-  # Create the layer tarball
-  tar --sort=name --owner=root:0 --group=root:0 --mode=544 --mtime='UTC 1970-01-01' -cC ./root -f $out/layer.tar .
-  # Calculate the layer tarball's diffID (hash of the uncompressed tarball)
-  diffID=$(nix-hash --type sha256 --flat $out/layer.tar)
-  # Compress the layer tarball
-  if [[ "$compression" = "gzip" ]]; then
-    gzip -c $out/layer.tar > $out/$outPath
-  elif [[ "$compression" = "zstd" ]]; then
-    zstd -T0 -q -c $out/layer.tar > $out/$outPath
-  else
-    mv $out/layer.tar $out/$outPath
-  fi
-  rm -f $out/layer.tar
+    # Create the layer tarball
+    tar --sort=name --owner=root:0 --group=root:0 --mode=544 --mtime='UTC 1970-01-01' -cC ./root -f $out/layer.tar .
+    # Calculate the layer tarball's diffID (hash of the uncompressed tarball)
+    diffID=$(nix-hash --type sha256 --flat $out/layer.tar)
+    # Compress the layer tarball
+    if [[ "$compression" = "gzip" ]]; then
+      gzip -c $out/layer.tar > $out/$outPath
+    elif [[ "$compression" = "zstd" ]]; then
+      zstd -T0 -q -c $out/layer.tar > $out/$outPath
+    else
+      mv $out/layer.tar $out/$outPath
+    fi
+    rm -f $out/layer.tar
 
-  # Calculate the blob's sha256 hash and write the media descriptor
-  sha256=$(nix-hash --type sha256 --flat $out/$outPath)
-  echo -n "{\"mediaType\": \"$mediaType\", \"size\": $(stat -c %s $out/$outPath), \"digest\": \"sha256:$sha256\"}" > $out/media-descriptor.json
-  echo -n "sha256:$diffID" > $out/DiffID
+    # Calculate the blob's sha256 hash and write the media descriptor
+    sha256=$(nix-hash --type sha256 --flat $out/$outPath)
+    echo -n "{\"mediaType\": \"$mediaType\", \"size\": $(stat -c %s $out/$outPath), \"digest\": \"sha256:$sha256\"}" > $out/media-descriptor.json
+    echo -n "sha256:$diffID" > $out/DiffID
 
-  # Move the compressed layer tarball to the blobs directory and create a symlink
-  mkdir -p $out/blobs/sha256
-  mv $out/$outPath $out/blobs/sha256/$sha256
-  ln -s $out/blobs/sha256/$sha256 $out/$outPath
-  rm -rf ./root
-''
+    # Move the compressed layer tarball to the blobs directory and create a symlink
+    mkdir -p $out/blobs/sha256
+    mv $out/$outPath $out/blobs/sha256/$sha256
+    ln -s $out/blobs/sha256/$sha256 $out/$outPath
+    rm -rf ./root
+  ''

--- a/packages/by-name/rpm-pin-vendor/package.nix
+++ b/packages/by-name/rpm-pin-vendor/package.nix
@@ -1,18 +1,19 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, dnf-plugins-core
-, writeText
-, writeTextDir
-, writeShellApplication
-, runCommand
-, dnf4
-, jq
-, wget
-, python3
-, fakeroot
-, nix
+{
+  lib,
+  dnf-plugins-core,
+  writeText,
+  writeTextDir,
+  writeShellApplication,
+  runCommand,
+  dnf4,
+  jq,
+  wget,
+  python3,
+  fakeroot,
+  nix,
 }:
 
 let
@@ -36,7 +37,13 @@ let
   '';
   update_lockfile = writeShellApplication {
     name = "update_lockfile";
-    runtimeInputs = [ dnf4 jq wget nix fakeroot ];
+    runtimeInputs = [
+      dnf4
+      jq
+      wget
+      nix
+      fakeroot
+    ];
     text = builtins.readFile ./update_lockfile.sh;
   };
 in

--- a/packages/by-name/service-mesh/package.nix
+++ b/packages/by-name/service-mesh/package.nix
@@ -1,9 +1,7 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, buildGoModule
-}:
+{ lib, buildGoModule }:
 
 buildGoModule rec {
   pname = "service-mesh";

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -1,45 +1,53 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, pkgs
-, writeShellApplication
-, dockerTools
+{
+  lib,
+  pkgs,
+  writeShellApplication,
+  dockerTools,
 }:
 
 let
-  pushContainer = container: writeShellApplication {
-    name = "push-${container.name}";
-    runtimeInputs = with pkgs; [ crane gzip ];
-    text = ''
-      imageName="$1"
-      tmpdir=$(mktemp -d)
-      trap 'rm -rf $tmpdir' EXIT
-      gunzip < "${container}" > "$tmpdir/image.tar"
-      crane push "$tmpdir/image.tar" "$imageName:${container.imageTag}"
-    '';
-  };
+  pushContainer =
+    container:
+    writeShellApplication {
+      name = "push-${container.name}";
+      runtimeInputs = with pkgs; [
+        crane
+        gzip
+      ];
+      text = ''
+        imageName="$1"
+        tmpdir=$(mktemp -d)
+        trap 'rm -rf $tmpdir' EXIT
+        gunzip < "${container}" > "$tmpdir/image.tar"
+        crane push "$tmpdir/image.tar" "$imageName:${container.imageTag}"
+      '';
+    };
 
-  pushOCIDir = name: dir: tag: writeShellApplication {
-    name = "push-${name}";
-    runtimeInputs = with pkgs;  [ crane ];
-    text = ''
-      imageName="$1"
-      crane push "${dir}" "$imageName:${tag}"
-    '';
-  };
+  pushOCIDir =
+    name: dir: tag:
+    writeShellApplication {
+      name = "push-${name}";
+      runtimeInputs = with pkgs; [ crane ];
+      text = ''
+        imageName="$1"
+        crane push "${dir}" "$imageName:${tag}"
+      '';
+    };
 
   containers = {
     coordinator = dockerTools.buildImage {
       name = "coordinator";
       tag = "v${pkgs.contrast.version}";
-      copyToRoot = (with pkgs; [
-        util-linux
-        e2fsprogs
-        coreutils
-      ]) ++ (with dockerTools; [
-        caCertificates
-      ]);
+      copyToRoot =
+        (with pkgs; [
+          util-linux
+          e2fsprogs
+          coreutils
+        ])
+        ++ (with dockerTools; [ caCertificates ]);
       config = {
         Cmd = [ "${pkgs.contrast.coordinator}/bin/coordinator" ];
         Env = [ "PATH=/bin" ]; # This is only here for policy generation.
@@ -78,13 +86,19 @@ let
     port-forwarder = dockerTools.buildImage {
       name = "port-forwarder";
       tag = "v${pkgs.contrast.version}";
-      copyToRoot = with pkgs; [ bash socat ];
+      copyToRoot = with pkgs; [
+        bash
+        socat
+      ];
     };
 
     service-mesh-proxy = dockerTools.buildImage {
       name = "service-mesh-proxy";
       tag = "v${pkgs.service-mesh.version}";
-      copyToRoot = with pkgs; [ envoy iptables-legacy ];
+      copyToRoot = with pkgs; [
+        envoy
+        iptables-legacy
+      ];
       config = {
         Cmd = [ "${pkgs.service-mesh}/bin/service-mesh" ];
         Env = [ "PATH=/bin" ]; # This is only here for policy generation.
@@ -92,9 +106,13 @@ let
     };
   };
 in
-containers // {
-  push-node-installer-microsoft = pushOCIDir "push-node-installer-microsoft" pkgs.microsoft.contrast-node-installer-image "v${pkgs.contrast.version}";
-  push-node-installer-kata = pushOCIDir "push-node-installer-kata" pkgs.kata.contrast-node-installer-image "v${pkgs.contrast.version}";
-} // (
-  lib.concatMapAttrs (name: container: { "push-${name}" = pushContainer container; }) containers
-)
+containers
+// {
+  push-node-installer-microsoft =
+    pushOCIDir "push-node-installer-microsoft" pkgs.microsoft.contrast-node-installer-image
+      "v${pkgs.contrast.version}";
+  push-node-installer-kata =
+    pushOCIDir "push-node-installer-kata" pkgs.kata.contrast-node-installer-image
+      "v${pkgs.contrast.version}";
+}
+// (lib.concatMapAttrs (name: container: { "push-${name}" = pushContainer container; }) containers)

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -1,80 +1,94 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ lib
-, unzip
-, fetchurl
-, runCommand
-, installShellFiles
+{
+  lib,
+  unzip,
+  fetchurl,
+  runCommand,
+  installShellFiles,
 }:
 
 let
   json = builtins.fromJSON (builtins.readFile ./contrast-releases.json);
   listOrEmpty = list: field: if builtins.hasAttr field json then list.${field} else [ ];
-  findVersion = field: version: lib.lists.findFirst (obj: obj.version == version) { hash = "unknown"; } (listOrEmpty json field);
+  findVersion =
+    field: version:
+    lib.lists.findFirst (obj: obj.version == version) { hash = "unknown"; } (listOrEmpty json field);
 
-  buildContrastRelease = { version, hash }: {
-    name = builtins.replaceStrings [ "." ] [ "-" ] version;
-    value =
-      let
-        cli = fetchurl {
-          inherit hash version;
-          url = "https://github.com/edgelesssys/contrast/releases/download/${version}/contrast";
-        };
+  buildContrastRelease =
+    { version, hash }:
+    {
+      name = builtins.replaceStrings [ "." ] [ "-" ] version;
+      value =
+        let
+          cli = fetchurl {
+            inherit hash version;
+            url = "https://github.com/edgelesssys/contrast/releases/download/${version}/contrast";
+          };
 
-        coordinator = fetchurl {
-          inherit version;
-          url = "https://github.com/edgelesssys/contrast/releases/download/${version}/coordinator.yml";
-          inherit (findVersion "coordinator.yml" version) hash;
-        };
+          coordinator = fetchurl {
+            inherit version;
+            url = "https://github.com/edgelesssys/contrast/releases/download/${version}/coordinator.yml";
+            inherit (findVersion "coordinator.yml" version) hash;
+          };
 
-        runtime = fetchurl {
-          inherit version;
-          url = "https://github.com/edgelesssys/contrast/releases/download/${version}/runtime.yml";
-          inherit (findVersion "runtime.yml" version) hash;
-          # runtime.yml was introduced in release v0.6.0
-          passthru.exists = (builtins.compareVersions "v0.6.0" version) <= 0;
-        };
+          runtime = fetchurl {
+            inherit version;
+            url = "https://github.com/edgelesssys/contrast/releases/download/${version}/runtime.yml";
+            inherit (findVersion "runtime.yml" version) hash;
+            # runtime.yml was introduced in release v0.6.0
+            passthru.exists = (builtins.compareVersions "v0.6.0" version) <= 0;
+          };
 
-        emojivoto-zip = fetchurl {
-          # fetchurl instead of fetchzip since the hashes in contrast-release.json are computed from the zip file
-          inherit version;
-          url = "https://github.com/edgelesssys/contrast/releases/download/${version}/emojivoto-demo.zip";
-          inherit (findVersion "emojivoto-demo.zip" version) hash;
-          # emojivoto-demo.zip was introduced in version v0.5.0
-          passthru.exists = (builtins.compareVersions "v0.5.0" version) <= 0 && (builtins.compareVersions version "v0.8.0") < 0;
-        };
+          emojivoto-zip = fetchurl {
+            # fetchurl instead of fetchzip since the hashes in contrast-release.json are computed from the zip file
+            inherit version;
+            url = "https://github.com/edgelesssys/contrast/releases/download/${version}/emojivoto-demo.zip";
+            inherit (findVersion "emojivoto-demo.zip" version) hash;
+            # emojivoto-demo.zip was introduced in version v0.5.0
+            passthru.exists =
+              (builtins.compareVersions "v0.5.0" version) <= 0 && (builtins.compareVersions version "v0.8.0") < 0;
+          };
 
-        emojivoto = fetchurl {
-          inherit version;
-          url = "https://github.com/edgelesssys/contrast/releases/download/${version}/emojivoto-demo.yml";
-          inherit (findVersion "emojivoto-demo.yml" version) hash;
-          # emojivoto-demo.yml was changed from zip to yml in version v0.8.0
-          passthru.exists = (builtins.compareVersions "v0.8.0" version) <= 0;
-        };
-      in
-      runCommand version
-        {
-          buildInputs = [ unzip installShellFiles ]; # needed to unzip emojivoto-demo.zip
-        }
-        (''
-          mkdir -p $out/bin
-          install -m 777 ${cli} $out/bin/contrast
-          installShellCompletion --cmd contrast \
-            --bash <($out/bin/contrast completion bash) \
-            --fish <($out/bin/contrast completion fish) \
-            --zsh <($out/bin/contrast completion zsh)
+          emojivoto = fetchurl {
+            inherit version;
+            url = "https://github.com/edgelesssys/contrast/releases/download/${version}/emojivoto-demo.yml";
+            inherit (findVersion "emojivoto-demo.yml" version) hash;
+            # emojivoto-demo.yml was changed from zip to yml in version v0.8.0
+            passthru.exists = (builtins.compareVersions "v0.8.0" version) <= 0;
+          };
+        in
+        runCommand version
+          {
+            buildInputs = [
+              unzip
+              installShellFiles
+            ]; # needed to unzip emojivoto-demo.zip
+          }
+          (
+            ''
+              mkdir -p $out/bin
+              install -m 777 ${cli} $out/bin/contrast
+              installShellCompletion --cmd contrast \
+                --bash <($out/bin/contrast completion bash) \
+                --fish <($out/bin/contrast completion fish) \
+                --zsh <($out/bin/contrast completion zsh)
 
-          install -m 644 ${coordinator} $out/coordinator.yml
-        '' + lib.optionalString runtime.exists ''
-          install -m 644 ${runtime} $out/runtime.yml
-        '' + lib.optionalString emojivoto-zip.exists ''
-          unzip ${emojivoto-zip} -d $out
-        '' + lib.optionalString emojivoto.exists ''
-          mkdir -p $out/deployment
-          install -m 644 ${emojivoto} $out/deployment/emojivoto-demo.yml
-        '');
-  };
+              install -m 644 ${coordinator} $out/coordinator.yml
+            ''
+            + lib.optionalString runtime.exists ''
+              install -m 644 ${runtime} $out/runtime.yml
+            ''
+            + lib.optionalString emojivoto-zip.exists ''
+              unzip ${emojivoto-zip} -d $out
+            ''
+            + lib.optionalString emojivoto.exists ''
+              mkdir -p $out/deployment
+              install -m 644 ${emojivoto} $out/deployment/emojivoto-demo.yml
+            ''
+          );
+    };
   releases = builtins.listToAttrs (builtins.map buildContrastRelease json.contrast);
   latestVersion = builtins.replaceStrings [ "." ] [ "-" ] (lib.last json.contrast).version;
 in

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -1,9 +1,7 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-{ pkgs
-, writeShellApplication
-}:
+{ pkgs, writeShellApplication }:
 
 {
   create-coco-aks = writeShellApplication {
@@ -56,7 +54,10 @@
 
   govulncheck = writeShellApplication {
     name = "govulncheck";
-    runtimeInputs = with pkgs; [ go govulncheck ];
+    runtimeInputs = with pkgs; [
+      go
+      govulncheck
+    ];
     text = ''
       exitcode=0
 
@@ -71,7 +72,10 @@
 
   golangci-lint = writeShellApplication {
     name = "golangci-lint";
-    runtimeInputs = with pkgs; [ go golangci-lint ];
+    runtimeInputs = with pkgs; [
+      go
+      golangci-lint
+    ];
     text = ''
       exitcode=0
 
@@ -216,15 +220,17 @@
 
   update-contrast-releases = writeShellApplication {
     name = "update-contrast-releases";
-    runtimeInputs = with pkgs; [
-      jq
-    ];
+    runtimeInputs = with pkgs; [ jq ];
     text = builtins.readFile ./update-contrast-releases.sh;
   };
 
   update-release-urls = writeShellApplication {
     name = "update-release-urls";
-    runtimeInputs = with pkgs; [ coreutils findutils gnused ];
+    runtimeInputs = with pkgs; [
+      coreutils
+      findutils
+      gnused
+    ];
     text = ''
       tag="[a-zA-Z0-9_.-]\{1,\}"
       sha="@sha256:[a-fA-F0-9]\{64\}"
@@ -257,7 +263,10 @@
   # Usage: cat events.log | parse-blocked-by-policy
   parse-blocked-by-policy = writeShellApplication {
     name = "parse-blocked-by-policy";
-    runtimeInputs = with pkgs; [ gnugrep gnused ];
+    runtimeInputs = with pkgs; [
+      gnugrep
+      gnused
+    ];
     text = ''
       set -euo pipefail
       grep "CreateContainerRequest is blocked by policy" |

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -15,7 +15,7 @@
     };
     just.enable = true;
     keep-sorted.enable = true;
-    nixpkgs-fmt.enable = true;
+    nixfmt.enable = true;
     shellcheck.enable = true;
     shfmt.enable = true;
     statix.enable = true;

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -36,13 +36,16 @@
       ];
     };
     vale = {
-      command = "${pkgs.vale.withStyles (s: with s; [ microsoft google ])}/bin/vale";
-      options = [
-        "--no-wrap"
-      ];
-      includes = [
-        "*.md"
-      ];
+      command = "${
+        pkgs.vale.withStyles (
+          s: with s; [
+            microsoft
+            google
+          ]
+        )
+      }/bin/vale";
+      options = [ "--no-wrap" ];
+      includes = [ "*.md" ];
       excludes = [
         "CODE_OF_CONDUCT.md"
         "LICENSE"
@@ -52,10 +55,11 @@
     # https://github.com/numtide/treefmt-nix/pull/193 is merged.
     yamlfmt = {
       command = "${lib.getExe pkgs.yamlfmt}";
-      options = [
-        "-formatter=retain_line_breaks_single=true"
+      options = [ "-formatter=retain_line_breaks_single=true" ];
+      includes = [
+        "*.yaml"
+        "*.yml"
       ];
-      includes = [ "*.yaml" "*.yml" ];
     };
   };
 }


### PR DESCRIPTION
nixpkgs is about to switch from nixpkgs-fmt to nixfmt(-rfc-style), and as we follow nixpkgs practices closely, we should do that switch, too.

cc @miampf @burgerdev @Freax13 @3u13r 

In case you are using nixd vscode extension, you should update your config to set [nixfmt-rfc-style](https://search.nixos.org/packages?channel=unstable&show=nixfmt-rfc-style&from=0&size=50&sort=relevance&type=packages&query=nixfmt-rfc-style) as formatter:

```nix
      "nix.serverSettings" = {
        "nixd" = {
          "formatting" = {
            "command" = [ "${lib.getExe pkgs.nixfmt-rfc-style}" ];
          };
        };
      };
```