### PR TITLE
git: add formatting commits to blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Formatting commits
+e69eddf72139e3751fda75ca391ce7aad88cf3c4
+89dd79f55b6d7150b2456aaa068084f62ac67cc3


### PR DESCRIPTION
You might need to run `git config blame.ignoreRevsFile .git-blame-ignore-revs`.