### PR TITLE
node-installer: use full OVMF image on bare-metal TDX

### DIFF
--- a/node-installer/internal/constants/constants.go
+++ b/node-installer/internal/constants/constants.go
@@ -54,8 +54,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, debug bool) 
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
 		config.Hypervisor["qemu"]["path"] = filepath.Join(baseDir, "bin", "qemu-system-x86_64")
-		config.Hypervisor["qemu"]["firmware"] = filepath.Join(baseDir, "shae", "OVMF_CODE.fd")
-		config.Hypervisor["qemu"]["firmware_volume"] = filepath.Join(baseDir, "share", "OVMF_VARS.fd")
+		config.Hypervisor["qemu"]["firmware"] = filepath.Join(baseDir, "share", "OVMF.fd")
 		config.Hypervisor["qemu"]["image"] = filepath.Join(baseDir, "share", "kata-containers.img")
 		config.Hypervisor["qemu"]["kernel"] = filepath.Join(baseDir, "share", "kata-kernel")
 		config.Hypervisor["qemu"]["valid_hypervisor_paths"] = []string{filepath.Join(baseDir, "bin", "qemu-system-x86_64")}

--- a/packages/by-name/kata/contrast-node-installer-image/package.nix
+++ b/packages/by-name/kata/contrast-node-installer-image/package.nix
@@ -51,12 +51,8 @@ let
               path = "/opt/edgeless/${runtime-handler}/bin/qemu-system-x86_64";
             }
             {
-              url = "file:///opt/edgeless/share/OVMF_CODE.fd";
-              path = "/opt/edgeless/${runtime-handler}/share/OVMF_CODE.fd";
-            }
-            {
-              url = "file:///opt/edgeless/share/OVMF_VARS.fd";
-              path = "/opt/edgeless/${runtime-handler}/share/OVMF_VARS.fd";
+              url = "file:///opt/edgeless/share/OVMF.fd";
+              path = "/opt/edgeless/${runtime-handler}/share/OVMF.fd";
             }
             {
               url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2";
@@ -87,12 +83,8 @@ let
   ovmf = ociLayerTar {
     files = [
       {
-        source = kata.runtime-class-files.ovmf-code;
-        destination = "/opt/edgeless/share/OVMF_CODE.fd";
-      }
-      {
-        source = kata.runtime-class-files.ovmf-vars;
-        destination = "/opt/edgeless/share/OVMF_VARS.fd";
+        source = kata.runtime-class-files.ovmf;
+        destination = "/opt/edgeless/share/OVMF.fd";
       }
     ];
   };

--- a/packages/by-name/kata/runtime-class-files/package.nix
+++ b/packages/by-name/kata/runtime-class-files/package.nix
@@ -29,8 +29,7 @@ let
     '';
   };
 
-  ovmf-code = OVMF.firmware;
-  ovmf-vars = OVMF.variables;
+  ovmf = "${OVMF.fd}/FV/OVMF.fd";
 
   containerd-shim-contrast-cc-v2 = "${kata.kata-runtime}/bin/containerd-shim-kata-v2";
 in
@@ -44,7 +43,7 @@ stdenvNoCC.mkDerivation {
   # TODO(msanft): perform the actual launch digest calculation.
   buildPhase = ''
     mkdir -p $out
-    sha256sum ${image} ${kernel} ${qemu-bin} ${containerd-shim-contrast-cc-v2} ${ovmf-code} ${ovmf-vars} | sha256sum | cut -d " " -f 1 > $out/launch-digest.hex
+    sha256sum ${image} ${kernel} ${qemu-bin} ${containerd-shim-contrast-cc-v2} ${ovmf} | sha256sum | cut -d " " -f 1 > $out/launch-digest.hex
     printf "contrast-cc-%s" "$(cat $out/launch-digest.hex | head -c 32)" > $out/runtime-handler
   '';
 
@@ -54,8 +53,7 @@ stdenvNoCC.mkDerivation {
       image
       qemu-bin
       containerd-shim-contrast-cc-v2
-      ovmf-code
-      ovmf-vars
+      ovmf
       ;
   };
 }


### PR DESCRIPTION
Specifying separate OVMF EFI variables and code is not possible on TDX since pflash devices are unsupported. This fixes this by specifying a full bundled OVMF image.

related-to: https://github.com/kata-containers/kata-containers/commit/3e158001993cc2356d6ac084e6c82714210c9f24