### PR TITLE
packages: package bare-metal kata-runtime tool

### DIFF
--- a/packages/by-name/kata/contrast-node-installer-image/package.nix
+++ b/packages/by-name/kata/contrast-node-installer-image/package.nix
@@ -58,6 +58,10 @@ let
               url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2";
               path = "/opt/edgeless/${runtime-handler}/bin/containerd-shim-contrast-cc-v2";
             }
+            {
+              url = "file:///opt/edgeless/bin/kata-runtime";
+              path = "/opt/edgeless/${runtime-handler}/bin/kata-runtime";
+            }
           ];
           runtimeHandlerName = runtime-handler;
           inherit (kata.runtime-class-files) debugRuntime;
@@ -98,8 +102,12 @@ let
     ];
   };
 
-  containerd-shim = ociLayerTar {
+  kata-runtime = ociLayerTar {
     files = [
+      {
+        source = kata.runtime-class-files.kata-runtime;
+        destination = "/opt/edgeless/bin/kata-runtime";
+      }
       {
         source = kata.runtime-class-files.containerd-shim-contrast-cc-v2;
         destination = "/opt/edgeless/bin/containerd-shim-contrast-cc-v2";
@@ -114,7 +122,7 @@ let
       kata-container-img
       ovmf
       qemu
-      containerd-shim
+      kata-runtime
     ];
     extraConfig = {
       "config" = {

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -26,9 +26,7 @@ buildGoModule rec {
   subPackages = [
     "cmd/containerd-shim-kata-v2"
     "cmd/kata-monitor"
-    # TODO(msanft): enable kata-runtime
-    # It depends on CGO and kvm
-    # "cmd/kata-runtime"
+    "cmd/kata-runtime"
   ];
 
   preBuild = ''
@@ -44,8 +42,12 @@ buildGoModule rec {
     git
   ];
 
-  CGO_ENABLED = 0;
   ldflags = [ "-s" ];
+
+  # Hack to skip all kata-runtime tests, which require a Git repo.
+  preCheck = ''
+    rm cmd/kata-runtime/*_test.go
+  '';
 
   checkFlags =
     let

--- a/packages/by-name/kata/runtime-class-files/package.nix
+++ b/packages/by-name/kata/runtime-class-files/package.nix
@@ -32,6 +32,8 @@ let
   ovmf = "${OVMF.fd}/FV/OVMF.fd";
 
   containerd-shim-contrast-cc-v2 = "${kata.kata-runtime}/bin/containerd-shim-kata-v2";
+
+  kata-runtime = "${kata.kata-runtime}/bin/kata-runtime";
 in
 
 stdenvNoCC.mkDerivation {
@@ -54,6 +56,7 @@ stdenvNoCC.mkDerivation {
       qemu-bin
       containerd-shim-contrast-cc-v2
       ovmf
+      kata-runtime
       ;
   };
 }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -22,6 +22,7 @@ let
       genpolicy = pkgs.pkgsStatic.callPackage ./by-name/kata/genpolicy/package.nix {
         inherit (self) kata; # This is only to inherit src/version, must not be depended on.
       };
+      kata-runtime = pkgs.pkgsStatic.callPackage ./by-name/kata/kata-runtime/package.nix { };
     };
   };
 in


### PR DESCRIPTION
This packages a statically compiled version of the `kata-runtime` command line tool that's especially useful for debugging into Kata CVMs. On AKS, this is not necessary as of now, as the nodes contain the upstream version of the tool, and including the statically compiled version woul only bloat the node-installer image.