### PR TITLE
cli: use platform string for reference-values flag

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -159,7 +159,7 @@ After that, it will generate the execution policies and add them as annotations 
 A `manifest.json` with the reference values of your deployment will be created.
 
 ```sh
-contrast generate --reference-values aks resources/
+contrast generate --reference-values aks-clh-snp resources/
 ```
 
 :::warning
@@ -177,7 +177,7 @@ You can disable the Initializer injection completely by specifying the
 `--skip-initializer` flag in the `generate` command.
 
 ```sh
-contrast generate --reference-values aks --skip-initializer resources/
+contrast generate --reference-values aks-clh-snp --skip-initializer resources/
 ```
 
 </TabItem>

--- a/docs/docs/examples/emojivoto.md
+++ b/docs/docs/examples/emojivoto.md
@@ -70,7 +70,7 @@ annotations to your deployment files. A `manifest.json` file with the reference 
 of your deployment will be created:
 
 ```sh
-contrast generate --reference-values aks deployment/
+contrast generate --reference-values aks-clh-snp deployment/
 ```
 
 :::note[Runtime class and Initializer]

--- a/e2e/genpolicy/genpolicy_test.go
+++ b/e2e/genpolicy/genpolicy_test.go
@@ -41,7 +41,7 @@ func TestGenpolicy(t *testing.T) {
 				require := require.New(t)
 				args := []string{
 					"--workspace-dir", ct.WorkDir,
-					"--reference-values", "aks",
+					"--reference-values", "aks-clh-snp",
 					"--skip-initializer",
 					path.Join(ct.WorkDir, "resources.yaml"),
 				}

--- a/e2e/getdents/getdents_test.go
+++ b/e2e/getdents/getdents_test.go
@@ -44,7 +44,7 @@ func TestGetDEnts(t *testing.T) {
 		require := require.New(t)
 		args := []string{
 			"--workspace-dir", ct.WorkDir,
-			"--reference-values", "aks",
+			"--reference-values", "aks-clh-snp",
 			"--skip-initializer",
 			path.Join(ct.WorkDir, "resources.yaml"),
 		}

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -138,7 +138,7 @@ func (ct *ContrastTest) Generate(t *testing.T) {
 	args := append(
 		ct.commonArgs(),
 		"--image-replacements", ct.ImageReplacementsFile,
-		"--reference-values", "aks",
+		"--reference-values", "aks-clh-snp",
 		path.Join(ct.WorkDir, "resources.yaml"),
 	)
 

--- a/justfile
+++ b/justfile
@@ -83,7 +83,7 @@ generate cli=default_cli:
     nix run .#{{ cli }} -- generate \
         --workspace-dir ./{{ workspace_dir }} \
         --image-replacements ./{{ workspace_dir }}/just.containerlookup \
-        --reference-values aks \
+        --reference-values aks-clh-snp \
         ./{{ workspace_dir }}/deployment/*.yml
     duration=$(( $(date +%s) - $t ))
     echo "Generated policies in $duration seconds."

--- a/node-installer/platforms/platforms.go
+++ b/node-installer/platforms/platforms.go
@@ -5,7 +5,10 @@
 // of Contrast.
 package platforms
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Platform is a type that represents a deployment platform of Contrast.
 type Platform int
@@ -20,6 +23,20 @@ const (
 	// RKE2QEMUTDX represents a deployment with QEMU on bare-metal TDX RKE2.
 	RKE2QEMUTDX
 )
+
+// All returns a list of all available platforms.
+func All() []Platform {
+	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, RKE2QEMUTDX}
+}
+
+// AllStrings returns a list of all available platforms as strings.
+func AllStrings() []string {
+	platformStrings := make([]string, 0, len(All()))
+	for _, p := range All() {
+		platformStrings = append(platformStrings, p.String())
+	}
+	return platformStrings
+}
 
 // String returns the string representation of the Platform type.
 func (p Platform) String() string {
@@ -37,12 +54,12 @@ func (p Platform) String() string {
 
 // FromString returns the Platform type corresponding to the given string.
 func FromString(s string) (Platform, error) {
-	switch s {
-	case "AKS-CLH-SNP":
+	switch strings.ToLower(s) {
+	case "aks-clh-snp":
 		return AKSCloudHypervisorSNP, nil
-	case "K3s-QEMU-TDX":
+	case "k3s-qemu-tdx":
 		return K3sQEMUTDX, nil
-	case "RKE2-QEMU-TDX":
+	case "rke2-qemu-tdx":
 		return RKE2QEMUTDX, nil
 	default:
 		return Unknown, fmt.Errorf("unknown platform: %s", s)


### PR DESCRIPTION
For consistency, we should use the platform string for the reference-values flag in the CLI.