### PR TITLE
packages: mount configfs into bare-metal kata agent

### DIFF
--- a/packages/by-name/kata/kata-agent/package.nix
+++ b/packages/by-name/kata/kata-agent/package.nix
@@ -14,6 +14,7 @@
   openssl,
   withAgentPolicy ? true,
   withStandardOCIRuntime ? false,
+  fetchpatch,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -30,6 +31,15 @@ rustPlatform.buildRustPackage rec {
       "sigstore-0.8.0" = "sha256-lmcokyIx4R84miC8Rf3NjV3QS6XffbhzQeZGCM0u7lc=";
     };
   };
+
+  patches = [
+    # Mount configfs into the workload container from the UVM.
+    (fetchpatch {
+      url = "https://github.com/kata-containers/kata-containers/commit/779152b91b20b22009d215887d06908c638d2efc.patch";
+      stripLen = 2;
+      hash = "sha256-gs1EgD+1Ol9rg0oo14WFQ3H7GCAU5EQrXSuQW+DtEWk=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/packages/by-name/kata/runtime-class-files/package.nix
+++ b/packages/by-name/kata/runtime-class-files/package.nix
@@ -14,21 +14,25 @@ let
   kernel = "${kata.kata-kernel-uvm}/bzImage";
 
   # TODO(msanft): building a static qemu with nix.
-  qemu-bin = stdenvNoCC.mkDerivation rec {
-    pname = "qemu-static-kata";
-    version = "3.6.0";
+  qemu-bin =
+    let
+      qemuDrv = stdenvNoCC.mkDerivation rec {
+        pname = "qemu-static-kata";
+        version = "3.6.0";
 
-    src = fetchzip {
-      url = "https://github.com/kata-containers/kata-containers/releases/download/${version}/kata-static-${version}-amd64.tar.xz";
-      hash = "sha256-ynMzMoJ90BzKuE6ih6DmbM2zWTDxsMwkAKsI8pbO3sg=";
-    };
+        src = fetchzip {
+          url = "https://github.com/kata-containers/kata-containers/releases/download/${version}/kata-static-${version}-amd64.tar.xz";
+          hash = "sha256-ynMzMoJ90BzKuE6ih6DmbM2zWTDxsMwkAKsI8pbO3sg=";
+        };
 
-    dontBuild = true;
+        dontBuild = true;
 
-    installPhase = ''
-      install -Dt $out/bin kata/bin/qemu-system-x86_64
-    '';
-  };
+        installPhase = ''
+          install -Dt $out/bin kata/bin/qemu-system-x86_64
+        '';
+      };
+    in
+    "${qemuDrv}/bin/qemu-system-x86_64";
 
   ovmf = "${OVMF.fd}/FV/OVMF.fd";
 

--- a/packages/by-name/kata/runtime-class-files/package.nix
+++ b/packages/by-name/kata/runtime-class-files/package.nix
@@ -6,6 +6,7 @@
   kata,
   fetchzip,
   OVMF,
+  debugRuntime ? false,
 }:
 
 let
@@ -57,6 +58,7 @@ stdenvNoCC.mkDerivation {
       containerd-shim-contrast-cc-v2
       ovmf
       kata-runtime
+      debugRuntime
       ;
   };
 }


### PR DESCRIPTION
This adds an upstream patch mounting the configfs for CC report querying into the guest container through the Kata agent.