### PR TITLE
kata: add patches for bare metal SNP

### DIFF
--- a/packages/by-name/kata/genpolicy/package.nix
+++ b/packages/by-name/kata/genpolicy/package.nix
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage rec {
   passthru = {
     settings = fetchurl {
       name = "${pname}-${version}-settings";
-      url = "https://raw.githubusercontent.com/kata-containers/kata-containers/${src.rev}/src/tools/genpolicy/genpolicy-settings.json";
+      url = "https://raw.githubusercontent.com/kata-containers/kata-containers/${version}/src/tools/genpolicy/genpolicy-settings.json";
       hash = "sha256-Rlm1BOo0/yNHBf17p2Mk7ta6VbaGcrgezCk8mraFPtU=";
       downloadToTemp = true;
       recursiveHash = true;
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage rec {
 
     rules = fetchurl {
       name = "${pname}-${version}-rules";
-      url = "https://raw.githubusercontent.com/kata-containers/kata-containers/${src.rev}/src/tools/genpolicy/rules.rego";
+      url = "https://raw.githubusercontent.com/kata-containers/kata-containers/${version}/src/tools/genpolicy/rules.rego";
       hash = "sha256-J4WIgEgCzm3vEji9f/0kF+gLdE8ziio4PAyRWUJjqZk=";
       downloadToTemp = true;
       recursiveHash = true;

--- a/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
+++ b/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
@@ -1,0 +1,28 @@
+From 2ba6a74a1c10c740540e572f3cab7dc2dd664cc8 Mon Sep 17 00:00:00 2001
+From: Tom Dohrmann <erbse.13@gmx.de>
+Date: Fri, 5 Jul 2024 08:43:13 +0000
+Subject: [PATCH 1/3] govmm: Directly pass the firwmare using -bios with SNP
+
+3e158001993cc2356d6ac084e6c82714210c9f24, but for SNP.
+---
+ src/runtime/pkg/govmm/qemu/qemu.go | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/runtime/pkg/govmm/qemu/qemu.go b/src/runtime/pkg/govmm/qemu/qemu.go
+index e752f8181..dadbe8b35 100644
+--- a/src/runtime/pkg/govmm/qemu/qemu.go
++++ b/src/runtime/pkg/govmm/qemu/qemu.go
+@@ -388,9 +388,7 @@ func (object Object) QemuParams(config *Config) []string {
+ 		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
+ 		objectParams = append(objectParams, fmt.Sprintf("reduced-phys-bits=%d", object.ReducedPhysBits))
+ 		objectParams = append(objectParams, "kernel-hashes=on")
+-
+-		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
+-		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))
++		config.Bios = object.File
+ 	case SecExecGuest:
+ 		objectParams = append(objectParams, string(object.Type))
+ 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
+-- 
+2.34.1
+

--- a/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
+++ b/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
@@ -1,0 +1,40 @@
+From 5f827c88c43c0e3143543d59f8b6f12a7b936832 Mon Sep 17 00:00:00 2001
+From: Tom Dohrmann <erbse.13@gmx.de>
+Date: Mon, 8 Jul 2024 07:35:54 +0000
+Subject: [PATCH 2/3] emulate CPU model that most closely matches the host
+
+QEMU's CPU model 'host' still doesn't support SNP, but by using the
+correct model, the guest is able to figure out the correct CPU model
+which is important for fetching the correct ARK/ASK certificates for
+attestation.
+---
+ src/runtime/virtcontainers/qemu_amd64.go | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/runtime/virtcontainers/qemu_amd64.go b/src/runtime/virtcontainers/qemu_amd64.go
+index ade7356eb..ca8f9998c 100644
+--- a/src/runtime/virtcontainers/qemu_amd64.go
++++ b/src/runtime/virtcontainers/qemu_amd64.go
+@@ -188,7 +188,18 @@ func (q *qemuAmd64) cpuModel() string {
+ 	protection, err := availableGuestProtection()
+ 	if err == nil {
+ 		if protection == snpProtection && q.snpGuest {
+-			cpuModel = "EPYC-v4"
++			// Decide which CPU model line to emulate based on the host CPU's
++			// model value.
++			switch cpuid.DisplayModel {
++			case 0x01:
++				cpuModel = "EPYC-Milan"
++			case 0x11:
++				cpuModel = "EPYC-Genoa"
++			default:
++				// Fall back to a generic CPU.
++				cpuModel = "EPYC-v4"
++			}
++
+ 		}
+ 	}
+ 
+-- 
+2.34.1
+

--- a/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
+++ b/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
@@ -1,0 +1,1285 @@
+From 4beb630e5184338075996bda2b8669ff464d44be Mon Sep 17 00:00:00 2001
+From: Tom Dohrmann <erbse.13@gmx.de>
+Date: Mon, 8 Jul 2024 07:51:20 +0000
+Subject: [PATCH 3/3] runtime: agent: verify the agent policy hash
+
+For TEE Guests that support the inclusion of immutable Host owned
+data in their configuration (SNP HostData and TDX MRCONFIGID):
+
+- runtime: attach the Agent Policy hash to these Guest VMs.
+- agent: compute the hash of the Agent Policy and verify that it
+  matches the TEE configuration data.
+
+The hash value attached to the TEE will be included in the TEE
+attestation reports. This allows an attestation service to verify that
+the hash has the expected value, and therefore the Policy enforced by
+the Agent has the expected contents.
+
+Signed-off-by: Dan Mihai <dmihai@microsoft.com>
+Signed-off-by: Tom Dohrmann <erbse.13@gmx.de>
+---
+ src/agent/Cargo.lock                          | 101 +++++++++
+ src/agent/Cargo.toml                          |   7 +-
+ src/agent/src/main.rs                         |   4 +
+ src/agent/src/policy.rs                       |  68 +++++-
+ src/agent/src/sev.rs                          |  19 ++
+ src/agent/src/tdx.rs                          | 194 ++++++++++++++++++
+ src/runtime/pkg/govmm/qemu/qemu.go            |  17 ++
+ src/runtime/virtcontainers/hypervisor.go      |   4 +
+ src/runtime/virtcontainers/qemu.go            |   2 +-
+ src/runtime/virtcontainers/qemu_amd64.go      |  38 +++-
+ src/runtime/virtcontainers/qemu_amd64_test.go | 116 ++++++++++-
+ src/runtime/virtcontainers/qemu_arch_base.go  |   4 +-
+ src/runtime/virtcontainers/qemu_arm64.go      |   2 +-
+ src/runtime/virtcontainers/qemu_arm64_test.go |  47 ++++-
+ src/runtime/virtcontainers/qemu_ppc64le.go    |   2 +-
+ .../virtcontainers/qemu_ppc64le_test.go       |  53 ++++-
+ src/runtime/virtcontainers/qemu_s390x.go      |   2 +-
+ src/runtime/virtcontainers/qemu_s390x_test.go |  51 ++++-
+ src/runtime/virtcontainers/sandbox.go         |   1 +
+ 19 files changed, 696 insertions(+), 36 deletions(-)
+ create mode 100644 src/agent/src/sev.rs
+ create mode 100644 src/agent/src/tdx.rs
+
+diff --git a/src/agent/Cargo.lock b/src/agent/Cargo.lock
+index 911bca114..fef34b648 100644
+--- a/src/agent/Cargo.lock
++++ b/src/agent/Cargo.lock
+@@ -465,6 +465,12 @@ version = "0.6.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+ 
++[[package]]
++name = "bitfield"
++version = "0.13.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
++
+ [[package]]
+ name = "bitflags"
+ version = "1.3.2"
+@@ -802,6 +808,12 @@ dependencies = [
+  "os_str_bytes",
+ ]
+ 
++[[package]]
++name = "codicon"
++version = "3.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
++
+ [[package]]
+ name = "combine"
+ version = "4.6.6"
+@@ -1201,6 +1213,15 @@ dependencies = [
+  "subtle",
+ ]
+ 
++[[package]]
++name = "dirs"
++version = "5.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
++dependencies = [
++ "dirs-sys",
++]
++
+ [[package]]
+ name = "dirs-next"
+ version = "2.0.0"
+@@ -1211,6 +1232,18 @@ dependencies = [
+  "dirs-sys-next",
+ ]
+ 
++[[package]]
++name = "dirs-sys"
++version = "0.4.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
++dependencies = [
++ "libc",
++ "option-ext",
++ "redox_users",
++ "windows-sys 0.48.0",
++]
++
+ [[package]]
+ name = "dirs-sys-next"
+ version = "0.1.2"
+@@ -1995,6 +2028,12 @@ dependencies = [
+  "windows-sys 0.48.0",
+ ]
+ 
++[[package]]
++name = "iocuddle"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
++
+ [[package]]
+ name = "iovec"
+ version = "0.1.4"
+@@ -2173,6 +2212,8 @@ dependencies = [
+  "serde",
+  "serde_json",
+  "serial_test",
++ "sev",
++ "sha2",
+  "slog",
+  "slog-scope",
+  "slog-stdlog",
+@@ -2190,6 +2231,7 @@ dependencies = [
+  "tracing-subscriber",
+  "ttrpc",
+  "url",
++ "vmm-sys-util",
+  "vsock-exporter",
+  "which",
+ ]
+@@ -3013,6 +3055,12 @@ dependencies = [
+  "tokio-stream",
+ ]
+ 
++[[package]]
++name = "option-ext"
++version = "0.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
++
+ [[package]]
+ name = "ordered-stream"
+ version = "0.2.0"
+@@ -4354,6 +4402,15 @@ dependencies = [
+  "syn 1.0.109",
+ ]
+ 
++[[package]]
++name = "serde-big-array"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
++dependencies = [
++ "serde",
++]
++
+ [[package]]
+ name = "serde-enum-str"
+ version = "0.4.0"
+@@ -4373,6 +4430,15 @@ version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "794e44574226fc701e3be5c651feb7939038fc67fb73f6f4dd5c4ba90fd3be70"
+ 
++[[package]]
++name = "serde_bytes"
++version = "0.11.10"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
++dependencies = [
++ "serde",
++]
++
+ [[package]]
+ name = "serde_derive"
+ version = "1.0.198"
+@@ -4470,6 +4536,28 @@ dependencies = [
+  "syn 1.0.109",
+ ]
+ 
++[[package]]
++name = "sev"
++version = "2.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "77e9de97c6e3c65e4e67997d48ad506d258da10edc10894277093da679441f23"
++dependencies = [
++ "bincode",
++ "bitfield",
++ "bitflags 1.3.2",
++ "codicon",
++ "dirs",
++ "hex",
++ "iocuddle",
++ "lazy_static",
++ "libc",
++ "serde",
++ "serde-big-array",
++ "serde_bytes",
++ "static_assertions",
++ "uuid",
++]
++
+ [[package]]
+ name = "sha1"
+ version = "0.10.6"
+@@ -5466,6 +5554,9 @@ name = "uuid"
+ version = "1.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
++dependencies = [
++ "serde",
++]
+ 
+ [[package]]
+ name = "valuable"
+@@ -5495,6 +5586,16 @@ version = "0.9.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+ 
++[[package]]
++name = "vmm-sys-util"
++version = "0.11.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
++dependencies = [
++ "bitflags 1.3.2",
++ "libc",
++]
++
+ [[package]]
+ name = "vsock"
+ version = "0.2.6"
+diff --git a/src/agent/Cargo.toml b/src/agent/Cargo.toml
+index 0ab98b3e3..37263149d 100644
+--- a/src/agent/Cargo.toml
++++ b/src/agent/Cargo.toml
+@@ -90,6 +90,11 @@ regorus = { version = "0.1.4", default-features = false, features = [
+     "regex",
+ ], optional = true }
+ 
++# Policy validation
++sha2 = { version = "0.10.6", optional = true }
++sev = { version = "2.0.2", default-features = false, features = ["snp"], optional = true }
++vmm-sys-util = { version = "0.11.0", optional = true }
++
+ [dev-dependencies]
+ tempfile = "3.1.0"
+ test-utils = { path = "../libs/test-utils" }
+@@ -108,7 +113,7 @@ lto = true
+ default-pull = ["guest-pull"]
+ seccomp = ["rustjail/seccomp"]
+ standard-oci-runtime = ["rustjail/standard-oci-runtime"]
+-agent-policy = ["regorus"]
++agent-policy = ["regorus", "sev", "sha2", "vmm-sys-util"]
+ guest-pull = ["image-rs", "openssl"]
+ 
+ [[bin]]
+diff --git a/src/agent/src/main.rs b/src/agent/src/main.rs
+index 0450b1bcc..87cb18101 100644
+--- a/src/agent/src/main.rs
++++ b/src/agent/src/main.rs
+@@ -85,6 +85,10 @@ mod tracer;
+ 
+ #[cfg(feature = "agent-policy")]
+ mod policy;
++#[cfg(feature = "agent-policy")]
++mod sev;
++#[cfg(feature = "agent-policy")]
++mod tdx;
+ 
+ cfg_if! {
+     if #[cfg(target_arch = "s390x")] {
+diff --git a/src/agent/src/policy.rs b/src/agent/src/policy.rs
+index d709515ff..fe1461e5c 100644
+--- a/src/agent/src/policy.rs
++++ b/src/agent/src/policy.rs
+@@ -3,12 +3,15 @@
+ // SPDX-License-Identifier: Apache-2.0
+ //
+ 
+-use anyhow::Result;
++use anyhow::{Result, bail};
+ use protobuf::MessageDyn;
++use sha2::{Digest, Sha256, Sha384};
+ use slog::Drain;
+ use tokio::io::AsyncWriteExt;
+ 
+ use crate::rpc::ttrpc_error;
++use crate::sev::get_snp_host_data;
++use crate::tdx::get_tdx_mrconfigid;
+ use crate::AGENT_POLICY;
+ 
+ static POLICY_LOG_FILE: &str = "/tmp/policy.txt";
+@@ -131,6 +134,7 @@ impl AgentPolicy {
+ 
+     /// Replace the Policy in regorus.
+     pub async fn set_policy(&mut self, policy: &str) -> Result<()> {
++        verify_policy_digest(policy)?;
+         self.engine = Self::new_engine();
+         self.engine
+             .add_policy("agent_policy".to_string(), policy.to_string())?;
+@@ -161,3 +165,65 @@ impl AgentPolicy {
+         }
+     }
+ }
++
++fn verify_policy_digest(policy: &str) -> Result<()> {
++    // TODO: check if the user configured this Guest VM as using either SNP or TDX,
++    // and if that's the case return an error if the TEE attestation report didn't
++    // provide a policy digest value.
++
++    if let Ok(expected_digest) = get_tdx_mrconfigid() {
++        info!(sl!(), "policy: TDX expected digest ({:?})", expected_digest);
++        verify_sha_384(policy, expected_digest.as_slice())
++    } else if let Ok(expected_digest) = get_snp_host_data() {
++        info!(sl!(), "policy: SNP expected digest ({:?})", expected_digest);
++        // TODO: fix the SNP CI machines and then don't ignore zeroes anymore.
++        let ignore_zero_digest = true;
++        verify_sha_256(policy, expected_digest.as_slice(), ignore_zero_digest)
++    } else {
++        warn!(sl!(), "policy: integrity has not been verified!");
++        Ok(())
++    }
++}
++
++fn verify_sha_384(policy: &str, expected_digest: &[u8]) -> Result<()> {
++    let mut hasher = Sha384::new();
++    hasher.update(policy.as_bytes());
++    let digest = hasher.finalize();
++    info!(sl!(), "policy: calculated digest ({:?})", digest);
++
++    if expected_digest != digest.as_slice() {
++        bail!(
++            "policy: rejecting unexpected digest ({:?}), expected ({:?})",
++            digest.as_slice(),
++            expected_digest
++        );
++    }
++
++    Ok(())
++}
++
++pub fn verify_sha_256(
++    policy: &str,
++    expected_digest: &[u8],
++    ignore_zero_digest: bool,
++) -> Result<()> {
++    let mut hasher = Sha256::new();
++    hasher.update(policy.as_bytes());
++    let digest = hasher.finalize();
++    info!(sl!(), "policy: calculated digest ({:?})", digest);
++
++    if expected_digest != digest.as_slice() {
++        if ignore_zero_digest && !expected_digest.iter().any(|&x| x != 0) {
++            error!(sl!(), "Temporarily ignoring incorrect SNP Host Data field");
++            return Ok(());
++        }
++
++        bail!(
++            "policy: rejecting unexpected digest ({:?}), expected ({:?})",
++            digest,
++            expected_digest
++        );
++    }
++
++    Ok(())
++}
+diff --git a/src/agent/src/sev.rs b/src/agent/src/sev.rs
+new file mode 100644
+index 000000000..3257eabaf
+--- /dev/null
++++ b/src/agent/src/sev.rs
+@@ -0,0 +1,19 @@
++// Copyright (c) 2023 Microsoft Corporation
++//
++// SPDX-License-Identifier: Apache-2.0
++//
++
++use anyhow::Result;
++
++pub fn get_snp_host_data() -> Result<Vec<u8>> {
++    match sev::firmware::guest::Firmware::open() {
++        Ok(mut firmware) => {
++            let report_data: [u8; 64] = [0; 64];
++            match firmware.get_report(None, Some(report_data), Some(0)) {
++                Ok(report) => Ok(report.host_data.to_vec()),
++                Err(e) => Err(e.into()),
++            }
++        }
++        Err(e) => Err(e.into()),
++    }
++}
+diff --git a/src/agent/src/tdx.rs b/src/agent/src/tdx.rs
+new file mode 100644
+index 000000000..1531e72a8
+--- /dev/null
++++ b/src/agent/src/tdx.rs
+@@ -0,0 +1,194 @@
++// Copyright (c) 2023 Microsoft Corporation
++//
++// SPDX-License-Identifier: Apache-2.0
++//
++
++use anyhow::{bail, Result};
++use nix::fcntl::{self, OFlag};
++use nix::sys::stat::Mode;
++use std::os::fd::{AsRawFd, FromRawFd};
++use vmm_sys_util::ioctl::ioctl_with_val;
++use vmm_sys_util::{ioctl_ioc_nr, ioctl_iowr_nr};
++
++#[repr(C)]
++#[derive(Default)]
++/// Type header of TDREPORT_STRUCT.
++struct TdTransportType {
++    /// Type of the TDREPORT (0 - SGX, 81 - TDX, rest are reserved).
++    type_: u8,
++
++    /// Subtype of the TDREPORT (Default value is 0).
++    sub_type: u8,
++
++    /// TDREPORT version (Default value is 0).
++    version: u8,
++
++    /// Added for future extension.
++    reserved: u8,
++}
++
++#[repr(C)]
++/// TDX guest report data, MAC and TEE hashes.
++struct ReportMac {
++    /// TDREPORT type header.
++    type_: TdTransportType,
++
++    /// Reserved for future extension.
++    reserved1: [u8; 12],
++
++    /// CPU security version.
++    cpu_svn: [u8; 16],
++
++    /// SHA384 hash of TEE TCB INFO.
++    tee_tcb_info_hash: [u8; 48],
++
++    /// SHA384 hash of TDINFO_STRUCT.
++    tee_td_info_hash: [u8; 48],
++
++    /// User defined unique data passed in TDG.MR.REPORT request.
++    reportdata: [u8; 64],
++
++    /// Reserved for future extension.
++    reserved2: [u8; 32],
++
++    /// CPU MAC ID.
++    mac: [u8; 32],
++}
++
++impl Default for ReportMac {
++    fn default() -> Self {
++        Self {
++            type_: Default::default(),
++            reserved1: [0; 12],
++            cpu_svn: [0; 16],
++            tee_tcb_info_hash: [0; 48],
++            tee_td_info_hash: [0; 48],
++            reportdata: [0; 64],
++            reserved2: [0; 32],
++            mac: [0; 32],
++        }
++    }
++}
++
++#[repr(C)]
++#[derive(Default)]
++/// TDX guest measurements and configuration.
++struct TdInfo {
++    /// TDX Guest attributes (like debug, spet_disable, etc).
++    attr: [u8; 8],
++
++    /// Extended features allowed mask.
++    xfam: u64,
++
++    /// Build time measurement register.
++    mrtd: [u64; 6],
++
++    /// Software-defined ID for non-owner-defined configuration of the guest - e.g., run-time or OS configuration.
++    mrconfigid: [u64; 6],
++
++    /// Software-defined ID for the guest owner.
++    mrowner: [u64; 6],
++
++    /// Software-defined ID for owner-defined configuration of the guest - e.g., specific to the workload.
++    mrownerconfig: [u64; 6],
++
++    /// Run time measurement registers.
++    rtmr: [u64; 24],
++
++    /// For future extension.
++    reserved: [u64; 14],
++}
++
++#[repr(C)]
++/// Output of TDCALL[TDG.MR.REPORT].
++struct TdReport {
++    /// Mac protected header of size 256 bytes.
++    report_mac: ReportMac,
++
++    /// Additional attestable elements in the TCB are not reflected in the report_mac.
++    tee_tcb_info: [u8; 239],
++
++    /// Added for future extension.
++    reserved: [u8; 17],
++
++    /// Measurements and configuration data of size 512 bytes.
++    tdinfo: TdInfo,
++}
++
++impl Default for TdReport {
++    fn default() -> Self {
++        Self {
++            report_mac: Default::default(),
++            tee_tcb_info: [0; 239],
++            reserved: [0; 17],
++            tdinfo: Default::default(),
++        }
++    }
++}
++
++#[repr(C)]
++/// Request struct for TDX_CMD_GET_REPORT0 IOCTL.
++struct TdxReportReq {
++    /// User buffer with REPORTDATA to be included into TDREPORT.
++    /// Typically it can be some nonce provided by attestation, service,
++    /// so the generated TDREPORT can be uniquely verified.
++    reportdata: [u8; 64],
++
++    /// User buffer to store TDREPORT output from TDCALL[TDG.MR.REPORT].
++    tdreport: TdReport,
++}
++
++impl Default for TdxReportReq {
++    fn default() -> Self {
++        Self {
++            reportdata: [0; 64],
++            tdreport: Default::default(),
++        }
++    }
++}
++
++// Get TDREPORT0 (a.k.a. TDREPORT subtype 0) using TDCALL[TDG.MR.REPORT].
++ioctl_iowr_nr!(
++    TDX_CMD_GET_REPORT0,
++    'T' as ::std::os::raw::c_uint,
++    1,
++    TdxReportReq
++);
++
++pub fn get_tdx_mrconfigid() -> Result<Vec<u8>> {
++    let fd = {
++        let raw_fd = fcntl::open(
++            "/dev/tdx_guest",
++            OFlag::O_CLOEXEC | OFlag::O_RDWR | OFlag::O_SYNC,
++            Mode::empty(),
++        )?;
++        unsafe { std::fs::File::from_raw_fd(raw_fd) }
++    };
++
++    let mut req = TdxReportReq {
++        reportdata: [0; 64],
++        tdreport: Default::default(),
++    };
++    let ret = unsafe {
++        ioctl_with_val(
++            &fd.as_raw_fd(),
++            TDX_CMD_GET_REPORT0(),
++            &mut req as *mut TdxReportReq as std::os::raw::c_ulong,
++        )
++    };
++    if ret < 0 {
++        bail!(
++            "TDX_CMD_GET_REPORT0 failed: {:?}",
++            std::io::Error::last_os_error(),
++        );
++    }
++
++    let mrconfigid: Vec<u8> = req
++        .tdreport
++        .tdinfo
++        .mrconfigid
++        .iter()
++        .flat_map(|val| val.to_le_bytes())
++        .collect();
++    Ok(mrconfigid)
++}
+diff --git a/src/runtime/pkg/govmm/qemu/qemu.go b/src/runtime/pkg/govmm/qemu/qemu.go
+index dadbe8b35..d85f207b7 100644
+--- a/src/runtime/pkg/govmm/qemu/qemu.go
++++ b/src/runtime/pkg/govmm/qemu/qemu.go
+@@ -316,6 +316,11 @@ type Object struct {
+ 
+ 	// QgsPort defines Intel Quote Generation Service port exposed from the host
+ 	QgsPort uint32
++
++	// TEEConfigData represents opaque binary data attached to a TEE and typically used
++	// for Guest attestation. This is only relevant for sev-snp-guest and tdx-guest
++	// objects and is encoded in the format expected by QEMU for each TEE type.
++	TEEConfigData string
+ }
+ 
+ // Valid returns true if the Object structure is valid and complete.
+@@ -373,6 +378,15 @@ func (object Object) QemuParams(config *Config) []string {
+ 
+ 	case TDXGuest:
+ 		objectParams = append(objectParams, prepareObjectWithTdxQgs(object))
++		objectParams = append(objectParams, string(object.Type))
++		objectParams = append(objectParams, "sept-ve-disable=on")
++		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
++		if object.Debug {
++			objectParams = append(objectParams, "debug=on")
++		}
++		if len(object.TEEConfigData) > 0 {
++			objectParams = append(objectParams, fmt.Sprintf("mrconfigid=%s", object.TEEConfigData))
++		}
+ 		config.Bios = object.File
+ 	case SEVGuest:
+ 		objectParams = append(objectParams, string(object.Type))
+@@ -388,6 +402,9 @@ func (object Object) QemuParams(config *Config) []string {
+ 		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
+ 		objectParams = append(objectParams, fmt.Sprintf("reduced-phys-bits=%d", object.ReducedPhysBits))
+ 		objectParams = append(objectParams, "kernel-hashes=on")
++		if len(object.TEEConfigData) > 0 {
++			objectParams = append(objectParams, fmt.Sprintf("host-data=%s", object.TEEConfigData))
++		}
+ 		config.Bios = object.File
+ 	case SecExecGuest:
+ 		objectParams = append(objectParams, string(object.Type))
+diff --git a/src/runtime/virtcontainers/hypervisor.go b/src/runtime/virtcontainers/hypervisor.go
+index aa3082324..2fa88c11f 100644
+--- a/src/runtime/virtcontainers/hypervisor.go
++++ b/src/runtime/virtcontainers/hypervisor.go
+@@ -680,6 +680,10 @@ type HypervisorConfig struct {
+ 
+ 	// QgsPort defines Intel Quote Generation Service port exposed from the host
+ 	QgsPort uint32
++	
++	// Policy text, for sandboxes created using a valid io.katacontainers.config.agent.policy
++	// annotation
++	AgentPolicy string
+ }
+ 
+ // vcpu mapping from vcpu number to thread number
+diff --git a/src/runtime/virtcontainers/qemu.go b/src/runtime/virtcontainers/qemu.go
+index 7a189bb91..509f74a3c 100644
+--- a/src/runtime/virtcontainers/qemu.go
++++ b/src/runtime/virtcontainers/qemu.go
+@@ -681,7 +681,7 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
+ 		Debug:          hypervisorConfig.Debug,
+ 	}
+ 
+-	qemuConfig.Devices, qemuConfig.Bios, err = q.arch.appendProtectionDevice(qemuConfig.Devices, firmwarePath, firmwareVolumePath)
++	qemuConfig.Devices, qemuConfig.Bios, err = q.arch.appendProtectionDevice(qemuConfig.Devices, firmwarePath, firmwareVolumePath, q.config.AgentPolicy)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/src/runtime/virtcontainers/qemu_amd64.go b/src/runtime/virtcontainers/qemu_amd64.go
+index ca8f9998c..0a6612736 100644
+--- a/src/runtime/virtcontainers/qemu_amd64.go
++++ b/src/runtime/virtcontainers/qemu_amd64.go
+@@ -9,6 +9,10 @@ package virtcontainers
+ 
+ import (
+ 	"context"
++	"crypto/sha256"
++	"crypto/sha512"
++	"encoding/base64"
++	"encoding/hex"
+ 	"fmt"
+ 	"time"
+ 
+@@ -277,7 +281,7 @@ func (q *qemuAmd64) enableProtection() error {
+ }
+ 
+ // append protection device
+-func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
++func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
+ 	if q.sgxEPCSize != 0 {
+ 		devices = append(devices,
+ 			govmmQemu.Object{
+@@ -302,6 +306,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
+ 				Debug:          false,
+ 				File:           firmware,
+ 				FirmwareVolume: firmwareVolume,
++				TEEConfigData:  tdxMRCONFIGID(agentPolicy),
+ 			}), "", nil
+ 	case sevProtection:
+ 		return append(devices,
+@@ -322,6 +327,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
+ 				File:            firmware,
+ 				CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
+ 				ReducedPhysBits: 1,
++				TEEConfigData:   snpHostData(agentPolicy),
+ 			}), "", nil
+ 	case noneProtection:
+ 
+@@ -331,3 +337,33 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
+ 		return devices, "", fmt.Errorf("Unsupported guest protection technology: %v", q.protection)
+ 	}
+ }
++
++// return the policy hash in the host-data format expected by QEMU for SEV-SNP.
++func snpHostData(policy string) string {
++	if len(policy) == 0 {
++		return ""
++	}
++
++	h := sha256.New()
++	h.Write([]byte(policy))
++	hash := h.Sum(nil)
++	hvLogger.WithField("hash", hash).Info("policy hash")
++
++	encoded_hash := make([]byte, base64.StdEncoding.EncodedLen(len(hash)))
++	base64.StdEncoding.Encode(encoded_hash, hash)
++	return string(encoded_hash)
++}
++
++// return the policy hash in the mrconfigid format expected by QEMU for TDX.
++func tdxMRCONFIGID(policy string) string {
++	if len(policy) == 0 {
++		return ""
++	}
++
++	h := sha512.New384()
++	h.Write([]byte(policy))
++	hash := h.Sum(nil)
++	hvLogger.WithField("hash", hash).Info("policy hash")
++
++	return hex.EncodeToString(hash)
++}
+diff --git a/src/runtime/virtcontainers/qemu_amd64_test.go b/src/runtime/virtcontainers/qemu_amd64_test.go
+index 1425cb38c..f0a9c691a 100644
+--- a/src/runtime/virtcontainers/qemu_amd64_test.go
++++ b/src/runtime/virtcontainers/qemu_amd64_test.go
+@@ -9,6 +9,10 @@ package virtcontainers
+ 
+ import (
+ 	"context"
++	"crypto/sha256"
++	"crypto/sha512"
++	"encoding/base64"
++	"encoding/hex"
+ 	"fmt"
+ 	"os"
+ 	"testing"
+@@ -247,6 +251,34 @@ func TestQemuAmd64Microvm(t *testing.T) {
+ 	assert.False(amd64.supportGuestMemoryHotplug())
+ }
+ 
++// return the policy hash in the host-data format expected by QEMU for SEV-SNP.
++func testSnpHostData(policy string) string {
++	if len(policy) == 0 {
++		return ""
++	}
++
++	h := sha256.New()
++	h.Write([]byte(policy))
++	hash := h.Sum(nil)
++
++	encoded_hash := make([]byte, base64.StdEncoding.EncodedLen(len(hash)))
++	base64.StdEncoding.Encode(encoded_hash, hash)
++	return string(encoded_hash)
++}
++
++// return the policy hash in the mrconfigid format expected by QEMU for TDX.
++func testTdxMRCONFIGID(policy string) string {
++	if len(policy) == 0 {
++		return ""
++	}
++
++	h := sha512.New384()
++	h.Write([]byte(policy))
++	hash := h.Sum(nil)
++
++	return hex.EncodeToString(hash)
++}
++
+ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
+ 	var devices []govmmQemu.Device
+ 	assert := assert.New(t)
+@@ -255,30 +287,48 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
+ 
+ 	id := amd64.(*qemuAmd64).devLoadersCount
+ 	firmware := "tdvf.fd"
++	policy := "package test1"
++	hostData := testSnpHostData(policy)
++	mrconfigid := testTdxMRCONFIGID(policy)
+ 	var bios string
+ 	var err error
+-	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "")
+-	assert.NoError(err)
+ 
+ 	// non-protection
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", "")
++	assert.NoError(err)
++	assert.NotEmpty(bios)
++
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", policy)
++	assert.NoError(err)
+ 	assert.NotEmpty(bios)
+ 
+ 	// pef protection
+ 	amd64.(*qemuAmd64).protection = pefProtection
+-	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	amd64.(*qemuAmd64).protection = pefProtection
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", policy)
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	// Secure Execution protection
+ 	amd64.(*qemuAmd64).protection = seProtection
+-	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", policy)
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	// sev protection
+ 	amd64.(*qemuAmd64).protection = sevProtection
+ 
+-	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", "")
+ 	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+@@ -295,10 +345,42 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
+ 
+ 	assert.Equal(expectedOut, devices)
+ 
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", policy)
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	expectedOut = append(expectedOut,
++		govmmQemu.Object{
++			Type:            govmmQemu.SEVGuest,
++			ID:              "sev",
++			Debug:           false,
++			File:            firmware,
++			CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
++			ReducedPhysBits: 1,
++		},
++	)
++
++	assert.Equal(expectedOut, devices)
++
+ 	// snp protection
+ 	amd64.(*qemuAmd64).protection = snpProtection
+ 
+-	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", "")
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	expectedOut = append(expectedOut,
++		govmmQemu.Object{
++			Type:            govmmQemu.SNPGuest,
++			ID:              "snp",
++			Debug:           false,
++			File:            firmware,
++			CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
++			ReducedPhysBits: 1,
++		},
++	)
++
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", policy)
+ 	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+@@ -310,6 +392,7 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
+ 			File:            firmware,
+ 			CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
+ 			ReducedPhysBits: 1,
++			TEEConfigData:   hostData,
+ 		},
+ 	)
+ 
+@@ -318,7 +401,7 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
+ 	// tdxProtection
+ 	amd64.(*qemuAmd64).protection = tdxProtection
+ 
+-	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", "")
+ 	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+@@ -334,4 +417,23 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
+ 	)
+ 
+ 	assert.Equal(expectedOut, devices)
++
++	id += 1
++	devices, bios, err = amd64.appendProtectionDevice(devices, firmware, "", policy)
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	expectedOut = append(expectedOut,
++		govmmQemu.Object{
++			Driver:        govmmQemu.Loader,
++			Type:          govmmQemu.TDXGuest,
++			ID:            "tdx",
++			DeviceID:      fmt.Sprintf("fd%d", id),
++			Debug:         false,
++			File:          firmware,
++			TEEConfigData: mrconfigid,
++		},
++	)
++
++	assert.Equal(expectedOut, devices)
+ }
+diff --git a/src/runtime/virtcontainers/qemu_arch_base.go b/src/runtime/virtcontainers/qemu_arch_base.go
+index fd92be772..662466f58 100644
+--- a/src/runtime/virtcontainers/qemu_arch_base.go
++++ b/src/runtime/virtcontainers/qemu_arch_base.go
+@@ -162,7 +162,7 @@ type qemuArch interface {
+ 	// This implementation is architecture specific, some archs may need
+ 	// a firmware, returns a string containing the path to the firmware that should
+ 	// be used with the -bios option, ommit -bios option if the path is empty.
+-	appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error)
++	appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error)
+ 
+ 	// scans the PCIe space and returns the biggest BAR sizes for 32-bit
+ 	// and 64-bit addressable memory
+@@ -897,7 +897,7 @@ func (q *qemuArchBase) setPFlash(p []string) {
+ }
+ 
+ // append protection device
+-func (q *qemuArchBase) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
++func (q *qemuArchBase) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
+ 	hvLogger.WithField("arch", runtime.GOARCH).Warnf("Confidential Computing has not been implemented for this architecture")
+ 	return devices, firmware, nil
+ }
+diff --git a/src/runtime/virtcontainers/qemu_arm64.go b/src/runtime/virtcontainers/qemu_arm64.go
+index a9b803f73..112fe358e 100644
+--- a/src/runtime/virtcontainers/qemu_arm64.go
++++ b/src/runtime/virtcontainers/qemu_arm64.go
+@@ -154,7 +154,7 @@ func (q *qemuArm64) enableProtection() error {
+ 	return nil
+ }
+ 
+-func (q *qemuArm64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
++func (q *qemuArm64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
+ 	err := q.enableProtection()
+ 	if err != nil {
+ 		hvLogger.WithField("arch", runtime.GOARCH).Error(err)
+diff --git a/src/runtime/virtcontainers/qemu_arm64_test.go b/src/runtime/virtcontainers/qemu_arm64_test.go
+index 07e67ac8c..8b6bd03eb 100644
+--- a/src/runtime/virtcontainers/qemu_arm64_test.go
++++ b/src/runtime/virtcontainers/qemu_arm64_test.go
+@@ -182,42 +182,77 @@ func TestQemuArm64AppendProtectionDevice(t *testing.T) {
+ 	var err error
+ 
+ 	// no protection
+-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Empty(devices)
++	assert.Empty(bios)
++	assert.NoError(err)
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "XYZ")
+ 	assert.Empty(devices)
+ 	assert.Empty(bios)
+ 	assert.NoError(err)
+ 
+ 	// PEF protection
+ 	arm64.(*qemuArm64).protection = pefProtection
+-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Empty(devices)
++	assert.Empty(bios)
++	assert.NoError(err)
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "11111111111")
+ 	assert.Empty(devices)
+ 	assert.Empty(bios)
+ 	assert.NoError(err)
+ 
+ 	// Secure Execution protection
+ 	arm64.(*qemuArm64).protection = seProtection
+-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Empty(devices)
++	assert.Empty(bios)
++	assert.NoError(err)
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "ABCD")
+ 	assert.Empty(devices)
+ 	assert.Empty(bios)
+ 	assert.NoError(err)
+ 
+ 	// SEV protection
+ 	arm64.(*qemuArm64).protection = sevProtection
+-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Empty(devices)
++	assert.Empty(bios)
++	assert.NoError(err)
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
+ 	assert.Empty(devices)
+ 	assert.Empty(bios)
+ 	assert.NoError(err)
+ 
+ 	// SNP protection
+ 	arm64.(*qemuArm64).protection = snpProtection
+-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Empty(devices)
++	assert.Empty(bios)
++	assert.NoError(err)
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
+ 	assert.Empty(devices)
+ 	assert.Empty(bios)
+ 	assert.NoError(err)
+ 
+ 	// TDX protection
+ 	arm64.(*qemuArm64).protection = tdxProtection
+-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
++	assert.Empty(devices)
++	assert.Empty(bios)
++	assert.NoError(err)
++
++	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "123456789012345678901234567890123456789012345678")
+ 	assert.Empty(devices)
+ 	assert.Empty(bios)
+ 	assert.NoError(err)
+diff --git a/src/runtime/virtcontainers/qemu_ppc64le.go b/src/runtime/virtcontainers/qemu_ppc64le.go
+index d2e0228c8..ed7a14c4d 100644
+--- a/src/runtime/virtcontainers/qemu_ppc64le.go
++++ b/src/runtime/virtcontainers/qemu_ppc64le.go
+@@ -157,7 +157,7 @@ func (q *qemuPPC64le) enableProtection() error {
+ }
+ 
+ // append protection device
+-func (q *qemuPPC64le) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
++func (q *qemuPPC64le) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
+ 	switch q.protection {
+ 	case pefProtection:
+ 		return append(devices,
+diff --git a/src/runtime/virtcontainers/qemu_ppc64le_test.go b/src/runtime/virtcontainers/qemu_ppc64le_test.go
+index 85e1dfe80..0c2f4b923 100644
+--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
++++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
+@@ -60,39 +60,63 @@ func TestQemuPPC64leAppendProtectionDevice(t *testing.T) {
+ 	var devices []govmmQemu.Device
+ 	var bios, firmware string
+ 	var err error
+-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+-	assert.NoError(err)
+ 
+ 	//no protection
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "FOObar")
++	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+ 	//Secure Execution protection
+ 	ppc64le.(*qemuPPC64le).protection = seProtection
+-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "adasawdq")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	//SEV protection
+ 	ppc64le.(*qemuPPC64le).protection = sevProtection
+-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	//SNP protection
+ 	ppc64le.(*qemuPPC64le).protection = snpProtection
+-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	//TDX protection
+ 	ppc64le.(*qemuPPC64le).protection = tdxProtection
+-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "123456789012345678901234567890123456789012345678")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	//PEF protection
+ 	ppc64le.(*qemuPPC64le).protection = pefProtection
+-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
+ 	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+@@ -107,4 +131,19 @@ func TestQemuPPC64leAppendProtectionDevice(t *testing.T) {
+ 	}
+ 	assert.Equal(expectedOut, devices)
+ 
++	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "abc")
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	expectedOut = append(expectedOut,
++		govmmQemu.Object{
++			Driver:   govmmQemu.SpaprTPMProxy,
++			Type:     govmmQemu.PEFGuest,
++			ID:       pefID,
++			DeviceID: tpmID,
++			File:     tpmHostPath,
++		},
++	)
++
++	assert.Equal(expectedOut, devices)
+ }
+diff --git a/src/runtime/virtcontainers/qemu_s390x.go b/src/runtime/virtcontainers/qemu_s390x.go
+index 29eaafe5b..787a0e589 100644
+--- a/src/runtime/virtcontainers/qemu_s390x.go
++++ b/src/runtime/virtcontainers/qemu_s390x.go
+@@ -337,7 +337,7 @@ func (q *qemuS390x) enableProtection() error {
+ 
+ // appendProtectionDevice appends a QEMU object for Secure Execution.
+ // Takes devices and returns updated version. Takes BIOS and returns it (no modification on s390x).
+-func (q *qemuS390x) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
++func (q *qemuS390x) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
+ 	switch q.protection {
+ 	case seProtection:
+ 		return append(devices,
+diff --git a/src/runtime/virtcontainers/qemu_s390x_test.go b/src/runtime/virtcontainers/qemu_s390x_test.go
+index 24a67bdd9..3f5f84aff 100644
+--- a/src/runtime/virtcontainers/qemu_s390x_test.go
++++ b/src/runtime/virtcontainers/qemu_s390x_test.go
+@@ -111,40 +111,64 @@ func TestQemuS390xAppendProtectionDevice(t *testing.T) {
+ 	var devices []govmmQemu.Device
+ 	var bios, firmware string
+ 	var err error
+-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
+-	assert.NoError(err)
+ 
+ 	// no protection
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "")
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "s390x_test")
++	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+ 	// PEF protection
+ 	s390x.(*qemuS390x).protection = pefProtection
+-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "1234")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	// TDX protection
+ 	s390x.(*qemuS390x).protection = tdxProtection
+-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "123456789012345678901234567890123456789012345678")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	// SEV protection
+ 	s390x.(*qemuS390x).protection = sevProtection
+-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	// SNP protection
+ 	s390x.(*qemuS390x).protection = snpProtection
+-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "")
++	assert.Error(err)
++	assert.Empty(bios)
++
++	s390x.(*qemuS390x).protection = snpProtection
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
+ 	assert.Error(err)
+ 	assert.Empty(bios)
+ 
+ 	// Secure Execution protection
+ 	s390x.(*qemuS390x).protection = seProtection
+ 
+-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "")
+ 	assert.NoError(err)
+ 	assert.Empty(bios)
+ 
+@@ -155,4 +179,17 @@ func TestQemuS390xAppendProtectionDevice(t *testing.T) {
+ 		},
+ 	}
+ 	assert.Equal(expectedOut, devices)
++
++	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", "foo")
++	assert.NoError(err)
++	assert.Empty(bios)
++
++	expectedOut = append(expectedOut,
++		govmmQemu.Object{
++			Type: govmmQemu.SecExecGuest,
++			ID:   secExecID,
++		},
++	)
++
++	assert.Equal(expectedOut, devices)
+ }
+diff --git a/src/runtime/virtcontainers/sandbox.go b/src/runtime/virtcontainers/sandbox.go
+index b58daccaa..af35af12e 100644
+--- a/src/runtime/virtcontainers/sandbox.go
++++ b/src/runtime/virtcontainers/sandbox.go
+@@ -596,6 +596,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
+ 
+ 	sandboxConfig.HypervisorConfig.VMStorePath = s.store.RunVMStoragePath()
+ 	sandboxConfig.HypervisorConfig.RunStorePath = s.store.RunStoragePath()
++	sandboxConfig.HypervisorConfig.AgentPolicy = sandboxConfig.AgentConfig.Policy
+ 
+ 	spec := s.GetPatchedOCISpec()
+ 	if spec != nil && spec.Process.SelinuxLabel != "" {
+-- 
+2.34.1
+

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -6,17 +6,32 @@
   fetchFromGitHub,
   yq-go,
   git,
+  applyPatches,
 }:
 
 buildGoModule rec {
   pname = "kata-runtime";
   version = "3.6.0";
 
-  src = fetchFromGitHub {
-    owner = "kata-containers";
-    repo = "kata-containers";
-    rev = version;
-    hash = "sha256-Setg6qmkUVn57BQ3wqqNpzmfXeYhJJt9Q4AVFbGrCug=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "kata-containers";
+      repo = "kata-containers";
+      rev = version;
+      hash = "sha256-Setg6qmkUVn57BQ3wqqNpzmfXeYhJJt9Q4AVFbGrCug=";
+    };
+
+    patches = [
+      ./0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
+      ./0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
+      # This patch makes the v2 shim set the host-data field for SNP and makes
+      # kata-agent verify it against the policy.
+      # source: https://github.com/kata-containers/kata-containers/pull/8469
+      # Note that these patches are incomplete/insecure because kata-agent just
+      # continue running if it can't query the host-data:
+      # https://github.com/kata-containers/kata-containers/blob/61c83dfde3e38aab53b66f46f860347f1753ef5c/src/agent/src/policy.rs#L320
+      ./0003-runtime-agent-verify-the-agent-policy-hash.patch
+    ];
   };
 
   sourceRoot = "${src.name}/src/runtime";


### PR DESCRIPTION
This PR adds some patches required for running kata-containers on bare metal and make it work with our attestation flow.