### PR TITLE
node-installer: configure and run tardev-snapshotter

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ default_platform := "AKS-CLH-SNP"
 workspace_dir := "workspace"
 
 # Build the node-installer, containerize and push it.
-node-installer platform=default_platform:
+node-installer platform=default_platform: tardev-snapshotter
     #!/usr/bin/env bash
     case {{ platform }} in
         "AKS-CLH-SNP")

--- a/justfile
+++ b/justfile
@@ -18,10 +18,14 @@ openssl: (push "openssl")
 # Build the port-forwarder container and push it.
 port-forwarder: (push "port-forwarder")
 
+# Build the service-mesh-proxy container and push it.
 service-mesh-proxy: (push "service-mesh-proxy")
 
 # Build the initializer, containerize and push it.
 initializer: (push "initializer")
+
+# Build the tardev-snapshotter, containerize and push it.
+tardev-snapshotter: (push "tardev-snapshotter")
 
 default_cli := "contrast.cli"
 default_deploy_target := "openssl"

--- a/node-installer/internal/constants/constants.go
+++ b/node-installer/internal/constants/constants.go
@@ -81,7 +81,7 @@ func ContainerdBaseConfig() config.ContainerdConfig {
 }
 
 // ContainerdRuntimeConfigFragment returns the containerd runtime configuration fragment.
-func ContainerdRuntimeConfigFragment(baseDir string, platform platforms.Platform) (*config.Runtime, error) {
+func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platforms.Platform) (*config.Runtime, error) {
 	cfg := config.Runtime{
 		Type:                         "io.containerd.contrast-cc.v2",
 		Path:                         filepath.Join(baseDir, "bin", "containerd-shim-contrast-cc-v2"),
@@ -91,7 +91,7 @@ func ContainerdRuntimeConfigFragment(baseDir string, platform platforms.Platform
 
 	switch platform {
 	case platforms.AKSCloudHypervisorSNP:
-		cfg.Snapshotter = "tardev"
+		cfg.Snapshotter = snapshotter
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-clh-snp.toml"),
 		}
@@ -104,12 +104,4 @@ func ContainerdRuntimeConfigFragment(baseDir string, platform platforms.Platform
 	}
 
 	return &cfg, nil
-}
-
-// TardevSnapshotterConfigFragment returns the tardev snapshotter configuration fragment.
-func TardevSnapshotterConfigFragment() config.ProxyPlugin {
-	return config.ProxyPlugin{
-		Type:    "snapshot",
-		Address: "/run/containerd/tardev-snapshotter.sock",
-	}
 }

--- a/node-installer/node-installer_test.go
+++ b/node-installer/node-installer_test.go
@@ -64,7 +64,7 @@ func TestPatchContainerdConfig(t *testing.T) {
 
 			configData, err := os.ReadFile(configPath)
 			require.NoError(err)
-			assert.Equal(tc.expected, configData)
+			assert.Equal(string(tc.expected), string(configData))
 		})
 	}
 }

--- a/node-installer/testdata/expected-aks-clh-snp.toml
+++ b/node-installer/testdata/expected-aks-clh-snp.toml
@@ -56,7 +56,7 @@ runtime_type = 'io.containerd.contrast-cc.v2'
 runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
 pod_annotations = ['io.katacontainers.*']
 privileged_without_host_devices = true
-snapshotter = 'tardev'
+snapshotter = 'tardev-my-runtime'
 
 [plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
 ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-clh-snp.toml'
@@ -80,6 +80,6 @@ config_path = '/etc/containerd/certs.d'
 X-Meta-Source-Client = ['azure/aks']
 
 [proxy_plugins]
-[proxy_plugins.tardev]
+[proxy_plugins.tardev-my-runtime]
 type = 'snapshot'
-address = '/run/containerd/tardev-snapshotter.sock'
+address = '/run/containerd/tardev-snapshotter-my-runtime.sock'

--- a/packages/by-name/microsoft/genpolicy/0004-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
+++ b/packages/by-name/microsoft/genpolicy/0004-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
@@ -1,0 +1,26 @@
+From b631f031ef231372595243699a95d9d6e50e86bf Mon Sep 17 00:00:00 2001
+From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
+Date: Thu, 11 Jul 2024 12:05:00 +0200
+Subject: [PATCH 4/4] genpolicy: regex check contrast specific layer-src-prefix
+
+Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
+---
+ src/tools/genpolicy/rules.rego | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
+index 25c16bada..4f622a9f7 100644
+--- a/src/tools/genpolicy/rules.rego
++++ b/src/tools/genpolicy/rules.rego
+@@ -887,7 +887,7 @@ allow_storage_options(p_storage, i_storage, layer_ids, root_hashes) {
+     i_count == p_count + 3
+ 
+     print("allow_storage_options 2: i_storage.options[0] =", i_storage.options[0])
+-    i_storage.options[0] == "io.katacontainers.fs-opt.layer-src-prefix=/var/lib/containerd/io.containerd.snapshotter.v1.tardev/layers"
++    regex.match(`io\.katacontainers\.fs-opt\.layer-src-prefix=/var/lib/containerd/io\.containerd\.snapshotter\.v1\.tardev-contrast-cc-[a-f0-9]{32}/layers`, i_storage.options[0])
+ 
+     print("allow_storage_options 2: i_storage.options[i_count - 2] =", i_storage.options[i_count - 2])
+     i_storage.options[i_count - 2] == "io.katacontainers.fs-opt.overlay-rw"
+-- 
+2.45.1
+

--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -37,6 +37,14 @@ rustPlatform.buildRustPackage rec {
       # Backport of https://github.com/kata-containers/kata-containers/pull/9864
       # remove when picked up by Microsoft/kata-containers fork.
       ./0003-genpolicy-allow-specifying-layer-cache-file.patch
+      # As we use a pinned version of the tardev-snapshotter per runtime version, and
+      # the tardev-snapshotter's directory has a hash suffix, we must allow multiple
+      # layer source directories. For now, match the layer-src-prefix with a regex.
+      # We could think about moving the specific path into the settings and set it
+      # to the expected value.
+      #
+      # This patch is not upstreamable.
+      ./0004-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
     ];
   };
 

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -104,6 +104,15 @@ let
         Env = [ "PATH=/bin" ]; # This is only here for policy generation.
       };
     };
+
+    tardev-snapshotter = dockerTools.buildImage {
+      name = "tardev-snapshotter";
+      tag = "v${pkgs.microsoft.tardev-snapshotter.version}";
+      copyToRoot = with pkgs; [ microsoft.tardev-snapshotter ];
+      config = {
+        Cmd = [ "${lib.getExe pkgs.microsoft.tardev-snapshotter}" ];
+      };
+    };
   };
 in
 containers


### PR DESCRIPTION
With this change, we improve the stability of Contrast by deploying our own tardev-snapshotter on the host as part of the node-installer deployment. Previously, the Contrast runtime would use the tardev-snapshotter installed on the host, which is managed by Azure. However, the snapshotter is highly coupled with the guest image, and breaking changes to the snaphotter led to workload pods not being able to start in Contrast. Therefore, we are shipping a pinned snapshotter as part of the runtime. This will also allow running multiple Contrast runtime next to each other that require different versions of the snapshotter.