### PR TITLE
snp: don't test properties that are not guaranteed

### DIFF
--- a/internal/attestation/snp/cached_client_test.go
+++ b/internal/attestation/snp/cached_client_test.go
@@ -113,9 +113,6 @@ func TestMemcachedHTTPSGetter(t *testing.T) {
 		go getFunc()
 		go getFunc()
 		wg.Wait()
-
-		// It's possible that the cache is not yet populated when it is checked by the second Get.
-		assert.Less(fakeGetter.hits["foo"], numGets)
 	})
 }
 


### PR DESCRIPTION
Nothing in the implementation of `CachedHTTPSGetter` guarantees that parallel access to the getter does not result in parallel backend calls. This is a source of sporadic test failures, e.g. https://github.com/edgelesssys/contrast/actions/runs/9641091365/job/26586044940?pr=620#step:11:322.

I'd suggest to just remove the final check and keep the parallel test for race detection.