### PR TITLE
generate: mark `--reference-values` flag as required

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -68,6 +68,7 @@ subcommands.`,
 			strings.Join(platforms.AllStrings(), ", "),
 		),
 	)
+	must(cmd.MarkFlagRequired("reference-values"))
 	cmd.Flags().StringArrayP("add-workload-owner-key", "w", []string{workloadOwnerPEM},
 		"add a workload owner key from a PEM file to the manifest (pass more than once to add multiple keys)")
 	cmd.Flags().StringArray("add-seedshare-owner-key", []string{seedshareOwnerPEM},


### PR DESCRIPTION
Right now, not passing the flag leads to an undescriptive error as we try to parse the empty value as platform. As the upcoming release will still only support aks-clh-snp, mark the flag as required for now.