### PR TITLE
ci: fix missing "current version" in commit message from `bump_version` action

### DIFF
--- a/.github/actions/bump_version/action.yml
+++ b/.github/actions/bump_version/action.yml
@@ -27,6 +27,7 @@ runs:
       run: |
         cd ${{ inputs.working-directory }}
 
+        current=$(<version.txt)
         echo -n "${{ inputs.version }}" > version.txt
 
         commit_msg="flake: ${current} -> ${{ inputs.version }}"


### PR DESCRIPTION
The action was missing an initialization of the `current` variable.
This leads to the current version being omitted from the commit message.
See https://github.com/edgelesssys/contrast/commit/f7c10e613c8b495b744cb3e377008bd57531bf41 for example.

Load current version from `version.txt` before writing the new version to fix this.