### PR TITLE
ci: fix typo

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,4 +1,4 @@
-name: stactic checks
+name: static checks
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR fixes a typo in the CI pipeline name.