### PR TITLE
meshapi: follow best practice for metric names

### DIFF
--- a/coordinator/meshapi.go
+++ b/coordinator/meshapi.go
@@ -49,7 +49,7 @@ func newMeshAPIServer(meshAuth *authority.Authority, bundleGetter certBundleGett
 
 	attestationFailuresCounter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Subsystem: "contrast_meshapi",
-		Name:      "attestation_failures",
+		Name:      "attestation_failures_total",
 		Help:      "Number of attestation failures from workloads to the Coordinator.",
 	})
 

--- a/docs/docs/architecture/observability.md
+++ b/docs/docs/architecture/observability.md
@@ -28,7 +28,7 @@ Coordinator](../deployment#verify-the-coordinator) respectively.
 The `meshapi.MeshAPI` service records metrics for the method `NewMeshCert`, which
 gets called by the [Initializer](../components#the-initializer) when starting a
 new workload. Attestation failures from workloads to the Coordinator can be
-tracked with the counter `contrast_meshapi_attestation_failures`.
+tracked with the counter `contrast_meshapi_attestation_failures_total`.
 
 The current manifest generation is exposed as a
 [gauge](https://prometheus.io/docs/concepts/metric_types/#gauge) with the metric

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -165,13 +165,13 @@ func getFailures(ctx context.Context, t *testing.T, ct *contrasttest.ContrastTes
 	require.NoError(err)
 	failures := -1
 	for k, v := range metrics {
-		if k == "contrast_meshapi_attestation_failures" {
+		if k == "contrast_meshapi_attestation_failures_total" {
 			failures = int(v.GetMetric()[0].GetCounter().GetValue())
 		}
 	}
 	if failures == -1 {
 		// metric not found
-		t.Error("metric \"contrast_meshapi_attestation_failures\" not found")
+		t.Error("metric \"contrast_meshapi_attestation_failures_total\" not found")
 	}
 	return failures
 }


### PR DESCRIPTION
Counters should have a _total suffix, so we are renaming
`contrast_meshapi_attestation_failures` -> `contrast_meshapi_attestation_failures_total`.

This will also be enforced by https://github.com/edgelesssys/contrast/pull/721 in the future.