### PR TITLE
scripts/destroy-coco-aks: delete resource group if not in ci

### DIFF
--- a/packages/destroy-coco-aks.sh
+++ b/packages/destroy-coco-aks.sh
@@ -19,7 +19,13 @@ done
 
 set -x
 
-az aks delete \
-  --resource-group "${name}" \
-  --name "${name}" \
-  --yes
+if [[ -z ${CI:-} ]]; then
+  az group delete \
+    --name "${name}" \
+    --yes
+else
+  az aks delete \
+    --resource-group "${name}" \
+    --name "${name}" \
+    --yes
+fi


### PR DESCRIPTION
When changing the region in justfile.env, the resource group must be deleted as there cannot be 2 groups with the same name. Skip that step in CI, as the creds are only scoped to the rg in that case.