### PR TITLE
renovate: ignore node-installer

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -77,5 +77,10 @@
         "rollback",
       ],
     },
+    {
+      // Disable updating of locally-replaced dependencies.
+      matchPackageNames: [ "github.com/edgelesssys/contrast/node-installer" ],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
The node-installer Go package is replaced locally in the go.mod and thus should not be updated by renovate.