### PR TITLE
atls: try to attest with all validators

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
-	"github.com/edgelesssys/contrast/internal/attestation"
+	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/meshapi"
@@ -135,7 +135,7 @@ func newServerMetrics(reg *prometheus.Registry) *grpcprometheus.ServerMetrics {
 }
 
 func newGRPCServer(serverMetrics *grpcprometheus.ServerMetrics, log *slog.Logger) (*grpc.Server, error) {
-	issuer, err := attestation.PlatformIssuer(log)
+	issuer, err := atls.PlatformIssuer(log)
 	if err != nil {
 		return nil, fmt.Errorf("creating issuer: %w", err)
 	}

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/internal/atls"
-	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/meshapi"
@@ -55,7 +54,7 @@ func run() (retErr error) {
 		return fmt.Errorf("generating key: %w", err)
 	}
 
-	issuer, err := attestation.PlatformIssuer(log)
+	issuer, err := atls.PlatformIssuer(log)
 	if err != nil {
 		return fmt.Errorf("creating issuer: %w", err)
 	}

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package atls
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/json"
+	"testing"
+
+	"github.com/edgelesssys/contrast/internal/oid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyEmbeddedReport(t *testing.T) {
+	fakeAttDoc := FakeAttestationDoc{}
+	attDocBytes, err := json.Marshal(fakeAttDoc)
+	assert.NoError(t, err)
+
+	testCases := map[string]struct {
+		cert       *x509.Certificate
+		validators []Validator
+		wantErr    bool
+		targetErr  error
+	}{
+		"success": {
+			cert: &x509.Certificate{
+				Extensions: []pkix.Extension{
+					{
+						Id: oid.RawTDXReport,
+					},
+					{
+						Id:    oid.RawSNPReport,
+						Value: attDocBytes,
+					},
+				},
+			},
+			validators: NewFakeValidators(stubSNPValidator{}),
+		},
+		"multiple matches": {
+			cert: &x509.Certificate{
+				Extensions: []pkix.Extension{
+					{
+						Id:    oid.RawSNPReport,
+						Value: []byte("foo"),
+					},
+					{
+						Id:    oid.RawSNPReport,
+						Value: attDocBytes,
+					},
+				},
+			},
+			validators: NewFakeValidators(stubSNPValidator{}),
+		},
+		"skip non-matching validator": {
+			cert: &x509.Certificate{
+				Extensions: []pkix.Extension{
+					{
+						Id: []int{4, 5, 6},
+					},
+					{
+						Id:    oid.RawSNPReport,
+						Value: attDocBytes,
+					},
+				},
+			},
+			validators: append(NewFakeValidators(stubSNPValidator{}), NewFakeValidator(stubFooValidator{})),
+		},
+		"match, error": {
+			cert: &x509.Certificate{
+				Extensions: []pkix.Extension{
+					{
+						Id:    oid.RawSNPReport,
+						Value: []byte("foo"),
+					},
+				},
+			},
+			validators: NewFakeValidators(stubSNPValidator{}),
+			wantErr:    true,
+		},
+		"no extensions": {
+			cert:       &x509.Certificate{},
+			validators: nil,
+			targetErr:  ErrNoValidAttestationExtensions,
+			wantErr:    true,
+		},
+		"no matching validator": {
+			cert: &x509.Certificate{
+				Extensions: []pkix.Extension{
+					{
+						Id: oid.RawSNPReport,
+					},
+				},
+			},
+			validators: nil,
+			targetErr:  ErrNoMatchingValidators,
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			err := verifyEmbeddedReport(tc.validators, tc.cert, nil, nil)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.targetErr != nil {
+					assert.ErrorIs(err, tc.targetErr)
+				}
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}
+
+type stubSNPValidator struct{}
+
+func (v stubSNPValidator) OID() asn1.ObjectIdentifier {
+	return oid.RawSNPReport
+}
+
+type stubFooValidator struct{}
+
+func (v stubFooValidator) OID() asn1.ObjectIdentifier {
+	return []int{1, 2, 3}
+}

--- a/internal/atls/issuer.go
+++ b/internal/atls/issuer.go
@@ -1,13 +1,12 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package attestation
+package atls
 
 import (
 	"fmt"
 	"log/slog"
 
-	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/logger"
@@ -15,7 +14,7 @@ import (
 )
 
 // PlatformIssuer creates an attestation issuer for the current platform.
-func PlatformIssuer(log *slog.Logger) (atls.Issuer, error) {
+func PlatformIssuer(log *slog.Logger) (Issuer, error) {
 	cpuid.Detect()
 	switch {
 	case cpuid.CPU.Supports(cpuid.SEV_SNP):

--- a/internal/attestation/oid.go
+++ b/internal/attestation/oid.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package attestation
+
+import (
+	"encoding/asn1"
+
+	oids "github.com/edgelesssys/contrast/internal/oid"
+)
+
+// IsAttestationDocumentExtension checks whether the given OID corresponds to an attestation document extension
+// supported by Contrast (i.e. TDX or SNP).
+func IsAttestationDocumentExtension(oid asn1.ObjectIdentifier) bool {
+	return oid.Equal(oids.RawTDXReport) || oid.Equal(oids.RawSNPReport)
+}


### PR DESCRIPTION
Our aTLS code needs to be adjusted to allow for multiple attestation variants. While we did allow one to have multiple validators before, we tried to validate the first matching one and instantly errored out if validation for that validator failed. Now, we can have multiple matching validators and try all until one successfully validated the document, or until the list of applicable validators is exhausted, where we can return an error.