### PR TITLE
kata: use restrictive default policy

### DIFF
--- a/packages/by-name/kata/kata-image/package.nix
+++ b/packages/by-name/kata/kata-image/package.nix
@@ -38,14 +38,16 @@ let
     inherit (kata.kata-runtime) src version;
 
     # https://github.com/microsoft/azurelinux/blob/59ce246f224f282b3e199d9a2dacaa8011b75a06/SPECS/kata-containers-cc/mariner-coco-build-uvm.sh#L34-L41
-    # TODO(msanft): Use a more constrained policy.
     buildPhase = ''
       runHook preBuild
 
       mkdir -p /build/rootfs/etc/kata-opa /build/rootfs/usr/lib/systemd/system /build/rootfs/nix/store
       cp src/agent/kata-agent.service.in /build/rootfs/usr/lib/systemd/system/kata-agent.service
       cp src/agent/kata-containers.target /build/rootfs/usr/lib/systemd/system/kata-containers.target
-      cp src/kata-opa/allow-all.rego /build/rootfs/etc/kata-opa/default-policy.rego
+      cat > /build/rootfs/etc/kata-opa/default-policy.rego <<EOF
+      package agent_policy
+      default SetPolicyRequest := true
+      EOF
       sed -i 's/@BINDIR@\/@AGENT_NAME@/\/usr\/bin\/kata-agent/g'  /build/rootfs/usr/lib/systemd/system/kata-agent.service
       touch /build/rootfs/etc/machine-id
 

--- a/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
+++ b/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
@@ -1,4 +1,4 @@
-From 5af1244f3ed285fcbbb98f68d7584ca9292e9688 Mon Sep 17 00:00:00 2001
+From 5f8dbb3390fc47b7330b1bf6419466261a0541c1 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Fri, 5 Jul 2024 08:43:13 +0000
 Subject: [PATCH 1/3] govmm: Directly pass the firwmare using -bios with SNP
@@ -24,5 +24,5 @@ index 6d71e28f9..4cc2239ec 100644
  		objectParams = append(objectParams, string(object.Type))
  		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
 -- 
-2.45.1
+2.45.2
 

--- a/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
+++ b/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
@@ -1,4 +1,4 @@
-From 9be4faa0887716435e290beccef7f7bca0cb3960 Mon Sep 17 00:00:00 2001
+From f6bb9ca2c01ba9ed474c60faa8e29b033e8ca763 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 8 Jul 2024 07:35:54 +0000
 Subject: [PATCH 2/3] emulate CPU model that most closely matches the host
@@ -36,5 +36,5 @@ index 1d1be1711..6ebee26ce 100644
  	}
  
 -- 
-2.45.1
+2.45.2
 

--- a/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
+++ b/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
@@ -1,4 +1,4 @@
-From cf4f4d946cbc78a9e37386f5be95ebdc39040e4c Mon Sep 17 00:00:00 2001
+From 5228b0f7a667c700dbe9d169d7c735f1625f242a Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 8 Jul 2024 07:51:20 +0000
 Subject: [PATCH 3/3] runtime: agent: verify the agent policy hash
@@ -24,10 +24,10 @@ Signed-off-by: Tom Dohrmann <erbse.13@gmx.de>
  src/agent/src/policy.rs                       |  68 +++++-
  src/agent/src/sev.rs                          |  19 ++
  src/agent/src/tdx.rs                          | 194 ++++++++++++++++++
- src/runtime/pkg/govmm/qemu/qemu.go            |   8 +
+ src/runtime/pkg/govmm/qemu/qemu.go            |  25 ++-
  src/runtime/virtcontainers/hypervisor.go      |   4 +
  src/runtime/virtcontainers/qemu.go            |   2 +-
- src/runtime/virtcontainers/qemu_amd64.go      |  38 +++-
+ src/runtime/virtcontainers/qemu_amd64.go      |  37 +++-
  src/runtime/virtcontainers/qemu_amd64_test.go | 116 ++++++++++-
  src/runtime/virtcontainers/qemu_arch_base.go  |   4 +-
  src/runtime/virtcontainers/qemu_arm64.go      |   2 +-
@@ -37,7 +37,7 @@ Signed-off-by: Tom Dohrmann <erbse.13@gmx.de>
  src/runtime/virtcontainers/qemu_s390x.go      |   2 +-
  src/runtime/virtcontainers/qemu_s390x_test.go |  51 ++++-
  src/runtime/virtcontainers/sandbox.go         |   1 +
- 19 files changed, 684 insertions(+), 36 deletions(-)
+ 19 files changed, 698 insertions(+), 38 deletions(-)
  create mode 100644 src/agent/src/sev.rs
  create mode 100644 src/agent/src/tdx.rs
 
@@ -588,7 +588,7 @@ index 000000000..1531e72a8
 +    Ok(mrconfigid)
 +}
 diff --git a/src/runtime/pkg/govmm/qemu/qemu.go b/src/runtime/pkg/govmm/qemu/qemu.go
-index 4cc2239ec..5d669ca21 100644
+index 4cc2239ec..f5ff0fc95 100644
 --- a/src/runtime/pkg/govmm/qemu/qemu.go
 +++ b/src/runtime/pkg/govmm/qemu/qemu.go
 @@ -320,6 +320,11 @@ type Object struct {
@@ -613,6 +613,39 @@ index 4cc2239ec..5d669ca21 100644
  		config.Bios = object.File
  	case SecExecGuest:
  		objectParams = append(objectParams, string(object.Type))
+@@ -435,6 +443,10 @@ type SocketAddress struct {
+ type TdxQomObject struct {
+ 	QomType               string        `json:"qom-type"`
+ 	Id                    string        `json:"id"`
++	SeptVEDisable         *bool         `json:"sept-ve-disable,omitempty"`
++	MRConfigID            string        `json:"mrconfigid,omitempty"`
++	MROwner               string        `json:"mrowner,omitempty"`
++	MROwnerConfig         string        `json:"mrownerconfig,omitempty"`
+ 	QuoteGenerationSocket SocketAddress `json:"quote-generation-socket"`
+ 	Debug                 *bool         `json:"debug,omitempty"`
+ }
+@@ -463,10 +475,19 @@ func (this *TdxQomObject) String() string {
+ 
+ func prepareObjectWithTdxQgs(object Object) string {
+ 	qgsSocket := SocketAddress{"vsock", fmt.Sprint(VsockHostCid), fmt.Sprint(object.QgsPort)}
+-	tdxObject := TdxQomObject{string(object.Type), object.ID, qgsSocket, nil}
++	tdxObject := TdxQomObject{
++		QomType:               string(object.Type),
++		Id:                    object.ID,
++		QuoteGenerationSocket: qgsSocket,
++	}
+ 
+ 	if object.Debug {
+-		*tdxObject.Debug = true
++		t := true
++		tdxObject.Debug = &t
++	}
++
++	if len(object.TEEConfigData) > 0 {
++		tdxObject.MRConfigID = object.TEEConfigData
+ 	}
+ 
+ 	return tdxObject.String()
 diff --git a/src/runtime/virtcontainers/hypervisor.go b/src/runtime/virtcontainers/hypervisor.go
 index cc3743310..0c24183a3 100644
 --- a/src/runtime/virtcontainers/hypervisor.go
@@ -642,21 +675,20 @@ index 7a189bb91..509f74a3c 100644
  		return err
  	}
 diff --git a/src/runtime/virtcontainers/qemu_amd64.go b/src/runtime/virtcontainers/qemu_amd64.go
-index 6ebee26ce..7b702c305 100644
+index 6ebee26ce..44e0e3956 100644
 --- a/src/runtime/virtcontainers/qemu_amd64.go
 +++ b/src/runtime/virtcontainers/qemu_amd64.go
-@@ -9,6 +9,10 @@ package virtcontainers
+@@ -9,6 +9,9 @@ package virtcontainers
  
  import (
  	"context"
 +	"crypto/sha256"
 +	"crypto/sha512"
 +	"encoding/base64"
-+	"encoding/hex"
  	"fmt"
  	"time"
  
-@@ -280,7 +284,7 @@ func (q *qemuAmd64) enableProtection() error {
+@@ -280,7 +283,7 @@ func (q *qemuAmd64) enableProtection() error {
  }
  
  // append protection device
@@ -665,7 +697,7 @@ index 6ebee26ce..7b702c305 100644
  	if q.sgxEPCSize != 0 {
  		devices = append(devices,
  			govmmQemu.Object{
-@@ -305,6 +309,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
+@@ -305,6 +308,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
  				Debug:          false,
  				File:           firmware,
  				FirmwareVolume: firmwareVolume,
@@ -673,7 +705,7 @@ index 6ebee26ce..7b702c305 100644
  			}), "", nil
  	case sevProtection:
  		return append(devices,
-@@ -326,6 +331,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
+@@ -326,6 +330,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
  				CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
  				ReducedPhysBits: 1,
  				SnpCertsPath:    q.snpCertsPath,
@@ -681,7 +713,7 @@ index 6ebee26ce..7b702c305 100644
  			}), "", nil
  	case noneProtection:
  
-@@ -335,3 +341,33 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
+@@ -335,3 +340,33 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
  		return devices, "", fmt.Errorf("Unsupported guest protection technology: %v", q.protection)
  	}
  }
@@ -713,7 +745,7 @@ index 6ebee26ce..7b702c305 100644
 +	hash := h.Sum(nil)
 +	hvLogger.WithField("hash", hash).Info("policy hash")
 +
-+	return hex.EncodeToString(hash)
++	return base64.StdEncoding.EncodeToString(hash)
 +}
 diff --git a/src/runtime/virtcontainers/qemu_amd64_test.go b/src/runtime/virtcontainers/qemu_amd64_test.go
 index 1425cb38c..f0a9c691a 100644
@@ -1255,5 +1287,5 @@ index b58daccaa..af35af12e 100644
  	spec := s.GetPatchedOCISpec()
  	if spec != nil && spec.Process.SelinuxLabel != "" {
 -- 
-2.45.1
+2.45.2
 

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -26,10 +26,20 @@ buildGoModule rec {
       ./0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
       # This patch makes the v2 shim set the host-data field for SNP and makes
       # kata-agent verify it against the policy.
-      # source: https://github.com/kata-containers/kata-containers/pull/8469
+      # It was adapted from https://github.com/kata-containers/kata-containers/pull/8469,
+      # with the following modifications:
+      # - Rebase on 3.7.0 picked up regorus, guest-pull capabilities, SNP certificates and TDX fixes.
+      # - The TDX parameters for QEMU needed to be converted to a JSON object.
+      # - The encoding of MRCONFIGID needed to be switched from hex to base64.
+      # This patch is not going to be accepted upstream. The declared path
+      # forward is the initdata proposal, https://github.com/kata-containers/kata-containers/issues/9468,
+      # which extends the hostdata to arbitrary config beyond the policy and
+      # delegates hash verification to the AA. Until that effort lands, we're
+      # sticking with the policy verification from AKS CoCo.
+      #
       # Note that these patches are incomplete/insecure because kata-agent just
-      # continue running if it can't query the host-data:
-      # https://github.com/kata-containers/kata-containers/blob/61c83dfde3e38aab53b66f46f860347f1753ef5c/src/agent/src/policy.rs#L320
+      # continue running if it can't query the host-data.
+      # TODO(Freax13): fail verify_policy_digest without TEE data
       ./0003-runtime-agent-verify-the-agent-policy-hash.patch
     ];
   };


### PR DESCRIPTION
There's a bug in patch 0003 which causes wrong arguments for QEMU and thus prevents starting VMs ~- patch 0004 in this PR fixes that bug. Since 0003 corresponds to an open upstream PR, I'd rather not integrate the patch here into 0003, so that we have a clear history of the modifications.~

There was another bug in the upstream PR, which assumed hex encoding for MRCONFIGID where it should have been base64.

I amended 0003 to fix these, and subsequently changed to a restrictive default policy.
