### PR TITLE
cli: always write the coordinator policy hash file

### DIFF
--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -119,9 +119,9 @@ func getCoordinatorPolicyHash(policies []deployment, log *slog.Logger) string {
 		}
 		if deployment.policy.Hash().String() != DefaultCoordinatorPolicyHash {
 			log.Warn("Found unexpected coordinator policy", "name", deployment.name, "hash", deployment.policy.Hash())
-			hash = deployment.policy.Hash().String()
-			// Keep going, in case we need to warn about another coordinator.
 		}
+		hash = deployment.policy.Hash().String()
+		// Keep going, in case we need to warn about another coordinator.
 	}
 	return hash
 }


### PR DESCRIPTION
We only wrote the `coordinator-policy.sha256` file if the coordinator hash did not correspond to the embedded hash. This behavior is inconsistent and can cause problems, for example when users anticipate a diffferent hash but the policy happens to be the same as the default one. With this change, we're always writing the file.