### PR TITLE
genpolicy: hide logs by default

### DIFF
--- a/packages/by-name/microsoft/genpolicy/genpolicy_msft_settings_prod.patch
+++ b/packages/by-name/microsoft/genpolicy/genpolicy_msft_settings_prod.patch
@@ -1,0 +1,13 @@
+diff --git a/genpolicy-settings.json b/genpolicy-settings.json
+index 7d35862af..4e468d78e 100644
+--- a/genpolicy-settings.json
++++ b/genpolicy-settings.json
+@@ -318,7 +318,7 @@
+             "regex": []
+         },
+         "CloseStdinRequest": false,
+-        "ReadStreamRequest": true,
++        "ReadStreamRequest": false,
+         "UpdateEphemeralMountsRequest": false,
+         "WriteStreamRequest": false
+     }

--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru = rec {
-    settings = stdenvNoCC.mkDerivation {
+    settings-base = stdenvNoCC.mkDerivation {
       name = "${pname}-${version}-settings";
       inherit src sourceRoot;
 
@@ -88,14 +88,19 @@ rustPlatform.buildRustPackage rec {
       '';
     };
 
+    settings = applyPatches {
+      src = settings-base;
+      patches = [ ./genpolicy_msft_settings_prod.patch ];
+    };
+
     settings-coordinator = applyPatches {
-      src = settings;
+      src = settings-base;
       patches = [ ./genpolicy_msft_settings_coordinator.patch ];
     };
 
     # Settings that allow exec into CVM pods - not safe for production use!
     settings-dev = applyPatches {
-      src = settings;
+      src = settings-base;
       patches = [ ./genpolicy_msft_settings_dev.patch ];
     };
 


### PR DESCRIPTION
Logs may contain sensitive data and so they should be hidden by default. Upstream kata hides logs by default, but the Microsoft fork made them visible. This patch reverts back to hiding the logs. This won't affect the coordinator though because it uses a different set of settings. Note that this settings file is only included in release builds (.#cli-release).

Logs can be re-enabled by changing the `ReadStreamRequest` in settings.json to `true`.