### PR TITLE
[release/v0.8] telemetry: only send cli version

### DIFF
--- a/cli/constants/constants.go
+++ b/cli/constants/constants.go
@@ -1,0 +1,10 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package constants
+
+// Version value is injected at build time.
+var (
+	Version          = "0.0.0-dev"
+	GenpolicyVersion = "0.0.0-dev"
+)

--- a/cli/main.go
+++ b/cli/main.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/edgelesssys/contrast/cli/cmd"
+	"github.com/edgelesssys/contrast/cli/constants"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/node-installer/platforms"
 	"github.com/spf13/cobra"
@@ -30,15 +31,10 @@ func execute() error {
 	return cmd.ExecuteContext(ctx)
 }
 
-var (
-	version          = "0.0.0-dev"
-	genpolicyVersion = "0.0.0-dev"
-)
-
 func buildVersionString() string {
 	var versionsBuilder strings.Builder
 	versionsWriter := tabwriter.NewWriter(&versionsBuilder, 0, 0, 4, ' ', 0)
-	fmt.Fprintf(versionsWriter, "%s\n\n", version)
+	fmt.Fprintf(versionsWriter, "%s\n\n", constants.Version)
 	fmt.Fprintf(versionsWriter, "container image versions:\n")
 	imageReplacements := strings.Trim(string(cmd.ReleaseImageReplacements), "\n")
 	for _, image := range strings.Split(imageReplacements, "\n") {
@@ -51,7 +47,7 @@ func buildVersionString() string {
 	fmt.Fprintf(versionsWriter, "reference values for %s platform:\n", platforms.AKSCloudHypervisorSNP.String())
 	fmt.Fprintf(versionsWriter, "\truntime handler:\tcontrast-cc-%s\n", manifest.TrustedMeasurement[:32])
 	fmt.Fprintf(versionsWriter, "\tlaunch digest:\t%s\n", manifest.TrustedMeasurement)
-	fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", genpolicyVersion)
+	fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.GenpolicyVersion)
 	versionsWriter.Flush()
 	return versionsBuilder.String()
 }

--- a/cli/telemetry/telemetry.go
+++ b/cli/telemetry/telemetry.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"runtime"
 
+	"github.com/edgelesssys/contrast/cli/constants"
 	"github.com/spf13/cobra"
 )
 
@@ -51,12 +52,8 @@ func NewClient() *Client {
 func (c *Client) SendTelemetry(ctx context.Context, cmd *cobra.Command, cmdErr error) error {
 	cmdErrClass := classifyCmdErr(cmdErr)
 
-	if cmd.Root().Version == "" {
-		return fmt.Errorf("no cli version found")
-	}
-
 	telemetryRequest := RequestV1{
-		Version:     cmd.Root().Version,
+		Version:     constants.Version,
 		GOOS:        runtime.GOOS,
 		GOARCH:      runtime.GOARCH,
 		Cmd:         cmd.Name(),

--- a/cli/telemetry/telemetry_test.go
+++ b/cli/telemetry/telemetry_test.go
@@ -30,8 +30,6 @@ func TestSendTelemetry(t *testing.T) {
 	goodTestCmd := &cobra.Command{}
 	rootTestCmd.AddCommand(goodTestCmd)
 
-	badTestCmd := &cobra.Command{}
-
 	testCases := map[string]struct {
 		cmd                *cobra.Command
 		cmdErr             error
@@ -49,12 +47,6 @@ func TestSendTelemetry(t *testing.T) {
 			cmdErr:             fmt.Errorf("test error"),
 			serverResponseCode: http.StatusOK,
 			wantError:          false,
-		},
-		"bad command": {
-			cmd:                badTestCmd,
-			cmdErr:             nil,
-			serverResponseCode: http.StatusOK,
-			wantError:          true,
 		},
 		"bad http response": {
 			cmd:                goodTestCmd,

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -98,8 +98,8 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X main.version=v${version}"
-    "-X main.genpolicyVersion=${genpolicy.version}"
+    "-X github.com/edgelesssys/contrast/cli/constants.Version=${version}"
+    "-X github.com/edgelesssys/contrast/cli/constants.GenpolicyVersion=${genpolicy.version}"
     "-X github.com/edgelesssys/contrast/internal/manifest.TrustedMeasurement=${launchDigest}"
     "-X github.com/edgelesssys/contrast/internal/kuberesource.runtimeHandler=${runtimeHandler}"
   ];


### PR DESCRIPTION
Backport of #751 to `release/v0.8`.

Original description:

---

Only send the CLI version information in telemetry requests instead of a full version log obtained by `contrast --version`.