### PR TITLE
treewide: allow multiple validators

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -15,8 +15,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/ca"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
-	"github.com/google/go-sev-guest/proto/sevsnp"
-	"github.com/google/go-sev-guest/validate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -170,20 +168,4 @@ type State struct {
 
 	latest     *history.LatestTransition
 	generation int
-}
-
-// SNPValidateOpts returns SNP validation options from reference values.
-//
-// It also ensures that the policy hash in the report's HOSTDATA is allowed by the current
-// manifest.
-// TODO(msanft): make the manifest authoritative and allow other types of reference values.
-func (s *State) SNPValidateOpts(report *sevsnp.Report) (*validate.Options, error) {
-	mnfst := s.Manifest
-
-	hostData := manifest.NewHexString(report.HostData)
-	if _, ok := mnfst.Policies[hostData]; !ok {
-		return nil, fmt.Errorf("hostdata %s not found in manifest", hostData)
-	}
-
-	return mnfst.AKSValidateOpts()
 }

--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/internal/userapi"
-	"github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/spf13/afero"
@@ -37,8 +36,6 @@ func TestSNPValidateOpts(t *testing.T) {
 	require := require.New(t)
 	a, _ := newAuthority(t)
 	_, mnfstBytes, policies := newManifest(t)
-	policyHash := sha256.Sum256(policies[0])
-	report := &sevsnp.Report{HostData: policyHash[:]}
 
 	req := &userapi.SetManifestRequest{
 		Manifest: mnfstBytes,
@@ -47,16 +44,9 @@ func TestSNPValidateOpts(t *testing.T) {
 	_, err := a.SetManifest(context.Background(), req)
 	require.NoError(err)
 
-	opts, err := a.state.Load().SNPValidateOpts(report)
+	gens, err := a.state.Load().Manifest.SNPValidateOpts()
 	require.NoError(err)
-	require.NotNil(opts)
-
-	// Change to unknown policy hash in HostData.
-	report.HostData[0]++
-
-	opts, err = a.state.Load().SNPValidateOpts(report)
-	require.Error(err)
-	require.Nil(opts)
+	require.NotNil(gens)
 }
 
 // TODO(burgerdev): test ValidateCallback and GetCertBundle

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -60,7 +60,9 @@ func run() (retErr error) {
 	}
 
 	requestCert := func() (*meshapi.NewMeshCertResponse, error) {
-		dial := dialer.NewWithKey(issuer, atls.NoValidator, &net.Dialer{}, privKey)
+		// Supply an empty list of validators, as the coordinator does not need to be
+		// validated by the initializer.
+		dial := dialer.NewWithKey(issuer, atls.NoValidators, &net.Dialer{}, privKey)
 		conn, err := dial.Dial(ctx, net.JoinHostPort(coordinatorHostname, meshapi.Port))
 		if err != nil {
 			return nil, fmt.Errorf("dialing: %w", err)

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -28,8 +28,8 @@ import (
 const attestationTimeout = 30 * time.Second
 
 var (
-	// NoValidator skips validation of the server's attestation document.
-	NoValidator Validator
+	// NoValidators skips validation of the server's attestation document.
+	NoValidators = []Validator{}
 	// NoIssuer skips embedding the client's attestation document.
 	NoIssuer Issuer
 

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -18,38 +18,34 @@ import (
 
 // Dialer can open grpc client connections with different levels of ATLS encryption / verification.
 type Dialer struct {
-	issuer    atls.Issuer
-	validator atls.Validator
-	netDialer NetDialer
-	privKey   *ecdsa.PrivateKey
+	issuer     atls.Issuer
+	validators []atls.Validator
+	netDialer  NetDialer
+	privKey    *ecdsa.PrivateKey
 }
 
 // New creates a new Dialer.
-func New(issuer atls.Issuer, validator atls.Validator, netDialer NetDialer) *Dialer {
+func New(issuer atls.Issuer, validators []atls.Validator, netDialer NetDialer) *Dialer {
 	return &Dialer{
-		issuer:    issuer,
-		validator: validator,
-		netDialer: netDialer,
+		issuer:     issuer,
+		validators: validators,
+		netDialer:  netDialer,
 	}
 }
 
 // NewWithKey creates a new Dialer with the given private key.
-func NewWithKey(issuer atls.Issuer, validator atls.Validator, netDialer NetDialer, privKey *ecdsa.PrivateKey) *Dialer {
+func NewWithKey(issuer atls.Issuer, validators []atls.Validator, netDialer NetDialer, privKey *ecdsa.PrivateKey) *Dialer {
 	return &Dialer{
-		issuer:    issuer,
-		validator: validator,
-		netDialer: netDialer,
-		privKey:   privKey,
+		issuer:     issuer,
+		validators: validators,
+		netDialer:  netDialer,
+		privKey:    privKey,
 	}
 }
 
 // Dial creates a new grpc client connection to the given target using the atls validator.
 func (d *Dialer) Dial(_ context.Context, target string) (*grpc.ClientConn, error) {
-	var validators []atls.Validator
-	if d.validator != nil {
-		validators = append(validators, d.validator)
-	}
-	credentials := atlscredentials.NewWithKey(d.issuer, validators, d.privKey)
+	credentials := atlscredentials.NewWithKey(d.issuer, d.validators, d.privKey)
 
 	return grpc.NewClient(target,
 		d.grpcWithDialer(),

--- a/internal/manifest/constants.go
+++ b/internal/manifest/constants.go
@@ -13,27 +13,13 @@ import (
 // Default returns a default manifest with reference values for the given platform.
 func Default(platform platforms.Platform) (*Manifest, error) {
 	embeddedRefValues := GetEmbeddedReferenceValues()
+
 	refValues, err := embeddedRefValues.ForPlatform(platform)
 	if err != nil {
 		return nil, fmt.Errorf("get reference values for platform %s: %w", platform, err)
 	}
 
-	mnfst := Manifest{}
-	switch platform {
-	case platforms.AKSCloudHypervisorSNP:
-		return &Manifest{
-			ReferenceValues: ReferenceValues{
-				AKS: refValues.AKS,
-			},
-		}, nil
-	case platforms.RKE2QEMUTDX, platforms.K3sQEMUTDX:
-		return &Manifest{
-			ReferenceValues: ReferenceValues{
-				BareMetalTDX: refValues.BareMetalTDX,
-			},
-		}, nil
-	}
-	return &mnfst, nil
+	return &Manifest{ReferenceValues: *refValues}, nil
 }
 
 // GetEmbeddedReferenceValues returns the reference values embedded in the binary.

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -19,35 +19,30 @@ import (
 //go:embed assets/reference-values.json
 var EmbeddedReferenceValuesJSON []byte
 
-// ReferenceValues contains the workload-independent reference values for each platform.
+// ReferenceValues contains the workload-independent reference values for each TEE type.
 type ReferenceValues struct {
-	// AKS holds the reference values for AKS.
-	AKS *AKSReferenceValues `json:"aks,omitempty"`
-	// BareMetalTDX holds the reference values for TDX on bare metal.
-	BareMetalTDX *BareMetalTDXReferenceValues `json:"bareMetalTDX,omitempty"`
+	// SNP holds the reference values for SNP.
+	SNP []SNPReferenceValues `json:"snp,omitempty"`
+	// TDX holds the reference values for TDX.
+	TDX []TDXReferenceValues `json:"tdx,omitempty"`
 }
 
-// EmbeddedReferenceValues is a map of runtime handler names to reference values, as
-// embedded in the binary.
+// EmbeddedReferenceValues is a map of runtime handler names to a list of reference values
+// for the runtime handler, as embedded in the binary.
 type EmbeddedReferenceValues map[string]ReferenceValues
 
-// AKSReferenceValues contains reference values for AKS.
-type AKSReferenceValues struct {
-	SNP                SNPReferenceValues
-	TrustedMeasurement HexString
-}
-
-// BareMetalTDXReferenceValues contains reference values for BareMetalTDX.
-type BareMetalTDXReferenceValues struct {
-	TrustedMeasurement HexString
-}
-
-// SNPReferenceValues contains reference values for the SNP report.
+// SNPReferenceValues contains reference values for SEV-SNP.
 type SNPReferenceValues struct {
-	MinimumTCB SNPTCB
+	MinimumTCB         SNPTCB
+	TrustedMeasurement HexString
 }
 
-// SNPTCB represents a set of SNP TCB values.
+// TDXReferenceValues contains reference values for TDX.
+type TDXReferenceValues struct {
+	TrustedMeasurement HexString
+}
+
+// SNPTCB represents a set of SEV-SNP TCB values.
 type SNPTCB struct {
 	BootloaderVersion *SVN
 	TEEVersion        *SVN

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -52,32 +52,38 @@ let
       k3s-qemu-snp-handler = runtimeHandler "k3s-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
 
       aksRefVals = {
-        aks = {
-          snp = {
+        snp = [
+          {
             minimumTCB = {
               bootloaderVersion = 3;
               teeVersion = 0;
               snpVersion = 8;
               microcodeVersion = 115;
             };
-          };
-          trustedMeasurement = lib.removeSuffix "\n" (builtins.readFile microsoft.kata-igvm.launch-digest);
-        };
+            trustedMeasurement = lib.removeSuffix "\n" (builtins.readFile microsoft.kata-igvm.launch-digest);
+          }
+        ];
       };
 
       snpRefVals = {
-        inherit (aksRefVals.aks) snp;
-        trustedMeasurement = lib.removeSuffix "\n" (
-          builtins.readFile "${kata.contrast-node-installer-image.runtimeHash}"
-        );
+        snp = [
+          {
+            inherit (builtins.head aksRefVals.snp) minimumTCB;
+            trustedMeasurement = lib.removeSuffix "\n" (
+              builtins.readFile "${kata.contrast-node-installer-image.runtimeHash}"
+            );
+          }
+        ];
       };
 
       tdxRefVals = {
-        bareMetalTDX = {
-          trustedMeasurement = lib.removeSuffix "\n" (
-            builtins.readFile "${kata.contrast-node-installer-image.runtimeHash}"
-          );
-        };
+        tdx = [
+          {
+            trustedMeasurement = lib.removeSuffix "\n" (
+              builtins.readFile "${kata.contrast-node-installer-image.runtimeHash}"
+            );
+          }
+        ];
       };
     in
     builtins.toFile "reference-values.json" (


### PR DESCRIPTION
This changes the attestation (as of now, only SEV-SNP) to be passed
multiple validators. The aTLS code already handles multiple validators,
but the code previously passed only one. This way, attestation will now
work by being handed a list of validators, and returning success as soon
as one can successfully validate a report. Furthermore, the
`atls.NoValidator` is now obsolete, and semantically represented by
passing an empty list of validators.