### PR TITLE
node-installer: only replace runtimeName in paths

### DIFF
--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -37,8 +37,8 @@ var (
 	//go:embed containerd-config.toml
 	containerdBaseConfig string
 
-	// RuntimeBasePlaceholder is the placeholder for the per-runtime path (i.e. /opt/edgeless/contrast-cc...) in the target file paths.
-	RuntimeBasePlaceholder = "@@runtimeBase@@"
+	// RuntimeNamePlaceholder is the placeholder for the per-runtime path (i.e. /opt/edgeless/contrast-cc...) in the target file paths.
+	RuntimeNamePlaceholder = "@@runtimeName@@"
 )
 
 // CRIFQDN is the fully qualified domain name of the CRI service.

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -71,12 +71,10 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 		return fmt.Errorf("getting runtime handler name: %w", err)
 	}
 
-	runtimeBase := filepath.Join("/opt", "edgeless", runtimeHandlerName)
-
 	// Copy the files
 	for _, file := range config.Files {
-		// Replace @@runtimeBase@@ in the target path with the actual base directory.
-		targetPath := strings.ReplaceAll(file.Path, constants.RuntimeBasePlaceholder, runtimeBase)
+		// Replace @@runtimeName@@ in the target path with the actual base directory.
+		targetPath := strings.ReplaceAll(file.Path, constants.RuntimeNamePlaceholder, runtimeHandlerName)
 
 		fmt.Printf("Fetching %q to %q\n", file.URL, targetPath)
 
@@ -96,6 +94,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	}
 
 	// Fix-up the permissions of executables
+	runtimeBase := filepath.Join("/opt", "edgeless", runtimeHandlerName)
 	binDirs := []string{filepath.Join(hostMount, runtimeBase, "bin")}
 	switch platform {
 	case platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:

--- a/packages/by-name/kata/contrast-node-installer-image/package.nix
+++ b/packages/by-name/kata/contrast-node-installer-image/package.nix
@@ -32,59 +32,59 @@ let
           files = [
             {
               url = "file:///opt/edgeless/share/kata-containers.img";
-              path = "@@runtimeBase@@/share/kata-containers.img";
+              path = "/opt/edgeless/@@runtimeName@@/share/kata-containers.img";
             }
             {
               url = "file:///opt/edgeless/share/kata-kernel";
-              path = "@@runtimeBase@@/share/kata-kernel";
+              path = "/opt/edgeless/@@runtimeName@@/share/kata-kernel";
             }
             {
               url = "file:///opt/edgeless/snp/bin/qemu-system-x86_64";
-              path = "@@runtimeBase@@/snp/bin/qemu-system-x86_64";
+              path = "/opt/edgeless/@@runtimeName@@/snp/bin/qemu-system-x86_64";
             }
             {
               url = "file:///opt/edgeless/tdx/bin/qemu-system-x86_64";
-              path = "@@runtimeBase@@/tdx/bin/qemu-system-x86_64";
+              path = "/opt/edgeless/@@runtimeName@@/tdx/bin/qemu-system-x86_64";
             }
             {
               url = "file:///opt/edgeless/snp/share/OVMF.fd";
-              path = "@@runtimeBase@@/snp/share/OVMF.fd";
+              path = "/opt/edgeless/@@runtimeName@@/snp/share/OVMF.fd";
             }
             {
               url = "file:///opt/edgeless/tdx/share/OVMF.fd";
-              path = "@@runtimeBase@@/tdx/share/OVMF.fd";
+              path = "/opt/edgeless/@@runtimeName@@/tdx/share/OVMF.fd";
             }
             {
               url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2";
-              path = "@@runtimeBase@@/bin/containerd-shim-contrast-cc-v2";
+              path = "/opt/edgeless/@@runtimeName@@/bin/containerd-shim-contrast-cc-v2";
             }
             {
               url = "file:///opt/edgeless/bin/kata-runtime";
-              path = "@@runtimeBase@@/bin/kata-runtime";
+              path = "/opt/edgeless/@@runtimeName@@/bin/kata-runtime";
             }
             {
               url = "file:///opt/edgeless/snp/share/qemu/kvmvapic.bin";
-              path = "@@runtimeBase@@/snp/share/qemu/kvmvapic.bin";
+              path = "/opt/edgeless/@@runtimeName@@/snp/share/qemu/kvmvapic.bin";
             }
             {
               url = "file:///opt/edgeless/snp/share/qemu/linuxboot_dma.bin";
-              path = "@@runtimeBase@@/snp/share/qemu/linuxboot_dma.bin";
+              path = "/opt/edgeless/@@runtimeName@@/snp/share/qemu/linuxboot_dma.bin";
             }
             {
               url = "file:///opt/edgeless/snp/share/qemu/efi-virtio.rom";
-              path = "@@runtimeBase@@/snp/share/qemu/efi-virtio.rom";
+              path = "/opt/edgeless/@@runtimeName@@/snp/share/qemu/efi-virtio.rom";
             }
             {
               url = "file:///opt/edgeless/tdx/share/qemu/kvmvapic.bin";
-              path = "@@runtimeBase@@/tdx/share/qemu/kvmvapic.bin";
+              path = "/opt/edgeless/@@runtimeName@@/tdx/share/qemu/kvmvapic.bin";
             }
             {
               url = "file:///opt/edgeless/tdx/share/qemu/linuxboot_dma.bin";
-              path = "@@runtimeBase@@/tdx/share/qemu/linuxboot_dma.bin";
+              path = "/opt/edgeless/@@runtimeName@@/tdx/share/qemu/linuxboot_dma.bin";
             }
             {
               url = "file:///opt/edgeless/tdx/share/qemu/efi-virtio.rom";
-              path = "@@runtimeBase@@/tdx/share/qemu/efi-virtio.rom";
+              path = "/opt/edgeless/@@runtimeName@@/tdx/share/qemu/efi-virtio.rom";
             }
           ];
           inherit (kata.runtime-class-files) debugRuntime;

--- a/packages/by-name/microsoft/contrast-node-installer-image/package.nix
+++ b/packages/by-name/microsoft/contrast-node-installer-image/package.nix
@@ -32,19 +32,19 @@ let
           files = [
             {
               url = "file:///opt/edgeless/share/kata-containers.img";
-              path = "@@runtimeBase@@/share/kata-containers.img";
+              path = "/opt/edgeless/@@runtimeName@@/share/kata-containers.img";
             }
             {
               url = "file:///opt/edgeless/share/kata-containers-igvm.img";
-              path = "@@runtimeBase@@/share/kata-containers-igvm.img";
+              path = "/opt/edgeless/@@runtimeName@@/share/kata-containers-igvm.img";
             }
             {
               url = "file:///opt/edgeless/bin/cloud-hypervisor-snp";
-              path = "@@runtimeBase@@/bin/cloud-hypervisor-snp";
+              path = "/opt/edgeless/@@runtimeName@@/bin/cloud-hypervisor-snp";
             }
             {
               url = "file:///opt/edgeless/bin/containerd-shim-contrast-cc-v2";
-              path = "@@runtimeBase@@/bin/containerd-shim-contrast-cc-v2";
+              path = "/opt/edgeless/@@runtimeName@@/bin/containerd-shim-contrast-cc-v2";
             }
           ];
           inherit (microsoft.runtime-class-files) debugRuntime;


### PR DESCRIPTION
This allows using the runtime name as replacement in paths outside of opt/edgeless.