### PR TITLE
coordinator: pass state as AuthInfo to meshapi

### DIFF
--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -40,25 +40,21 @@ func TestSNPValidateOpts(t *testing.T) {
 	policyHash := sha256.Sum256(policies[0])
 	report := &sevsnp.Report{HostData: policyHash[:]}
 
-	opts, err := a.SNPValidateOpts(report)
-	require.Error(err)
-	require.Nil(opts)
-
 	req := &userapi.SetManifestRequest{
 		Manifest: mnfstBytes,
 		Policies: policies,
 	}
-	_, err = a.SetManifest(context.Background(), req)
+	_, err := a.SetManifest(context.Background(), req)
 	require.NoError(err)
 
-	opts, err = a.SNPValidateOpts(report)
+	opts, err := a.state.Load().SNPValidateOpts(report)
 	require.NoError(err)
 	require.NotNil(opts)
 
 	// Change to unknown policy hash in HostData.
 	report.HostData[0]++
 
-	opts, err = a.SNPValidateOpts(report)
+	opts, err = a.state.Load().SNPValidateOpts(report)
 	require.Error(err)
 	require.Nil(opts)
 }

--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package authority
+
+import (
+	"context"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/attestation/snp"
+	"github.com/edgelesssys/contrast/internal/logger"
+	"github.com/edgelesssys/contrast/internal/memstore"
+	"github.com/google/go-sev-guest/proto/sevsnp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc/credentials"
+	"k8s.io/utils/clock"
+)
+
+// Credentials are gRPC transport credentials that dynamically update with the Coordinator state.
+type Credentials struct {
+	issuer   atls.Issuer
+	getState func() (*State, error)
+
+	logger                     *slog.Logger
+	attestationFailuresCounter prometheus.Counter
+	kdsGetter                  *snp.CachedHTTPSGetter
+}
+
+// Credentials creates new transport credentials that validate peers according to the latest manifest.
+func (a *Authority) Credentials(reg *prometheus.Registry, issuer atls.Issuer) (*Credentials, func()) {
+	ticker := clock.RealClock{}.NewTicker(24 * time.Hour)
+	kdsGetter := snp.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(a.logger, "kds-getter"))
+	attestationFailuresCounter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Subsystem: "contrast_meshapi",
+		Name:      "attestation_failures_total",
+		Help:      "Number of attestation failures from workloads to the Coordinator.",
+	})
+
+	return &Credentials{
+		issuer: issuer,
+		getState: func() (*State, error) {
+			if err := a.syncState(); err != nil {
+				return nil, fmt.Errorf("syncing state: %w", err)
+			}
+			state := a.state.Load()
+			if state == nil {
+				return nil, errors.New("coordinator is not initialized")
+			}
+			return state, nil
+		},
+		logger:                     a.logger,
+		attestationFailuresCounter: attestationFailuresCounter,
+		kdsGetter:                  kdsGetter,
+	}, ticker.Stop
+}
+
+// ServerHandshake implements an aTLS handshake for the latest state.
+//
+// If successful, the state will be passed to gRPC as [AuthInfo].
+func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	state, err := c.getState()
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting state: %w", err)
+	}
+
+	authInfo := AuthInfo{State: state}
+
+	validator := snp.NewValidatorWithCallbacks(state, c.kdsGetter,
+		logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"tee-type": "snp"}),
+		c.attestationFailuresCounter, &authInfo)
+
+	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, []atls.Validator{validator})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn, info, err := credentials.NewTLS(serverCfg).ServerHandshake(rawConn)
+	if err != nil {
+		return nil, nil, err
+	}
+	tlsInfo, ok := info.(credentials.TLSInfo)
+	if ok {
+		authInfo.TLSInfo = tlsInfo
+	} else {
+		c.logger.Error("credentials.NewTLS returned unexpected AuthInfo", "obj", info)
+	}
+
+	return conn, authInfo, nil
+}
+
+// Info provides information about the protocol.
+func (c *Credentials) Info() credentials.ProtocolInfo {
+	return credentials.NewTLS(nil).Info()
+}
+
+// Clone is only necessary for clients and thus not implemented.
+func (c *Credentials) Clone() credentials.TransportCredentials {
+	panic("authority.Credentials does not implement Clone()")
+}
+
+// OverrideServerName is not implemented.
+func (c *Credentials) OverrideServerName(_ string) error {
+	return errors.New("OverrideServerName is not implemented")
+}
+
+// ClientHandshake is not implemented.
+func (c *Credentials) ClientHandshake(_ context.Context, _ string, _ net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return nil, nil, errors.New("ClientHandshake is not implemented")
+}
+
+// AuthInfo is used to pass channel authentication information and state to gRPC handlers.
+//
+// It implements [snp.validateCallbacker] to capture report data from the TLS handshake.
+type AuthInfo struct {
+	// TLSInfo holds details from the TLS handshake.
+	credentials.TLSInfo
+	// State is the coordinator state at the time of the TLS handshake.
+	State *State
+	// Report is the attestation report sent by the peer.
+	Report *sevsnp.Report
+}
+
+// ValidateCallback takes the validated report and attaches it to the [AuthInfo].
+func (a *AuthInfo) ValidateCallback(_ context.Context, report *sevsnp.Report, _ asn1.ObjectIdentifier, _, _, _ []byte) error {
+	a.Report = report
+	return nil
+}

--- a/coordinator/internal/authority/userapi.go
+++ b/coordinator/internal/authority/userapi.go
@@ -44,7 +44,7 @@ func (a *Authority) SetManifest(ctx context.Context, req *userapi.SetManifestReq
 	oldState := a.state.Load()
 	if oldState != nil {
 		// Subsequent SetManifest call, check permissions of caller.
-		if err := a.validatePeer(ctx, oldState.manifest); err != nil {
+		if err := a.validatePeer(ctx, oldState.Manifest); err != nil {
 			a.logger.Warn("SetManifest peer validation failed", "err", err)
 			return nil, status.Errorf(codes.PermissionDenied, "validating peer: %v", err)
 		}
@@ -131,10 +131,10 @@ func (a *Authority) SetManifest(ctx context.Context, req *userapi.SetManifestReq
 		return nil, status.Errorf(codes.Internal, "creating CA: %v", err)
 	}
 
-	nextState := &state{
+	nextState := &State{
 		latest:     nextLatest,
-		manifest:   m,
-		ca:         ca,
+		Manifest:   m,
+		CA:         ca,
 		generation: oldGeneration + 1,
 	}
 
@@ -203,8 +203,8 @@ func (a *Authority) GetManifests(_ context.Context, _ *userapi.GetManifestsReque
 
 	resp := &userapi.GetManifestsResponse{
 		Manifests: manifests,
-		RootCA:    state.ca.GetRootCACert(),
-		MeshCA:    state.ca.GetMeshCACert(),
+		RootCA:    state.CA.GetRootCACert(),
+		MeshCA:    state.CA.GetMeshCACert(),
 	}
 	for _, policy := range policies {
 		resp.Policies = append(resp.Policies, policy)

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -76,7 +76,7 @@ func run() (retErr error) {
 
 	userapi.RegisterUserAPIServer(grpcServer, meshAuth)
 	serverMetrics.InitializeMetrics(grpcServer)
-	meshAPI := newMeshAPIServer(meshAuth, meshAuth, promRegistry, serverMetrics, logger)
+	meshAPI := newMeshAPIServer(meshAuth, promRegistry, serverMetrics, logger)
 	metricsServer := &http.Server{}
 
 	eg, ctx := errgroup.WithContext(ctx)

--- a/coordinator/meshapi.go
+++ b/coordinator/meshapi.go
@@ -5,9 +5,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/x509"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net"
@@ -16,47 +14,25 @@ import (
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
-	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
-	"github.com/edgelesssys/contrast/internal/logger"
-	"github.com/edgelesssys/contrast/internal/memstore"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/meshapi"
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
-	"k8s.io/utils/clock"
 )
 
 type meshAPIServer struct {
-	grpc         *grpc.Server
-	bundleGetter certBundleGetter
-	ticker       clock.Ticker
-	logger       *slog.Logger
+	grpc    *grpc.Server
+	cleanup func()
+	logger  *slog.Logger
 
 	meshapi.UnimplementedMeshAPIServer
 }
 
-type certBundleGetter interface {
-	GetCertBundle(peerPublicKeyHashStr string) (authority.Bundle, error)
-}
-
-func newMeshAPIServer(meshAuth *authority.Authority, bundleGetter certBundleGetter, reg *prometheus.Registry, serverMetrics *grpcprometheus.ServerMetrics, log *slog.Logger) *meshAPIServer {
-	ticker := clock.RealClock{}.NewTicker(24 * time.Hour)
-	kdsGetter := snp.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(log, "kds-getter"))
-
-	attestationFailuresCounter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
-		Subsystem: "contrast_meshapi",
-		Name:      "attestation_failures_total",
-		Help:      "Number of attestation failures from workloads to the Coordinator.",
-	})
-
-	validator := snp.NewValidatorWithCallbacks(meshAuth, kdsGetter,
-		logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"tee-type": "snp"}),
-		attestationFailuresCounter, meshAuth)
-	credentials := atlscredentials.New(atls.NoIssuer, []atls.Validator{validator})
+func newMeshAPIServer(meshAuth *authority.Authority, reg *prometheus.Registry, serverMetrics *grpcprometheus.ServerMetrics, log *slog.Logger) *meshAPIServer {
+	credentials, cancel := meshAuth.Credentials(reg, atls.NoIssuer)
 
 	grpcServer := grpc.NewServer(
 		grpc.Creds(credentials),
@@ -69,10 +45,9 @@ func newMeshAPIServer(meshAuth *authority.Authority, bundleGetter certBundleGett
 		),
 	)
 	s := &meshAPIServer{
-		grpc:         grpcServer,
-		bundleGetter: bundleGetter,
-		ticker:       ticker,
-		logger:       log.WithGroup("meshapi"),
+		grpc:    grpcServer,
+		cleanup: cancel,
+		logger:  log.WithGroup("meshapi"),
 	}
 	meshapi.RegisterMeshAPIServer(s.grpc, s)
 	serverMetrics.InitializeMetrics(s.grpc)
@@ -86,24 +61,30 @@ func (i *meshAPIServer) Serve(endpoint string) error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 
-	defer i.ticker.Stop()
+	defer i.cleanup()
 	return i.grpc.Serve(lis)
 }
 
+// NewMeshCert creates a mesh certificate for the connected peer.
+//
+// When this handler is called, the transport credentials already ensured that
+// the peer is authorized according to the manifest, so it can start issuing
+// right away.
 func (i *meshAPIServer) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertRequest) (*meshapi.NewMeshCertResponse, error) {
 	i.logger.Info("NewMeshCert called")
-
-	// Fetch the peer public key from gRPC's TLS context and look up the corresponding cetificate.
 
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("failed to get peer from context")
 	}
 
-	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	authInfo, ok := p.AuthInfo.(authority.AuthInfo)
 	if !ok {
-		return nil, fmt.Errorf("failed to get TLS info from peer")
+		return nil, fmt.Errorf("unexpected AuthInfo type: %T", p.AuthInfo)
 	}
+	state := authInfo.State
+	report := authInfo.Report
+	tlsInfo := authInfo.TLSInfo
 
 	if len(tlsInfo.State.PeerCertificates) == 0 {
 		return nil, fmt.Errorf("no peer certificates found")
@@ -114,17 +95,31 @@ func (i *meshAPIServer) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertR
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal public key: %w", err)
 	}
-	peerPubKeyHash := sha256.Sum256(peerPubKeyBytes)
-	peerPublicKeyHashStr := hex.EncodeToString(peerPubKeyHash[:])
 
-	bundle, err := i.bundleGetter.GetCertBundle(peerPublicKeyHashStr)
+	hostData := manifest.NewHexString(report.HostData)
+	entry, ok := state.Manifest.Policies[hostData]
+	if !ok {
+		return nil, fmt.Errorf("report data %s not found in manifest", hostData)
+	}
+	dnsNames := entry.SANs
+
+	peerPubKey, err := x509.ParsePKIXPublicKey(peerPubKeyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("server did not create a bundle for ")
+		return nil, fmt.Errorf("failed to parse peer public key: %w", err)
+	}
+
+	extensions, err := snp.ClaimsToCertExtension(report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct extensions: %w", err)
+	}
+	cert, err := state.CA.NewAttestedMeshCert(dnsNames, extensions, peerPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue new attested mesh cert: %w", err)
 	}
 
 	return &meshapi.NewMeshCertResponse{
-		MeshCACert: bundle.MeshCA,
-		CertChain:  append(bundle.WorkloadCert, bundle.IntermediateCA...),
-		RootCACert: bundle.RootCA,
+		MeshCACert: state.CA.GetMeshCACert(),
+		CertChain:  append(cert, state.CA.GetIntermCACert()...),
+		RootCACert: state.CA.GetRootCACert(),
 	}, nil
 }


### PR DESCRIPTION
This fixes a race condition between `SNPValidateOpts`, `ValidateCallback` and `SetManifest`. It should also make it easier to evolve validation logic based on state. 

Now that we have the current state available in the meshapi handler, we can move the certificate issuance there and not deal with that in the validation path.