### PR TITLE
just: credential getter as nix script

### DIFF
--- a/justfile
+++ b/justfile
@@ -225,16 +225,7 @@ get-credentials-ci:
         --admin
 
 get-credentials-from-gcloud path:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    tmpConfig=$(mktemp)
-    gcloud secrets versions access {{ path }} --out-file="$tmpConfig"
-    mergedConfig=$(mktemp)
-    KUBECONFIG_BAK=${KUBECONFIG:-~/.kube/config}
-    KUBECONFIG=$tmpConfig:${KUBECONFIG_BAK} kubectl config view --flatten > $mergedConfig
-    export newContext=$(yq -r '.contexts.[0].name' $tmpConfig)
-    yq -i '.current-context = env(newContext)' $mergedConfig
-    mv $mergedConfig ${KUBECONFIG_BAK%%:*}
+    nix run .#scripts.get-credentials {{ path }}
 
 get-credentials-tdxbm: (get-credentials-from-gcloud "projects/796962942582/secrets/m50-ganondorf-kubeconf/versions/2")
 


### PR DESCRIPTION
Packaging the script with nix makes it work even if `gcloud` is not in the path.