### PR TITLE
authority: remove unused Bundle struct

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -24,14 +24,6 @@ import (
 // ErrNoManifest is returned when a manifest is needed but not present.
 var ErrNoManifest = errors.New("no manifest configured")
 
-// Bundle is a set of PEM-encoded certificates for Contrast workloads.
-type Bundle struct {
-	WorkloadCert   []byte
-	MeshCA         []byte
-	IntermediateCA []byte
-	RootCA         []byte
-}
-
 // Authority manages the manifest state of Contrast.
 type Authority struct {
 	// state holds all required configuration to serve requests from userapi.


### PR DESCRIPTION
This struct no longer is used since https://github.com/edgelesssys/contrast/pull/791.