### PR TITLE
nix: bump reference values for SNP on AKS

### DIFF
--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -55,10 +55,10 @@ let
         snp = [
           {
             minimumTCB = {
-              bootloaderVersion = 3;
+              bootloaderVersion = 4;
               teeVersion = 0;
-              snpVersion = 8;
-              microcodeVersion = 115;
+              snpVersion = 21;
+              microcodeVersion = 211;
             };
             trustedMeasurement = lib.removeSuffix "\n" (builtins.readFile microsoft.kata-igvm.launch-digest);
           }


### PR DESCRIPTION
We observed these new TCB values in a report on 08/14/2024.

For safety, we shouldn't merge this until 08/28/2024.