### PR TITLE
e2e: specify multiple reference values in openssl test

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -265,16 +265,21 @@ func toPtr[T any](t T) *T {
 	return &t
 }
 
+// patchReferenceValues modifies the manifest to contain multiple reference values for testing
+// cases with multiple validators, as well as filling in bare-metal SNP-specific values.
 func patchReferenceValues(t *testing.T, platform platforms.Platform, ct *contrasttest.ContrastTest) {
+	manifestBytes, err := os.ReadFile(ct.WorkDir + "/manifest.json")
+	require.NoError(t, err)
+	var m manifest.Manifest
+	require.NoError(t, json.Unmarshal(manifestBytes, &m))
+
+	// Duplicate the reference values to test multiple validators by having at least 2.
+	m.ReferenceValues.SNP = append(m.ReferenceValues.SNP, m.ReferenceValues.SNP[len(m.ReferenceValues.SNP)-1])
+
+	// Fill in bare-metal-SNP-specific values.
 	if platform == platforms.K3sQEMUSNP {
 		// The generate command doesn't fill in all required fields when
 		// generating a manifest for baremetal SNP. Do that now.
-
-		manifestBytes, err := os.ReadFile(ct.WorkDir + "/manifest.json")
-		require.NoError(t, err)
-		var m manifest.Manifest
-		require.NoError(t, json.Unmarshal(manifestBytes, &m))
-
 		for i, snp := range m.ReferenceValues.SNP {
 			snp.MinimumTCB.BootloaderVersion = toPtr(manifest.SVN(0))
 			snp.MinimumTCB.TEEVersion = toPtr(manifest.SVN(0))
@@ -282,9 +287,17 @@ func patchReferenceValues(t *testing.T, platform platforms.Platform, ct *contras
 			snp.MinimumTCB.MicrocodeVersion = toPtr(manifest.SVN(0))
 			m.ReferenceValues.SNP[i] = snp
 		}
-
-		manifestBytes, err = json.Marshal(m)
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(ct.WorkDir+"/manifest.json", manifestBytes, 0o644))
 	}
+
+	// Make the last set of reference values invalid by changing the SVNs.
+	m.ReferenceValues.SNP[len(m.ReferenceValues.SNP)-1].MinimumTCB = manifest.SNPTCB{
+		BootloaderVersion: toPtr(manifest.SVN(255)),
+		TEEVersion:        toPtr(manifest.SVN(255)),
+		SNPVersion:        toPtr(manifest.SVN(255)),
+		MicrocodeVersion:  toPtr(manifest.SVN(255)),
+	}
+
+	manifestBytes, err = json.Marshal(m)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(ct.WorkDir+"/manifest.json", manifestBytes, 0o644))
 }


### PR DESCRIPTION
The openssl test now additionally uses multiple reference values to test attestation with multiple validators. Only the second one of the provided validators should successfully validate the attestation document.