### PR TITLE
atls: only report attestation error if all validators fail

### DIFF
--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -78,7 +78,7 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("getting validators: %w", err)
 	}
 
-	dialer := dialer.NewWithKey(atls.NoIssuer, validators, &net.Dialer{}, workloadOwnerKey)
+	dialer := dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{}, workloadOwnerKey)
 
 	log.Debug("Dialing coordinator", "endpoint", flags.coordinator)
 	conn, err := dialer.Dial(cmd.Context(), flags.coordinator)

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -102,7 +102,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting validators: %w", err)
 	}
-	dialer := dialer.NewWithKey(atls.NoIssuer, validators, &net.Dialer{}, workloadOwnerKey)
+	dialer := dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{}, workloadOwnerKey)
 
 	conn, err := dialer.Dial(cmd.Context(), flags.coordinator)
 	if err != nil {

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -72,7 +72,7 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("getting validators: %w", err)
 	}
-	dialer := dialer.New(atls.NoIssuer, validators, &net.Dialer{})
+	dialer := dialer.New(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{})
 
 	log.Debug("Dialing coordinator", "endpoint", flags.coordinator)
 	conn, err := dialer.Dial(cmd.Context(), flags.coordinator)

--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -87,10 +87,10 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 	for _, opt := range opts {
 		validator := snp.NewValidatorWithCallbacks(opt, allowedHostDataEntries, c.kdsGetter,
 			logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"tee-type": "snp"}),
-			c.attestationFailuresCounter, &authInfo)
+			&authInfo)
 		validators = append(validators, validator)
 	}
-	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, validators)
+	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, validators, c.attestationFailuresCounter)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -159,7 +159,7 @@ func newGRPCServer(serverMetrics *grpcprometheus.ServerMetrics, log *slog.Logger
 		return nil, fmt.Errorf("creating issuer: %w", err)
 	}
 
-	credentials := atlscredentials.New(issuer, nil)
+	credentials := atlscredentials.New(issuer, atls.NoValidators, atls.NoMetrics)
 
 	grpcServer := grpc.NewServer(
 		grpc.Creds(credentials),

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -62,7 +62,7 @@ func run() (retErr error) {
 	requestCert := func() (*meshapi.NewMeshCertResponse, error) {
 		// Supply an empty list of validators, as the coordinator does not need to be
 		// validated by the initializer.
-		dial := dialer.NewWithKey(issuer, atls.NoValidators, &net.Dialer{}, privKey)
+		dial := dialer.NewWithKey(issuer, atls.NoValidators, atls.NoMetrics, &net.Dialer{}, privKey)
 		conn, err := dial.Dial(ctx, net.JoinHostPort(coordinatorHostname, meshapi.Port))
 		if err != nil {
 			return nil, fmt.Errorf("dialing: %w", err)


### PR DESCRIPTION
Previously we reported every single validator error even if there's one validator that passes. This lead to noisy logs and incorrect metrics.