### PR TITLE
ci: only update packages in rpm update

### DIFF
--- a/.github/actions/setup_nix/action.yml
+++ b/.github/actions/setup_nix/action.yml
@@ -23,9 +23,9 @@ runs:
       shell: bash
       run: |
         sudo mkdir /nixbld
-        truncate -s 3G btrfs.img
-        sudo mkfs.btrfs -f btrfs.img
-        sudo mount btrfs.img /nixbld
+        sudo truncate -s 3G /btrfs.img
+        sudo mkfs.btrfs -f /btrfs.img
+        sudo mount /btrfs.img /nixbld
         sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
         echo -e "[Service]\nEnvironment=TMPDIR=/nixbld" | sudo tee /etc/systemd/system/nix-daemon.service.d/btrfs.conf
         sudo systemctl daemon-reload


### PR DESCRIPTION
This fixes unexpected files, such as the btrfs image used in CI to be committed into the PR branch, as when no paths are specified, all are added.

[Example Run](https://github.com/edgelesssys/contrast/actions/runs/10448369515)