### PR TITLE
ci: always cleanup runner, create nix builder volume under /mnt

### DIFF
--- a/.github/actions/setup_nix/action.yml
+++ b/.github/actions/setup_nix/action.yml
@@ -22,11 +22,23 @@ runs:
     - name: use btrfs for nix builds
       shell: bash
       run: |
-        sudo mkdir /nixbld
-        truncate -s 3G btrfs.img
-        sudo mkfs.btrfs -f btrfs.img
-        sudo mount btrfs.img /nixbld
+        sudo df -h
+
+        echo "Removing unwanted software... "
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker system prune --all --force
+        sudo df -h
+
+        echo "Setting up btrfs nix builder volume..."
+        sudo mkdir -p /mnt/nixbld
+        sudo truncate -s 20G /mnt/btrfs.img
+        sudo mkfs.btrfs -f /mnt/btrfs.img
+        sudo mount /mnt/btrfs.img /mnt/nixbld
         sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-        echo -e "[Service]\nEnvironment=TMPDIR=/nixbld" | sudo tee /etc/systemd/system/nix-daemon.service.d/btrfs.conf
+        echo -e "[Service]\nEnvironment=TMPDIR=/mnt/nixbld" | sudo tee /etc/systemd/system/nix-daemon.service.d/btrfs.conf
         sudo systemctl daemon-reload
         sudo systemctl restart nix-daemon
+        sudo df -h

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,15 +25,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     steps:
-      # This job needs quite some space, so we remove some unnecessary things.
-      - uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
-        with:
-          root-reserve-mb: 20000
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}


### PR DESCRIPTION
github hosted runners have a second disk under /mnt that we can use for the builder volume. 