### PR TITLE
manifest: use tdx validator

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
+	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/fsstore"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/manifest"
@@ -91,16 +92,25 @@ func validatorsFromManifest(m *manifest.Manifest, log *slog.Logger, hostData []b
 	kdsCache := fsstore.New(kdsDir, log.WithGroup("kds-cache"))
 	kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"))
 
+	var validators []atls.Validator
+
 	opts, err := m.SNPValidateOpts(kdsGetter)
 	if err != nil {
 		return nil, fmt.Errorf("getting SNP validate options: %w", err)
 	}
-
-	var validators []atls.Validator
 	for _, opt := range opts {
 		validators = append(validators, snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, []manifest.HexString{manifest.NewHexString(hostData)},
 			logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"tee-type": "snp"}),
 		))
 	}
+
+	tdxOpts, err := m.TDXValidateOpts()
+	if err != nil {
+		return nil, fmt.Errorf("generating TDX validation options: %w", err)
+	}
+	for _, opt := range tdxOpts {
+		validators = append(validators, tdx.NewValidator(&tdx.StaticValidateOptsGenerator{Opts: opt}, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"tee-type": "tdx"})))
+	}
+
 	return validators, nil
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -63,7 +63,7 @@ func buildVersionString() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("getting reference values: %w", err)
 		}
-		printOptional := func(label string, value *manifest.SVN) {
+		printOptionalSVN := func(label string, value *manifest.SVN) {
 			fmt.Fprintf(versionsWriter, "\t      %s:\t", label)
 			if value != nil {
 				fmt.Fprintf(versionsWriter, "%d", value.UInt8())
@@ -72,16 +72,34 @@ func buildVersionString() (string, error) {
 			}
 			fmt.Fprint(versionsWriter, "\n")
 		}
+		printOptionalUint16 := func(label string, value *uint16) {
+			fmt.Fprintf(versionsWriter, "\t  %s:\t", label)
+			if value != nil {
+				fmt.Fprintf(versionsWriter, "%d", *value)
+			} else {
+				fmt.Fprint(versionsWriter, "(no default)")
+			}
+			fmt.Fprint(versionsWriter, "\n")
+		}
 		for _, snp := range values.SNP {
 			fmt.Fprintf(versionsWriter, "\t- launch digest:\t%s\n", snp.TrustedMeasurement.String())
 			fmt.Fprint(versionsWriter, "\t  default SNP TCB:\t\n")
-			printOptional("bootloader", snp.MinimumTCB.BootloaderVersion)
-			printOptional("tee", snp.MinimumTCB.TEEVersion)
-			printOptional("snp", snp.MinimumTCB.SNPVersion)
-			printOptional("microcode", snp.MinimumTCB.MicrocodeVersion)
+			printOptionalSVN("bootloader", snp.MinimumTCB.BootloaderVersion)
+			printOptionalSVN("tee", snp.MinimumTCB.TEEVersion)
+			printOptionalSVN("snp", snp.MinimumTCB.SNPVersion)
+			printOptionalSVN("microcode", snp.MinimumTCB.MicrocodeVersion)
 		}
 		for _, tdx := range values.TDX {
-			fmt.Fprintf(versionsWriter, "\t- launch digest:\t%s\n", tdx.TrustedMeasurement.String())
+			fmt.Fprintf(versionsWriter, "\t- mrTd:\t%s\n", tdx.MrTd.String())
+			for i, rtmr := range tdx.Rtrms {
+				fmt.Fprintf(versionsWriter, "\t  rtrm[%d]:\t%s\n", i, rtmr.String())
+			}
+			printOptionalUint16("minimum qe svn", tdx.MinimumPceSvn)
+			printOptionalUint16("minimum pce svn", tdx.MinimumPceSvn)
+			fmt.Fprintf(versionsWriter, "\t  minimum tee tcb svn:\t%s\n", tdx.MinimumTeeTcbSvn.String())
+			fmt.Fprintf(versionsWriter, "\t  mrSeam:\t%s\n", tdx.MrSeam.String())
+			fmt.Fprintf(versionsWriter, "\t  tdAttributes:\t%s\n", tdx.TdAttributes.String())
+			fmt.Fprintf(versionsWriter, "\t  xfam:\t%s\n", tdx.Xfam.String())
 		}
 
 		switch platform {

--- a/internal/attestation/tdx/validator.go
+++ b/internal/attestation/tdx/validator.go
@@ -122,6 +122,7 @@ func (v *Validator) Validate(ctx context.Context, attDocRaw []byte, nonce []byte
 	}
 	verifyOpts.TrustedRoots = rootCerts
 	verifyOpts.CheckRevocations = true
+	verifyOpts.GetCollateral = true
 	verifyOpts.Getter = v.certGetter
 
 	// Verify the report signature.

--- a/internal/attestation/tdx/validator.go
+++ b/internal/attestation/tdx/validator.go
@@ -90,6 +90,8 @@ func (v *Validator) OID() asn1.ObjectIdentifier {
 
 // Validate a TDX attestation.
 func (v *Validator) Validate(ctx context.Context, attDocRaw []byte, nonce []byte, peerPublicKey []byte) (err error) {
+	// TODO(freax13): Validate the memory integrity mode (logical vs cryptographic) in the provisioning certificate.
+
 	v.logger.Info("Validate called", "nonce", hex.EncodeToString(nonce))
 	defer func() {
 		if err != nil {

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -40,7 +40,14 @@ type SNPReferenceValues struct {
 
 // TDXReferenceValues contains reference values for TDX.
 type TDXReferenceValues struct {
-	TrustedMeasurement HexString
+	MrTd             HexString
+	Rtrms            [4]HexString
+	MinimumQeSvn     *uint16
+	MinimumPceSvn    *uint16
+	MinimumTeeTcbSvn HexString
+	MrSeam           HexString
+	TdAttributes     HexString
+	Xfam             HexString
 }
 
 // SNPTCB represents a set of SEV-SNP TCB values.

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -96,12 +96,25 @@ let
           ];
       };
 
+      fakeSha384Hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
       tdxRefVals = {
         tdx = [
           {
-            trustedMeasurement = lib.removeSuffix "\n" (
-              builtins.readFile "${kata.contrast-node-installer-image.runtimeHash}"
-            );
+            mrTd = fakeSha384Hash;
+            rtrms = [
+              fakeSha384Hash
+              fakeSha384Hash
+              fakeSha384Hash
+              fakeSha384Hash
+            ];
+            minimumQeSvn = 0;
+            minimumPceSvn = 0;
+            # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
+            minimumTeeTcbSvn = "04010200000000000000000000000000";
+            # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
+            mrSeam = "9790d89a10210ec6968a773cee2ca05b5aa97309f36727a968527be4606fc19e6f73acce350946c9d46a9bf7a63f8430";
+            tdAttributes = "0000001000000000";
+            xfam = "e702060000000000";
           }
         ];
       };


### PR DESCRIPTION
This PR implements the necessary functions to generate validation options for TDX and adds the TDX validators to the list of validators. This is enough to make `set` work.

Some caveats/TODOs:
- We don't cache certificates yet.
- We don't validate the launch measurements (we only validate the TCB).
- The coordinator doesn't add the certificate extensions yet.