### PR TITLE
docs: enable broken anchor detection

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,6 +13,7 @@ async function createConfig() {
     trailingSlash: false,
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'throw',
+    onBrokenAnchors: 'throw',
     favicon: 'img/favicon.ico',
 
     // GitHub pages deployment config.


### PR DESCRIPTION
Enable docusaurus's broken anchor detection. (Currently detects none.)