### PR TITLE
kata.kata-image: don't include tdnf/history.db

### DIFF
--- a/packages/by-name/kata/kata-image/package.nix
+++ b/packages/by-name/kata/kata-image/package.nix
@@ -196,6 +196,7 @@ stdenv.mkDerivation rec {
           --exclude='./usr/lib/systemd/system/systemd-timesyncd*' \
           --exclude='./usr/lib/systemd/system/systemd-tmpfiles-setup*' \
           --exclude='./usr/lib/systemd/system/systemd-update-utmp*' \
+          --exclude='./usr/lib/sysimage/tdnf/history.db' \
           --exclude='*systemd-bless-boot-generator*' \
           --exclude='*systemd-fstab-generator*' \
           --exclude='*systemd-getty-generator*' \


### PR DESCRIPTION
This fixes a reproducibility issue, as the db contained timestamps.