### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/e2e_kubernetes.yaml
+++ b/.github/workflows/e2e_kubernetes.yaml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         test_name: [servicemesh, openssl, policy, workloadsecret]
+      fail-fast: false
 
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/e2e_openssl_baremetal.yml
+++ b/.github/workflows/e2e_openssl_baremetal.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         test_name: [servicemesh, openssl, policy, workloadsecret]
         tee: [SNP, TDX]
+      fail-fast: false
 
     runs-on:
       labels: ${{ matrix.tee }}

--- a/.github/workflows/e2e_regression.yml
+++ b/.github/workflows/e2e_regression.yml
@@ -34,6 +34,7 @@ jobs:
           - getdents
           - genpolicy
           - regression
+      fail-fast: false
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/setup_nix


### PR DESCRIPTION
The matrix strategy defaults to failing fast: If any one of the test cases fails all other cases get cancelled as well. The problem with this is that sometimes tests fail not because the code is bad, but because the test is flaky. In an ideal world, we'd make the tests less flaky, but until then we shouldn't abort all other tests in the matrix. The advantage of not failing fast is that when we inevitably have to manually push the re-run button, we don't have to wait for all test cases to complete, but only for the one that failed.