### PR TITLE
Revert "nix: bump reference values for SNP on AKS"

### DIFF
--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -57,10 +57,10 @@ let
         snp = [
           {
             minimumTCB = {
-              bootloaderVersion = 4;
+              bootloaderVersion = 3;
               teeVersion = 0;
-              snpVersion = 21;
-              microcodeVersion = 211;
+              snpVersion = 8;
+              microcodeVersion = 115;
             };
             trustedMeasurement = lib.removeSuffix "\n" (
               builtins.readFile (


### PR DESCRIPTION
Some regions (e.g. `NorthEurope`) still use older TCBs, so we can't increase the default without breaking deployments in those regions.

Reverts edgelesssys/contrast#811