### PR TITLE
docs: update docs to include bare metal SNP

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -3,7 +3,14 @@
 The following instructions will guide you through the process of making an existing Kubernetes deployment
 confidential and deploying it together with Contrast.
 
-A running CoCo-enabled cluster is required for these steps, see the [setup guide](./getting-started/cluster-setup.md) on how to set it up.
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
+A running CoCo-enabled cluster is required for these steps, see the [setup guide](./getting-started/cluster-setup.md) on how to set up a cluster on AKS.
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+A running CoCo-enabled cluster is required for these steps, see the [setup guide](./getting-started//bare-metal.md) on how to set up a bare metal cluster.
+</TabItem>
+</Tabs>
 
 ## Deploy the Contrast runtime
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -20,18 +20,36 @@ This consists of a `RuntimeClass` resource and a `DaemonSet` that performs insta
 This step is only required once for each version of the runtime.
 It can be shared between Contrast deployments.
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-aks-clh-snp.yml
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-snp.yml
+```
+</TabItem>
+</Tabs>
 
 ## Deploy the Contrast Coordinator
 
 Install the latest Contrast Coordinator release, comprising a single replica deployment and a
 LoadBalancer service, into your cluster.
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/coordinator.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/coordinator-aks-clh-snp.yml
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/coordinator-k3s-qemu-snp.yml
+```
+</TabItem>
+</Tabs>
 
 ## Prepare your Kubernetes resources
 
@@ -165,9 +183,18 @@ and the Contrast Service Mesh to all workloads that have a specified configurati
 After that, it will generate the execution policies and add them as annotations to your deployment files.
 A `manifest.json` with the reference values of your deployment will be created.
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
 contrast generate --reference-values aks-clh-snp resources/
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+contrast generate --reference-values k3s-qemu-snp resources/
+```
+</TabItem>
+</Tabs>
 
 :::warning
 Please be aware that runtime policies currently have some blind spots. For example, they can't guarantee the starting order of containers. See the [current limitations](features-limitations.md#runtime-policies) for more details.
@@ -183,9 +210,18 @@ depending on how you want to customize your deployment.
 You can disable the Initializer injection completely by specifying the
 `--skip-initializer` flag in the `generate` command.
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
 contrast generate --reference-values aks-clh-snp --skip-initializer resources/
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+contrast generate --reference-values k3s-qemu-snp --skip-initializer resources/
+```
+</TabItem>
+</Tabs>
 
 </TabItem>
 

--- a/docs/docs/examples/emojivoto.md
+++ b/docs/docs/examples/emojivoto.md
@@ -50,18 +50,36 @@ This consists of a `RuntimeClass` resource and a `DaemonSet` that performs insta
 This step is only required once for each version of the runtime.
 It can be shared between Contrast deployments.
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-aks-clh-snp.yml
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-snp.yml
+```
+</TabItem>
+</Tabs>
 
 ### Deploy the Contrast Coordinator
 
 Deploy the Contrast Coordinator, comprising a single replica deployment and a
 LoadBalancer service, into your cluster:
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/coordinator.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/coordinator-aks-clh-snp.yml
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/coordinator-k3s-qemu-snp.yml
+```
+</TabItem>
+</Tabs>
 
 ### Generate policy annotations and manifest
 
@@ -69,9 +87,18 @@ Run the `generate` command to generate the execution policies and add them as
 annotations to your deployment files. A `manifest.json` file with the reference values
 of your deployment will be created:
 
+<Tabs queryString="platform">
+<TabItem value="aks-clh-snp" label="AKS" default>
 ```sh
 contrast generate --reference-values aks-clh-snp deployment/
 ```
+</TabItem>
+<TabItem value="k3s-qemu-snp" label="Bare Metal (SNP)">
+```sh
+contrast generate --reference-values k3s-qemu-snp deployment/
+```
+</TabItem>
+</Tabs>
 
 :::note[Runtime class and Initializer]
 

--- a/docs/docs/examples/emojivoto.md
+++ b/docs/docs/examples/emojivoto.md
@@ -28,7 +28,7 @@ where their votes are processed without leaking to the platform provider or work
 - **Installed Contrast CLI.**
   See the [installation instructions](./../getting-started/install.md) on how to get it.
 - **Running cluster with Confidential Containers support.**
-  Please follow the [cluster setup instructions](./../getting-started/cluster-setup.md)
+  Please follow the [AKS cluster setup instructions](./../getting-started/cluster-setup.md) or [bare metal setup instructions](./../getting-started/bare metal.md)
   to create a cluster.
 
 ## Steps to deploy emojivoto with Contrast

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -5,7 +5,7 @@ This section lists planned features and current limitations of Contrast.
 ## Availability
 
 - **Platform support**: At present, Contrast is exclusively available on Azure AKS, supported by the [Confidential Container preview for AKS](https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-containers-on-aks-preview). Expansion to other cloud platforms is planned, pending the availability of necessary infrastructure enhancements.
-- **Bare-metal support**: Support for running Contrast on bare-metal Kubernetes will be available soon for AMD SEV and Intel TDX.
+- **Bare metal support**: Support for running Contrast on bare metal Kubernetes will be available soon for AMD SEV and Intel TDX.
 
 ## Kubernetes features
 

--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -1,0 +1,19 @@
+# Prepare a Bare Metal Instance
+
+## Hardware & Firmware Setup
+
+1. Update your BIOS to a version that supports AMD SEV-SNP. Updating to the latest available version is recommended as newer versions will likely contain security patches for AMD SEV-SNP.
+2. Enter BIOS setup to enable SMEE, IOMMU, RMP coverage, and SEV-SNP. Set the SEV-ES ASID Space Limit to a non-zero number (higher is better).
+3. Download the latest firmware version for your processor from [AMD](https://www.amd.com/de/developer/sev.html), unpack it, and place it in `/lib/firmware/amd`.
+
+Consult AMD's [Using SEV with AMD EPYC Processors](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/tuning-guides/58207-using-sev-with-amd-epyc-processors.pdf) user guide for more information.
+
+## Kernel Setup
+
+1. Install a kernel with version 6.11 or greater.
+2. Increase the `memlock` limit to 8 GiB.
+
+## K3s Setup
+
+1. Follow the [K3s setup instructions](https://docs.k3s.io/) to create a cluster.
+2. Install a block storage provider such as [Longhorn](https://docs.k3s.io/storage#setting-up-longhorn) and mark it as the default storage class.

--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -1,17 +1,16 @@
-# Prepare a Bare Metal Instance
+# Prepare a bare metal instance
 
-## Hardware & Firmware Setup
+## Hardware and firmware setup
 
 1. Update your BIOS to a version that supports AMD SEV-SNP. Updating to the latest available version is recommended as newer versions will likely contain security patches for AMD SEV-SNP.
 2. Enter BIOS setup to enable SMEE, IOMMU, RMP coverage, and SEV-SNP. Set the SEV-ES ASID Space Limit to a non-zero number (higher is better).
 3. Download the latest firmware version for your processor from [AMD](https://www.amd.com/de/developer/sev.html), unpack it, and place it in `/lib/firmware/amd`.
 
-Consult AMD's [Using SEV with AMD EPYC Processors](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/tuning-guides/58207-using-sev-with-amd-epyc-processors.pdf) user guide for more information.
+Consult AMD's [Using SEV with AMD EPYC Processors user guide](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/tuning-guides/58207-using-sev-with-amd-epyc-processors.pdf) for more information.
 
 ## Kernel Setup
 
-1. Install a kernel with version 6.11 or greater.
-2. Increase the `memlock` limit to 8 GiB.
+1. Install a kernel with version 6.11 or greater. If you're following this guide before 6.11 has been released, use 6.11-rc3. Don't use 6.11-rc4 - 6.11-rc6 as they contain a regression. 6.11-rc7+ might work.
 
 ## K3s Setup
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -56,6 +56,11 @@ const sidebars = {
           label: 'Cluster setup',
           id: 'getting-started/cluster-setup',
         },
+        {
+          type: 'doc',
+          label: 'Bare metal setup',
+          id: 'getting-started/bare-metal',
+        },
       ]
     },
     {


### PR DESCRIPTION
This PR updates the documentation to include setup guides for SNP on bare metal and updates the architecture section for the changes regarding VMMs and snapshotters.

This PR doesn't include any documentation on TDX on bare metal.