### PR TITLE
e2e: always sleep for 5 more seconds after resource is up

### DIFF
--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -239,6 +239,11 @@ retryLoop:
 					return err
 				}
 				if desiredPods <= numPodsReady {
+					// Wait for 5 more seconds just to be *really* sure that
+					// the pods are actually up.
+					sleep, cancel := context.WithTimeout(ctx, time.Second*5)
+					defer cancel()
+					<-sleep.Done()
 					return nil
 				}
 			case watch.Deleted:

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -137,7 +137,7 @@ func TestOpenSSL(t *testing.T) {
 		t.Run(fmt.Sprintf("certificate rotation and %s restart", deploymentToRestart), func(t *testing.T) {
 			require := require.New(t)
 
-			ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(1*time.Minute))
+			ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(2*time.Minute))
 			defer cancel()
 
 			c := kubeclient.NewForTest(t)


### PR DESCRIPTION
We've seen a lot of spurious errors when connecting to various resources. If we wait just a little longer the vast majority of these errors go away. This is not clean, but it works well.

I ran all e2e tests three times with these changes and only saw two failures: One of them was a timeout in the `certificate rotation and ... restart` test (probably because of the artificial delay introduced here), so I raised the timeout for that test. The other test failure was related to a DNS error while pulling the images. I didn't do anything to prevent that from happening again because I haven't seen this error occur much. All other test jobs succeeded on the first try.

The downside of this change is that all e2e tests now run a bit longer, but I'd say we'd likely want to prioritize CI stability over speed. 