### PR TITLE
bm: enable persistent volumes on block devices

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,17 +49,6 @@ jobs:
               runner: TDX
               self-hosted: true
             test_name: policy
-          # We don't have the policy support for CSI storage on K3s-qemu yet
-          - platform:
-              name: K3s-QEMU-SNP
-              runner: SNP
-              self-hosted: true
-            test_name: volumestatefulset
-          - platform:
-              name: K3s-QEMU-TDX
-              runner: TDX
-              self-hosted: true
-            test_name: volumestatefulset
       fail-fast: false
     name: "${{ matrix.platform.name }} / ${{ matrix.test_name }}"
     runs-on: ${{ matrix.platform.runner }}

--- a/e2e/volumestatefulset/volumestatefulset_test.go
+++ b/e2e/volumestatefulset/volumestatefulset_test.go
@@ -58,7 +58,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 	require.True(t, t.Run("deployments become available", func(t *testing.T) {
 		require := require.New(t)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(1*time.Minute))
 		defer cancel()
 
 		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
@@ -89,7 +89,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 	t.Run("file still exists when pod is restarted", func(t *testing.T) {
 		require := require.New(t)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(30*time.Second))
 		defer cancel()
 
 		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/edgelesssys/contrast/internal/platforms"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -543,6 +544,9 @@ sleep inf
 
 	vss := StatefulSet("volume-tester", "").
 		WithSpec(StatefulSetSpec().
+			WithPersistentVolumeClaimRetentionPolicy(applyappsv1.StatefulSetPersistentVolumeClaimRetentionPolicy().
+				WithWhenDeleted(appsv1.DeletePersistentVolumeClaimRetentionPolicyType).
+				WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)).
 			WithReplicas(1).
 			WithSelector(LabelSelector().
 				WithMatchLabels(map[string]string{"app.kubernetes.io/name": "volume-tester"}),

--- a/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
+++ b/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
@@ -1,7 +1,7 @@
-From 411bd00786e7ed1f75f2207093b05a5ee2406cb6 Mon Sep 17 00:00:00 2001
+From 26845d3f55d2d7a5cae227a2d54c05039b7fa5c1 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Fri, 5 Jul 2024 08:43:13 +0000
-Subject: [PATCH 01/15] govmm: Directly pass the firwmare using -bios with SNP
+Subject: [PATCH 01/16] govmm: Directly pass the firwmare using -bios with SNP
 
 3e158001993cc2356d6ac084e6c82714210c9f24, but for SNP.
 ---
@@ -24,5 +24,5 @@ index 47322c803..6b2b6b02d 100644
  		objectParams = append(objectParams, string(object.Type))
  		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
+++ b/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
@@ -1,7 +1,7 @@
-From 9a0824c8d4ec44ef0a0055ce55bad639a648f33f Mon Sep 17 00:00:00 2001
+From 733116619a9b1253e9ffaeb0a7ea940824a689ec Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 8 Jul 2024 07:35:54 +0000
-Subject: [PATCH 02/15] emulate CPU model that most closely matches the host
+Subject: [PATCH 02/16] emulate CPU model that most closely matches the host
 
 QEMU's CPU model 'host' still doesn't support SNP, but by using the
 correct model, the guest is able to figure out the correct CPU model
@@ -36,5 +36,5 @@ index 1d1be1711..6ebee26ce 100644
  	}
  
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
+++ b/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
@@ -1,7 +1,7 @@
-From de85c30c9583658b68ae7a3480f06141098ebd92 Mon Sep 17 00:00:00 2001
+From 0bac64b0dfa8ff2d55065dff6df106a6f02f19a3 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 8 Jul 2024 07:51:20 +0000
-Subject: [PATCH 03/15] runtime: agent: verify the agent policy hash
+Subject: [PATCH 03/16] runtime: agent: verify the agent policy hash
 
 For TEE Guests that support the inclusion of immutable Host owned
 data in their configuration (SNP HostData and TDX MRCONFIGID):
@@ -1287,5 +1287,5 @@ index b58daccaa..af35af12e 100644
  	spec := s.GetPatchedOCISpec()
  	if spec != nil && spec.Process.SelinuxLabel != "" {
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0004-virtcontainers-allow-specifying-nydus-overlayfs-bina.patch
+++ b/packages/by-name/kata/kata-runtime/0004-virtcontainers-allow-specifying-nydus-overlayfs-bina.patch
@@ -1,7 +1,7 @@
-From bfcf9e110f0037b7997f64316df69b1fa5a481ca Mon Sep 17 00:00:00 2001
+From a5f9f9f9ec4c39cba26bcb44f7723167dfeaafe6 Mon Sep 17 00:00:00 2001
 From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
 Date: Fri, 9 Aug 2024 11:06:04 +0200
-Subject: [PATCH 04/15] virtcontainers: allow specifying nydus-overlayfs binary
+Subject: [PATCH 04/16] virtcontainers: allow specifying nydus-overlayfs binary
  by path
 
 ...or by using a binary with additional suffix.
@@ -179,5 +179,5 @@ index be76a93a6..a809bb018 100644
  			} else {
  				errors = merr.Append(errors, bindUnmountContainerRootfs(ctx, sharedDir, c.id))
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0005-genpolicy-deny-UpdateEphemeralMountsRequest.patch
+++ b/packages/by-name/kata/kata-runtime/0005-genpolicy-deny-UpdateEphemeralMountsRequest.patch
@@ -1,7 +1,7 @@
-From 4fe46c61492a8c85151a33b077926b85061d63e2 Mon Sep 17 00:00:00 2001
+From 7d65877367e4426af37d268e6319aa774bea5130 Mon Sep 17 00:00:00 2001
 From: Dan Mihai <Daniel.Mihai@microsoft.com>
 Date: Tue, 19 Dec 2023 09:54:55 -0800
-Subject: [PATCH 05/15] genpolicy: deny UpdateEphemeralMountsRequest
+Subject: [PATCH 05/16] genpolicy: deny UpdateEphemeralMountsRequest
 
 * genpolicy: deny UpdateEphemeralMountsRequest
 
@@ -100,5 +100,5 @@ index c88b4adec..192bc637b 100644
  
  # If auto-generated policy testing is enabled, make a copy of the genpolicy settings,
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0006-genpolicy-validate-create-sandbox-storages.patch
+++ b/packages/by-name/kata/kata-runtime/0006-genpolicy-validate-create-sandbox-storages.patch
@@ -1,7 +1,7 @@
-From e902cd4eb01f4f3cef0b6ebba90bef29aa55f0a1 Mon Sep 17 00:00:00 2001
+From 2bc191c283ac45aa817ba381113ed7a64adb15b8 Mon Sep 17 00:00:00 2001
 From: Dan Mihai <dmihai@microsoft.com>
 Date: Thu, 4 Jan 2024 22:28:24 +0000
-Subject: [PATCH 06/15] genpolicy: validate create sandbox storages
+Subject: [PATCH 06/16] genpolicy: validate create sandbox storages
 
 Reject any unexpected values from the CreateSandboxRequest storages
 field.
@@ -143,5 +143,5 @@ index 949f6ad27..b7f0515d1 100644
  
  /// Volume settings loaded from genpolicy-settings.json.
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0007-genpolicy-enable-sysctl-checks.patch
+++ b/packages/by-name/kata/kata-runtime/0007-genpolicy-enable-sysctl-checks.patch
@@ -1,7 +1,7 @@
-From d52d9b317afd106b9e353a48997340ecf43c7cbb Mon Sep 17 00:00:00 2001
+From 1c92aee66cf7294a6b8bf635f6fc6b773a140fab Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Wed, 24 Jul 2024 09:48:48 +0200
-Subject: [PATCH 07/15] genpolicy: enable sysctl checks
+Subject: [PATCH 07/16] genpolicy: enable sysctl checks
 
 Sysctls may be added to a container by the Kubernetes pod definition or
 by containerd configuration. This commit adds support for the
@@ -219,5 +219,5 @@ index 973643e1f..adbdf97f3 100644
              OCI: KataSpec {
                  Version: self.config.settings.kata_config.oci_version.clone(),
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0008-genpolicy-read-bundle-id-from-rootfs.patch
+++ b/packages/by-name/kata/kata-runtime/0008-genpolicy-read-bundle-id-from-rootfs.patch
@@ -1,7 +1,7 @@
-From 092cbc6954d4c00822e59a96fc4e787e24b13879 Mon Sep 17 00:00:00 2001
+From 6ae1803e02b0b6bd036a432ef919b5fb5e1df0ad Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Wed, 24 Jul 2024 09:51:57 +0200
-Subject: [PATCH 08/15] genpolicy: read bundle-id from rootfs
+Subject: [PATCH 08/16] genpolicy: read bundle-id from rootfs
 
 The host path of bundles is not portable and could be literally anything
 depending on containerd configuration, so we can't rely on a specific
@@ -68,5 +68,5 @@ index fe80ed11f..7cd3d4202 100644
  allow_mount(p_oci, i_mount, bundle_id, sandbox_id) {
      print("allow_mount: i_mount =", i_mount)
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0009-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
+++ b/packages/by-name/kata/kata-runtime/0009-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
@@ -1,7 +1,7 @@
-From 47c4813e6216fbe3adeff31b89ef35ec15b33fab Mon Sep 17 00:00:00 2001
+From d7ec61a727cd80de6538b74bd00441feabbf5111 Mon Sep 17 00:00:00 2001
 From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
 Date: Thu, 11 Jul 2024 12:05:00 +0200
-Subject: [PATCH 09/15] genpolicy: regex check contrast specific
+Subject: [PATCH 09/16] genpolicy: regex check contrast specific
  layer-src-prefix
 
 Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
@@ -23,5 +23,5 @@ index 7cd3d4202..768d126f5 100644
      print("allow_storage_options 2: i_storage.options[i_count - 2] =", i_storage.options[i_count - 2])
      i_storage.options[i_count - 2] == "io.katacontainers.fs-opt.overlay-rw"
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0010-genpolicy-settings-bump-OCI-version.patch
+++ b/packages/by-name/kata/kata-runtime/0010-genpolicy-settings-bump-OCI-version.patch
@@ -1,7 +1,7 @@
-From 1fc19b89f1b50e1807ebbfe0db17ceb1c502fba5 Mon Sep 17 00:00:00 2001
+From 430ce6de80cd7fecb1c81b8c43a51f4e4a5d6c8e Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Wed, 24 Jul 2024 11:16:37 +0200
-Subject: [PATCH 10/15] genpolicy-settings: bump OCI version
+Subject: [PATCH 10/16] genpolicy-settings: bump OCI version
 
 Kata hard-codes OCI version 1.1.0, but latest K3S has 1.2.0.
 ---
@@ -29,5 +29,5 @@ index e50d5e545..fcafa46cc 100644
 \ No newline at end of file
 +}
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0011-genpolicy-settings-change-cpath-for-Nydus-guest-pull.patch
+++ b/packages/by-name/kata/kata-runtime/0011-genpolicy-settings-change-cpath-for-Nydus-guest-pull.patch
@@ -1,7 +1,7 @@
-From ebf6f448e2069019c6c8975bac82f499e8d69197 Mon Sep 17 00:00:00 2001
+From 898be6d6076647b09350cadd4ee0495d31b5eb79 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Mon, 12 Aug 2024 14:18:43 +0200
-Subject: [PATCH 11/15] genpolicy-settings: change cpath for Nydus guest pull
+Subject: [PATCH 11/16] genpolicy-settings: change cpath for Nydus guest pull
 
 Nydus uses a different base dir for container rootfs, see
 https://github.com/kata-containers/kata-containers/blob/775f6bd/tests/integration/kubernetes/tests_common.sh#L139
@@ -23,5 +23,5 @@ index fcafa46cc..4e9f6481d 100644
          "sfprefix": "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-",
          "ip_p": "[0-9]{1,5}",
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0012-genpolicy-allow-image_guest_pull.patch
+++ b/packages/by-name/kata/kata-runtime/0012-genpolicy-allow-image_guest_pull.patch
@@ -1,7 +1,7 @@
-From fe60478b58770704074b1552629c362037d89e71 Mon Sep 17 00:00:00 2001
+From bbe2c34d00d62473d24799470fdb22e6e9e65d0a Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Thu, 1 Aug 2024 15:58:42 +0200
-Subject: [PATCH 12/15] genpolicy: allow image_guest_pull
+Subject: [PATCH 12/16] genpolicy: allow image_guest_pull
 
 This adds an alternative version of allow_storages that checks Nydus
 guest pull instructions. The image reference is present in two
@@ -2343,5 +2343,5 @@ index 000000000..2f21e0674
 +  }
 +]
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0013-runtime-agent-mounts-Mount-configfs-into-the-contain.patch
+++ b/packages/by-name/kata/kata-runtime/0013-runtime-agent-mounts-Mount-configfs-into-the-contain.patch
@@ -1,7 +1,7 @@
-From b5f23b723f7e5eef438698d93c0d69328b722e0e Mon Sep 17 00:00:00 2001
+From bf2705a8fc385891890b96e2b175c837c076b91e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fabiano=20Fid=C3=AAncio?= <fabiano.fidencio@intel.com>
 Date: Thu, 25 Apr 2024 10:34:26 +0200
-Subject: [PATCH 13/15] runtime: agent: mounts: Mount configfs into the
+Subject: [PATCH 13/16] runtime: agent: mounts: Mount configfs into the
  container
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -55,5 +55,5 @@ index 14e3d9560..b5f857913 100644
      unistd::chdir(rootfs)?;
  
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0014-genpolicy-bump-oci-distribution-to-v0.12.0.patch
+++ b/packages/by-name/kata/kata-runtime/0014-genpolicy-bump-oci-distribution-to-v0.12.0.patch
@@ -1,7 +1,7 @@
-From fe09addb23320b1ac3d11052992f2db9dd764e22 Mon Sep 17 00:00:00 2001
+From f1810865d1996d3c75fcb40b4105a0b622036d15 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Mon, 12 Aug 2024 13:45:43 +0200
-Subject: [PATCH 14/15] genpolicy: bump oci-distribution to v0.12.0
+Subject: [PATCH 14/16] genpolicy: bump oci-distribution to v0.12.0
 
 This picks up a security fix for confidential pulling of unsigned
 images.
@@ -637,5 +637,5 @@ index 6e0d6af3f..c206dec86 100644
  use tokio::{
      io,
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0015-agent-bump-image-rs-version.patch
+++ b/packages/by-name/kata/kata-runtime/0015-agent-bump-image-rs-version.patch
@@ -1,7 +1,7 @@
-From 55176b158d2fe2b58c82d6ece687b77d816f0cdf Mon Sep 17 00:00:00 2001
+From ff84e4320e8b2a47bfa7ba8b0ff405ccb42074c8 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Fri, 13 Sep 2024 10:33:30 +0200
-Subject: [PATCH 15/15] agent: bump image-rs version
+Subject: [PATCH 15/16] agent: bump image-rs version
 
 The oci-distribution crate was recently renamed to oci-client, and new
 releases are only published for oci-client. image-rs needed to migrate
@@ -530,5 +530,5 @@ index 4b9a0ed48..005c551cc 100644
  # Agent Policy
  regorus = { version = "0.1.4", default-features = false, features = [
 -- 
-2.46.1
+2.46.2
 

--- a/packages/by-name/kata/kata-runtime/0016-genpolicy-support-mount-propagation-and-ro-mounts.patch
+++ b/packages/by-name/kata/kata-runtime/0016-genpolicy-support-mount-propagation-and-ro-mounts.patch
@@ -1,0 +1,58 @@
+From f7100bd145c2702546633dde0192cce6d53f032a Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Tue, 24 Sep 2024 16:05:31 +0200
+Subject: [PATCH 16/16] genpolicy: support mount propagation and ro-mounts
+
+---
+ src/tools/genpolicy/rules.rego               |  3 ++-
+ src/tools/genpolicy/src/mount_and_storage.rs | 14 ++++++++++++--
+ 2 files changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
+index 685109ba6..85d70d9b3 100644
+--- a/src/tools/genpolicy/rules.rego
++++ b/src/tools/genpolicy/rules.rego
+@@ -105,7 +105,8 @@ allow_create_container_input {
+     count(i_linux.GIDMappings) == 0
+     count(i_linux.MountLabel) == 0
+     count(i_linux.Resources.Devices) == 0
+-    count(i_linux.RootfsPropagation) == 0
++    # TODO(burgerdev): is it harmful to always allow RootfsPropagation?
++    # count(i_linux.RootfsPropagation) == 0
+     count(i_linux.UIDMappings) == 0
+     is_null(i_linux.IntelRdt)
+     is_null(i_linux.Resources.BlockIO)
+diff --git a/src/tools/genpolicy/src/mount_and_storage.rs b/src/tools/genpolicy/src/mount_and_storage.rs
+index 0e5a5da19..0e354584b 100644
+--- a/src/tools/genpolicy/src/mount_and_storage.rs
++++ b/src/tools/genpolicy/src/mount_and_storage.rs
+@@ -181,14 +181,24 @@ fn get_empty_dir_mount_and_storage(
+         &settings_empty_dir.mount_type
+     };
+ 
++    let rw_opt = match yaml_mount.readOnly {
++        Some(true) => "ro",
++        _ => "rw",
++    };
++    let mount_propagation = match &yaml_mount.mountPropagation {
++        Some(mode) if mode == "Bidirectional" => "rshared",
++        Some(mode) if mode == "HostToContainer" => "rslave",
++        _ => "rprivate",
++    };
++
+     p_mounts.push(policy::KataMount {
+         destination: yaml_mount.mountPath.to_string(),
+         type_: mount_type.to_string(),
+         source,
+         options: vec![
+             "rbind".to_string(),
+-            "rprivate".to_string(),
+-            "rw".to_string(),
++            mount_propagation.to_string(),
++            rw_opt.to_string(),
+         ],
+     });
+ }
+-- 
+2.46.2
+

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -83,6 +83,11 @@ buildGoModule rec {
       # TODO(burgerdev): backport
       ./0014-genpolicy-bump-oci-distribution-to-v0.12.0.patch
       ./0015-agent-bump-image-rs-version.patch
+
+      # This is an alternative implementation of
+      # packages/by-name/microsoft/genpolicy/0005-genpolicy-propagate-mount_options-for-empty-dirs.patch
+      # that does not depend on the CSI enabling changes exclusive to the Microsoft fork.
+      ./0016-genpolicy-support-mount-propagation-and-ro-mounts.patch
     ];
   };
 


### PR DESCRIPTION
This PR enables mounting block devices onto `emptyDir` volumes on bare metal by changing the policy to understand mount propagation.

In our bare metal CI the cryptsetup calls OOMed, leading to corrupted LUKS devices. As far as I understand, this is due to the memory requirements of the PBKDF, which are limited by total VM memory, but not container cgroup limits[^1]. On bare metal, we currently have much more memory than the limit, which probably leads to an optimistic choice of PBKDF memory. I'm manually restricting `--pbkdf-memory` to 10M to work around this.

Only tangentially related, I'm setting the retention policy of the test volume claims to `DELETE`. This is not necessary for regular CI operations, but helps when manually working with this resource.

[^1]: https://gitlab.com/cryptsetup/cryptsetup/-/blob/v2.7.5/man/common_options.adoc?ref_type=tags&plain=1#L763-768