### PR TITLE
include kernel command line in TDX measurement

### DIFF
--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -98,23 +98,32 @@ let
       };
       tdxRefVals = {
         tdx = [
-          {
-            mrTd = builtins.readFile "${kata.tdx-launch-digests}/mrtd.hex";
-            rtrms = [
-              (builtins.readFile "${kata.tdx-launch-digests}/rtmr0.hex")
-              (builtins.readFile "${kata.tdx-launch-digests}/rtmr1.hex")
-              (builtins.readFile "${kata.tdx-launch-digests}/rtmr2.hex")
-              (builtins.readFile "${kata.tdx-launch-digests}/rtmr3.hex")
-            ];
-            minimumQeSvn = 0;
-            minimumPceSvn = 0;
-            # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
-            minimumTeeTcbSvn = "04010200000000000000000000000000";
-            # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
-            mrSeam = "1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04";
-            tdAttributes = "0000001000000000";
-            xfam = "e702060000000000";
-          }
+          (
+            let
+              launch-digests =
+                if kata.contrast-node-installer-image.debugRuntime then
+                  kata.tdx-launch-digests.override { debug = true; }
+                else
+                  kata.tdx-launch-digests;
+            in
+            {
+              mrTd = builtins.readFile "${launch-digests}/mrtd.hex";
+              rtrms = [
+                (builtins.readFile "${launch-digests}/rtmr0.hex")
+                (builtins.readFile "${launch-digests}/rtmr1.hex")
+                (builtins.readFile "${launch-digests}/rtmr2.hex")
+                (builtins.readFile "${launch-digests}/rtmr3.hex")
+              ];
+              minimumQeSvn = 0;
+              minimumPceSvn = 0;
+              # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
+              minimumTeeTcbSvn = "04010200000000000000000000000000";
+              # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
+              mrSeam = "1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04";
+              tdAttributes = "0000001000000000";
+              xfam = "e702060000000000";
+            }
+          )
         ];
       };
     in

--- a/packages/by-name/kata/kata-kernel-uvm/package.nix
+++ b/packages/by-name/kata/kata-kernel-uvm/package.nix
@@ -41,12 +41,12 @@ let
 in
 
 linuxManualConfig rec {
-  version = "6.7";
+  version = "6.11";
 
   # See https://github.com/kata-containers/kata-containers/blob/5f11c0f144037d8d8f546c89a0392dcd84fa99e2/versions.yaml#L198-L201
   src = fetchurl {
     url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${version}.tar.xz";
-    hash = "sha256-7zEUSiV20IDYwxaY6D7J9mv5fGd/oqrw1bu58zRbEGk=";
+    hash = "sha256-VdLGwCXrwngQx0jWYyXdW8YB6NMvhYHZ53ZzUpvayy4=";
   };
 
   kernelPatches = [

--- a/packages/by-name/kata/snp-launch-digest/package.nix
+++ b/packages/by-name/kata/snp-launch-digest/package.nix
@@ -15,14 +15,7 @@ let
   kernel = "${kata.kata-kernel-uvm}/bzImage";
   ovmf-snp = "${OVMF-SNP}/FV/OVMF.fd";
   image = kata.kata-image;
-  dataBlockSize = builtins.readFile "${image.verity}/data_block_size";
-  hashBlockSize = builtins.readFile "${image.verity}/hash_block_size";
-  dataBlocks = builtins.readFile "${image.verity}/data_blocks";
-  rootHash = builtins.readFile "${image.verity}/roothash";
-  salt = builtins.readFile "${image.verity}/salt";
-  dataSectorsPerBlock = (lib.strings.toInt dataBlockSize) / 512;
-  dataSectors = (lib.strings.toInt dataBlocks) * dataSectorsPerBlock;
-  dmVerityArgs = "dm-mod.create=\"dm-verity,,,ro,0 ${toString dataSectors} verity 1 /dev/vda1 /dev/vda2 ${dataBlockSize} ${hashBlockSize} ${dataBlocks} 0 sha256 ${rootHash} ${salt}\" root=/dev/dm-0";
+  inherit (image) dmVerityArgs;
   cmdlineBase = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
   cmdlineBaseDebug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
   cmdline = "${if debug then cmdlineBaseDebug else cmdlineBase} ${dmVerityArgs}";

--- a/packages/by-name/kata/tdx-launch-digests/package.nix
+++ b/packages/by-name/kata/tdx-launch-digests/package.nix
@@ -7,11 +7,19 @@
   kata,
   OVMF-TDX,
   tdx-measure,
-}:
 
+  debug ? false,
+}:
+let
+  image = kata.kata-image;
+  inherit (image) dmVerityArgs;
+  cmdlineBase = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
+  cmdlineBaseDebug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
+  cmdline = "${if debug then cmdlineBaseDebug else cmdlineBase} ${dmVerityArgs}";
+in
 stdenvNoCC.mkDerivation {
   name = "tdx-launch-digests";
-  inherit (kata.kata-image) version;
+  inherit (image) version;
 
   dontUnpack = true;
 
@@ -19,9 +27,9 @@ stdenvNoCC.mkDerivation {
     mkdir $out
 
     ${lib.getExe tdx-measure} mrtd -f ${OVMF-TDX}/FV/OVMF.fd > $out/mrtd.hex
-    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage 0 > $out/rtmr0.hex
-    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage 1 > $out/rtmr1.hex
-    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage 2 > $out/rtmr2.hex
-    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage 3 > $out/rtmr3.hex
+    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage -c '${cmdline}' 0 > $out/rtmr0.hex
+    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage -c '${cmdline}' 1 > $out/rtmr1.hex
+    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage -c '${cmdline}' 2 > $out/rtmr2.hex
+    ${lib.getExe tdx-measure} rtmr -f ${OVMF-TDX}/FV/OVMF.fd -k ${kata.kata-kernel-uvm}/bzImage -c '${cmdline}' 3 > $out/rtmr3.hex
   '';
 }

--- a/tools/tdx-measure/main.go
+++ b/tools/tdx-measure/main.go
@@ -106,6 +106,7 @@ func newRtMrCmd() *cobra.Command {
 	if err := cmd.MarkFlagFilename("kernel"); err != nil {
 		panic(err)
 	}
+	cmd.Flags().StringP("cmdline", "c", "", "kernel command line")
 	return cmd
 }
 
@@ -141,7 +142,14 @@ func runRtMr(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("can't calculate RTMR 1: %w", err)
 		}
 	case "2":
-		digest = [48]byte{}
+		cmdLine, err := cmd.Flags().GetString("cmdline")
+		if err != nil {
+			return err
+		}
+		digest, err = rtmr.CalcRtmr2(cmdLine)
+		if err != nil {
+			return fmt.Errorf("can't calculate RTMR 2: %w", err)
+		}
 	case "3":
 		digest = [48]byte{}
 	}

--- a/tools/tdx-measure/rtmr/rtmr.go
+++ b/tools/tdx-measure/rtmr/rtmr.go
@@ -144,6 +144,20 @@ func CalcRtmr1(kernelFile []byte) ([48]byte, error) {
 	return rtmr.Get(), nil
 }
 
+// CalcRtmr2 calculates RTMR[2] for the given kernel command line.
+func CalcRtmr2(cmdLine string) ([48]byte, error) {
+	var rtmr Rtmr
+
+	codepoints := utf16.Encode([]rune(cmdLine))
+	bytes := make([]byte, (len(codepoints)+1)*2)
+	for i, codepoint := range codepoints {
+		binary.LittleEndian.PutUint16(bytes[i*2:][:2], codepoint)
+	}
+	rtmr.hashAndExtend(bytes)
+
+	return rtmr.Get(), nil
+}
+
 func hashKernel(kernelFile []byte) ([]byte, error) {
 	patchKernel(kernelFile)
 


### PR DESCRIPTION
This PR upgrades the kernel to version 6.11. This new kernel will measure the kernel command line into RTMR[2], so we also update tdx-measure to consider the kernel command line when calculating RTMR[2].