### PR TITLE
docs: add instructions to raise user.max_inotify_instances limit

### DIFF
--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -26,6 +26,8 @@ Follow Canonical's instructions on [setting up Intel TDX on Ubuntu 24.04](https:
 </TabItem>
 </Tabs>
 
+Increase the `user.max_inotify_instances` sysctl limit by adding `user.max_inotify_instances=8192` to `/etc/sysctl.d/99-sysctl.conf` and running `sysctl --system`.
+
 ## K3s Setup
 
 1. Follow the [K3s setup instructions](https://docs.k3s.io/) to create a cluster.

--- a/tools/vale/styles/config/vocabularies/edgeless/accept.txt
+++ b/tools/vale/styles/config/vocabularies/edgeless/accept.txt
@@ -105,6 +105,7 @@ Subresource
 substituters
 superset
 Syft
+sysctl
 systemd
 tardev
 tarfs


### PR DESCRIPTION
If this limit isn't raised, kata will fail with `failed to create containerd task: failed to create shim task: Creating watcher returned error too many open files: unknown` when running many containers.