### PR TITLE
e2e: add ability to wait for different conditions in `kubeclient.WaitFor`

### DIFF
--- a/e2e/genpolicy/genpolicy_test.go
+++ b/e2e/genpolicy/genpolicy_test.go
@@ -66,7 +66,7 @@ func TestGenpolicy(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			t.Cleanup(cancel)
-			require.NoError(t, ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, name))
+			require.NoError(t, ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, name))
 		})
 	}
 }

--- a/e2e/getdents/getdents_test.go
+++ b/e2e/getdents/getdents_test.go
@@ -76,7 +76,7 @@ func TestGetDEnts(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(30*time.Second))
 		defer cancel()
 
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, getdent))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, getdent))
 
 		pods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, getdent)
 		require.NoError(err)

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -313,12 +313,12 @@ func (ct *ContrastTest) installRuntime(t *testing.T) {
 
 	require.NoError(ct.Kubeclient.Apply(ctx, unstructuredResources...))
 
-	require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.DaemonSet{}, ct.Namespace, "contrast-node-installer"))
+	require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.DaemonSet{}, ct.Namespace, "contrast-node-installer"))
 }
 
 // runAgainstCoordinator forwards the coordinator port and executes the command against it.
 func (ct *ContrastTest) runAgainstCoordinator(ctx context.Context, cmd *cobra.Command, args ...string) error {
-	if err := ct.Kubeclient.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"); err != nil {
+	if err := ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"); err != nil {
 		return fmt.Errorf("waiting for coordinator: %w", err)
 	}
 	if err := ct.Kubeclient.WaitFor(ctx, kubeclient.Pod{}, ct.Namespace, "port-forwarder-coordinator"); err != nil {

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -321,7 +321,7 @@ func (ct *ContrastTest) runAgainstCoordinator(ctx context.Context, cmd *cobra.Co
 	if err := ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"); err != nil {
 		return fmt.Errorf("waiting for coordinator: %w", err)
 	}
-	if err := ct.Kubeclient.WaitFor(ctx, kubeclient.Pod{}, ct.Namespace, "port-forwarder-coordinator"); err != nil {
+	if err := ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Pod{}, ct.Namespace, "port-forwarder-coordinator"); err != nil {
 		return fmt.Errorf("waiting for port-forwarder-coordinator: %w", err)
 	}
 

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -217,7 +217,6 @@ func (c *Kubeclient) checkIfRunning(ctx context.Context, name string, namespace 
 	if err != nil {
 		return false, err
 	}
-	toBeRunningPods := len(pods)
 	for _, pod := range pods {
 		// check if all containers in the pod are running
 		var containers []corev1.ContainerStatus
@@ -226,21 +225,14 @@ func (c *Kubeclient) checkIfRunning(ctx context.Context, name string, namespace 
 		} else {
 			containers = pod.Status.ContainerStatuses
 		}
-		toBeRunningContainers := len(containers)
 
 		for _, container := range containers {
-			if container.State.Running != nil {
-				toBeRunningContainers--
+			if container.State.Running == nil {
+				return false, nil
 			}
 		}
-		if toBeRunningContainers == 0 {
-			toBeRunningPods--
-		}
 	}
-	if toBeRunningPods == 0 {
-		return true, nil
-	}
-	return false, nil
+	return true, nil
 }
 
 // WaitFor watches the given resource kind and blocks until the desired number of pods are
@@ -381,65 +373,6 @@ loop:
 				// TODO(burgerdev): deal with more than one port, and protocols other than TCP
 				port = int(svc.Spec.Ports[0].Port)
 				break loop
-			}
-		case watch.Deleted:
-			return "", fmt.Errorf("service %s/%s was deleted while waiting for it", namespace, name)
-		default:
-			c.log.Warn("ignoring unexpected watch event", "type", evt.Type, "object", evt.Object)
-		}
-	}
-
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	dialer := &net.Dialer{}
-	for {
-		select {
-		case <-ticker.C:
-			conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
-			if err == nil {
-				conn.Close()
-				return ip, nil
-			}
-			c.log.Info("probe failed", "namespace", namespace, "name", name, "error", err)
-		case <-ctx.Done():
-			return "", fmt.Errorf("LoadBalancer %s/%s never responded to probing before %w", namespace, name, ctx.Err())
-		}
-	}
-}
-
-// WaitForLoadBalancer waits until the given service is configured with an external IP and returns it.
-func (c *Kubeclient) WaitForLoadBalancer(ctx context.Context, namespace, name string) (string, error) {
-	watcher, err := c.Client.CoreV1().Services(namespace).Watch(ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + name})
-	if err != nil {
-		return "", err
-	}
-	var ip string
-	var port int
-loop:
-	for {
-		evt, ok := <-watcher.ResultChan()
-		if !ok {
-			if ctx.Err() == nil {
-				return "", fmt.Errorf("watcher for LoadBalancer %s/%s unexpectedly closed", namespace, name)
-			}
-			return "", fmt.Errorf("LoadBalancer %s/%s did not get a public IP before %w", namespace, name, ctx.Err())
-		}
-		switch evt.Type {
-		case watch.Added:
-			fallthrough
-		case watch.Modified:
-			svc, ok := evt.Object.(*corev1.Service)
-			if !ok {
-				return "", fmt.Errorf("watcher received unexpected type %T", evt.Object)
-			}
-			for _, ingress := range svc.Status.LoadBalancer.Ingress {
-				if ingress.IP != "" {
-					ip = ingress.IP
-					// TODO(burgerdev): deal with more than one port, and protocols other than TCP
-					port = int(svc.Spec.Ports[0].Port)
-					break loop
-				}
 			}
 		case watch.Deleted:
 			return "", fmt.Errorf("service %s/%s was deleted while waiting for it", namespace, name)

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -259,7 +259,13 @@ retryLoop:
 					return nil
 				}
 			case Running:
-				// TODO
+				running, err := c.checkIfRunning(ctx, name, namespace, resource)
+				if err != nil {
+					return err
+				}
+				if running {
+					return nil
+				}
 			}
 		}
 	}

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -297,6 +297,8 @@ func (c *Kubeclient) waitForRunning(ctx context.Context, name string, namespace 
 		if err != nil {
 			return err
 		}
+		// TODO(miampf): Currently this just checks if the init container enters the running state.
+		// Change this so that it checks every container in the pod.
 		if pods[0].Status.InitContainerStatuses[0].State.Running != nil {
 			return nil
 		}

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -192,6 +192,11 @@ func (c *Kubeclient) checkIfReady(ctx context.Context, name string, namespace st
 			return false, err
 		}
 		if desiredPods <= numPodsReady {
+			// Wait for 5 more seconds just to be *really* sure that
+			// the pods are actually up.
+			sleep, cancel := context.WithTimeout(ctx, time.Second*5)
+			defer cancel()
+			<-sleep.Done()
 			return true, nil
 		}
 	case watch.Deleted:

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -285,6 +285,19 @@ func (c *Kubeclient) waitForEvent(ctx context.Context, name string, namespace st
 	}
 }
 
+func (c *Kubeclient) waitForRunning(ctx context.Context, name string, namespace string) error {
+	for {
+		time.Sleep(1 * time.Second)
+		pods, err := c.PodsFromDeployment(ctx, namespace, name)
+		if err != nil {
+			return err
+		}
+		if pods[0].Status.InitContainerStatuses[0].State.Running != nil {
+			return nil
+		}
+	}
+}
+
 // WaitFor watches the given resource kind and blocks until the desired number of pods are
 // ready or the context expires (is cancelled or times out).
 func (c *Kubeclient) WaitFor(ctx context.Context, condition WaitCondition, resource ResourceWaiter, namespace, name string) error {

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -22,16 +22,24 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// WaitCondition is an enum type for the possible wait conditions when using `kubeclient.WaitFor`.
 type WaitCondition int
 
 const (
 	_ WaitCondition = iota
+	// Ready waits until the resource becomes ready.
 	Ready
+	// Added waits until a `watch.Added` event occurs.
 	Added
+	// Modified waits until a `watch.Modified` event occurs.
 	Modified
+	// Deleted waits until a `watch.Deleted` event occurs.
 	Deleted
+	// Bookmark waits until a `watch.Bookmark` event occurs.
 	Bookmark
+	// Running waits until all containers of all pods of the resource are running.
 	Running
+	// InitContainersRunning waits until all initial containers of all pods of the resource are running.
 	InitContainersRunning
 )
 

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -32,6 +32,7 @@ const (
 	Deleted
 	Bookmark
 	Running
+	InitContainersRunning
 )
 
 // ResourceWaiter is implemented by resources that can be waited for with WaitFor.
@@ -259,7 +260,15 @@ retryLoop:
 					return nil
 				}
 			case Running:
-				running, err := c.checkIfRunning(ctx, name, namespace, resource)
+				running, err := c.checkIfRunning(ctx, name, namespace, resource, false)
+				if err != nil {
+					return err
+				}
+				if running {
+					return nil
+				}
+			case InitContainersRunning:
+				running, err := c.checkIfRunning(ctx, name, namespace, resource, true)
 				if err != nil {
 					return err
 				}

--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -171,7 +171,7 @@ func (c *Kubeclient) Exec(ctx context.Context, namespace, pod string, argv []str
 
 // ExecDeployment executes a process in one of the deployment's pods.
 func (c *Kubeclient) ExecDeployment(ctx context.Context, namespace, deployment string, argv []string) (stdout string, stderr string, err error) {
-	if err := c.WaitFor(ctx, Deployment{}, namespace, deployment); err != nil {
+	if err := c.WaitFor(ctx, Ready, Deployment{}, namespace, deployment); err != nil {
 		return "", "", fmt.Errorf("deployment not ready: %w", err)
 	}
 

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -73,7 +73,7 @@ func TestOpenSSL(t *testing.T) {
 
 		require := require.New(t)
 
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 
 		frontendPods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, opensslFrontend)
 		require.NoError(err)
@@ -98,8 +98,7 @@ func TestOpenSSL(t *testing.T) {
 
 			require := require.New(t)
 
-			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
-			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Pod{}, ct.Namespace, "port-forwarder-openssl-frontend"))
+			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 
 			require.NoError(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-openssl-frontend", "443", func(addr string) error {
 				dialer := &tls.Dialer{Config: &tls.Config{RootCAs: pool}}

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -121,7 +121,7 @@ func TestOpenSSL(t *testing.T) {
 
 		c := kubeclient.NewForTest(t)
 
-		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
+		require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
 
 		// Call the backend server from the frontend. If this command produces no TLS error, we verified that
 		// - the certificate in the frontend pod can be used as a client certificate
@@ -164,7 +164,7 @@ func TestOpenSSL(t *testing.T) {
 
 			// Restart one deployment so it has the new certificates.
 			require.NoError(c.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, deploymentToRestart))
-			require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, deploymentToRestart))
+			require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, deploymentToRestart))
 
 			// This should not succeed because the certificates have changed.
 			stdout, stderr, err := c.ExecDeployment(ctx, ct.Namespace, opensslFrontend, []string{"/bin/sh", "-c", opensslConnectCmd("openssl-backend:443", meshCAFile)})
@@ -184,7 +184,7 @@ func TestOpenSSL(t *testing.T) {
 				d = opensslFrontend
 			}
 			require.NoError(c.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, d))
-			require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, d))
+			require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, d))
 
 			// This should succeed since both workloads now have updated certificates.
 			stdout, stderr, err = c.ExecDeployment(ctx, ct.Namespace, opensslFrontend, []string{"/bin/sh", "-c", opensslConnectCmd("openssl-backend:443", meshCAFile)})
@@ -202,7 +202,7 @@ func TestOpenSSL(t *testing.T) {
 		c := kubeclient.NewForTest(t)
 
 		require.NoError(c.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
-		require.NoError(c.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
+		require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
 
 		// TODO(freax13): The following verify sometimes fails spuriously due to
 		//                connection issues. Waiting a little bit longer makes
@@ -216,7 +216,7 @@ func TestOpenSSL(t *testing.T) {
 		require.True(t.Run("contrast verify", ct.Verify))
 
 		require.NoError(c.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
-		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
+		require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 
 		t.Run("root CA is still accepted after coordinator recovery", func(t *testing.T) {
 			stdout, stderr, err := c.ExecDeployment(ctx, ct.Namespace, opensslBackend, []string{"/bin/sh", "-c", opensslConnectCmd("openssl-frontend:443", rootCAFile)})
@@ -232,7 +232,7 @@ func TestOpenSSL(t *testing.T) {
 		})
 
 		require.NoError(c.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
-		require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
+		require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
 
 		t.Run("mesh CA after coordinator recovery is accepted when workloads are restarted", func(t *testing.T) {
 			stdout, stderr, err := c.ExecDeployment(ctx, ct.Namespace, opensslBackend, []string{"/bin/sh", "-c", opensslConnectCmd("openssl-frontend:443", meshCAFile)})

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -99,6 +99,7 @@ func TestOpenSSL(t *testing.T) {
 			require := require.New(t)
 
 			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
+			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Pod{}, ct.Namespace, "port-forwarder-openssl-frontend"))
 
 			require.NoError(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-openssl-frontend", "443", func(addr string) error {
 				dialer := &tls.Dialer{Config: &tls.Config{RootCAs: pool}}

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -131,7 +131,7 @@ func TestPolicy(t *testing.T) {
 		require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, opensslBackend))
 
 		// wait for the init container of the openssl-frontend pod to enter the running state
-		require.NoError(c.WaitFor(ctx, kubeclient.Running, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
+		require.NoError(c.WaitFor(ctx, kubeclient.InitContainersRunning, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))
 		newFailures := getFailures(ctx, t, ct)
 		t.Log("New failures:", newFailures)
 		// errors should happen

--- a/e2e/regression/regression_test.go
+++ b/e2e/regression/regression_test.go
@@ -89,6 +89,8 @@ func TestRegression(t *testing.T) {
 			require.True(t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
 			require.True(t.Run("verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
 
+			ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(3*time.Minute))
+			defer cancel()
 			require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, deploymentName))
 		})
 	}

--- a/e2e/regression/regression_test.go
+++ b/e2e/regression/regression_test.go
@@ -89,9 +89,7 @@ func TestRegression(t *testing.T) {
 			require.True(t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
 			require.True(t.Run("verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
 
-			ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(3*time.Minute))
-			defer cancel()
-			require.NoError(c.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, deploymentName))
+			require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, deploymentName))
 		})
 	}
 }

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -121,7 +121,7 @@ func TestRelease(t *testing.T) {
 
 		require.NoError(k.Apply(ctx, resources...))
 		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, "default", "coordinator"))
-		coordinatorIP, err = k.WaitForLoadBalancer(ctx, "default", "coordinator")
+		coordinatorIP, err = k.WaitForService(ctx, "default", "coordinator", hasLoadBalancer)
 		require.NoError(err)
 	}), "the coordinator is required for subsequent tests to run")
 

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -105,7 +105,7 @@ func TestRelease(t *testing.T) {
 		require.NoError(err)
 
 		require.NoError(k.Apply(ctx, resources...))
-		require.NoError(k.WaitFor(ctx, kubeclient.DaemonSet{}, "kube-system", "contrast-node-installer"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.DaemonSet{}, "kube-system", "contrast-node-installer"))
 	}), "the runtime is required for subsequent tests to run")
 
 	var coordinatorIP string
@@ -120,8 +120,8 @@ func TestRelease(t *testing.T) {
 		require.NoError(err)
 
 		require.NoError(k.Apply(ctx, resources...))
-		require.NoError(k.WaitFor(ctx, kubeclient.StatefulSet{}, "default", "coordinator"))
-		coordinatorIP, err = k.WaitForService(ctx, "default", "coordinator", hasLoadBalancer)
+		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, "default", "coordinator"))
+		coordinatorIP, err = k.WaitForLoadBalancer(ctx, "default", "coordinator")
 		require.NoError(err)
 	}), "the coordinator is required for subsequent tests to run")
 
@@ -175,10 +175,10 @@ func TestRelease(t *testing.T) {
 			require.NoError(k.Apply(ctx, resources...))
 		}
 
-		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "vote-bot"))
-		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "voting"))
-		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "emoji"))
-		require.NoError(k.WaitFor(ctx, kubeclient.Deployment{}, "default", "web"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, "default", "vote-bot"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, "default", "voting"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, "default", "emoji"))
+		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, "default", "web"))
 	}), "applying the demo is required for subsequent tests to run")
 
 	t.Run("test-demo", func(t *testing.T) {

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -65,11 +65,10 @@ func TestIngressEgress(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(1*time.Minute))
 		defer cancel()
 
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "vote-bot"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "emoji"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "voting"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "web"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Pod{}, ct.Namespace, "port-forwarder-web-svc"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "vote-bot"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "emoji"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "voting"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "web"))
 	}), "deployments need to be ready for subsequent tests")
 
 	certs := map[string]*x509.CertPool{

--- a/e2e/volumestatefulset/volumestatefulset_test.go
+++ b/e2e/volumestatefulset/volumestatefulset_test.go
@@ -61,7 +61,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(1*time.Minute))
 		defer cancel()
 
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
 	}), "deployments need to be ready for subsequent tests")
 
 	filePath := "/srv/state/test"
@@ -93,7 +93,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 		defer cancel()
 
 		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
 
 		pods, err := ct.Kubeclient.PodsFromOwner(ctx, ct.Namespace, "StatefulSet", "volume-tester")
 		require.NoError(err)

--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -64,10 +64,10 @@ func TestWorkloadSecrets(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(1*time.Minute))
 		defer cancel()
 
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "vote-bot"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "emoji"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "voting"))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "web"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "vote-bot"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "emoji"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "voting"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "web"))
 	}), "deployments need to be ready for subsequent tests")
 
 	// Scale web deployment to 2 replicas.
@@ -78,7 +78,7 @@ func TestWorkloadSecrets(t *testing.T) {
 		defer cancel()
 
 		require.NoError(ct.Kubeclient.ScaleDeployment(ctx, ct.Namespace, "web", 2))
-		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Deployment{}, ct.Namespace, "web"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "web"))
 	}), "web deployment needs to be scaled for subsequent tests")
 
 	var webWorkloadSecretBytes []byte


### PR DESCRIPTION
This adds the ability to wait for different conditions using the `kubeclient.WaitFor` function. Supported conditions are:
- `Ready`: This has the same functionality as the old `kubeclient.WaitFor`.
- `Running`: Waits until all containers of all pods of the corresponding resource are running or until the context timeouts.
- `InitContainersRunning`: Same as `Running`, but only check the initial containers of all pods of the corresponding resource.
- `Added`, `Bookmark`, `Deleted`, `Modified`: Those are synonymous for waiting on the corresponding `watch.EventType` found in `k8s.io/apimachinery/pkg/watch`.