### PR TITLE
image-podvm: add kata components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ id_rsa*
 kube.conf
 out.env
 infra/**/kustomization.yaml
+infra/**/workload-identity.yaml
+uplosi.conf*

--- a/infra/azure-peerpods/main.tf
+++ b/infra/azure-peerpods/main.tf
@@ -192,7 +192,7 @@ configMapGenerator:
   - AZURE_INSTANCE_SIZE=Standard_DC2as_v5
   - AZURE_RESOURCE_GROUP=${azurerm_resource_group.rg.name}
   - AZURE_SUBNET_ID=${one(azurerm_virtual_network.main.subnet.*.id)}
-  - AZURE_IMAGE_ID=/subscriptions/0d202bbb-4fa7-4af8-8125-58c269a05435/resourceGroups/otto-dev/providers/Microsoft.Compute/galleries/cocopriv/images/coco-gpus/versions/0.0.33
+  - AZURE_IMAGE_ID=/subscriptions/0d202bbb-4fa7-4af8-8125-58c269a05435/resourceGroups/otto-dev/providers/Microsoft.Compute/galleries/cocopriv/images/coco-gpus/versions/0.0.35
   - DISABLECVM=false
 secretGenerator:
 - name: peer-pods-secret

--- a/infra/azure-peerpods/main.tf
+++ b/infra/azure-peerpods/main.tf
@@ -117,11 +117,6 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     type = "SystemAssigned"
   }
 
-  linux_profile {
-    admin_username = "azuser"
-    ssh_key { key_data = file(var.ssh_pub_key_path) }
-  }
-
   default_node_pool {
     name                 = "default"
     node_count           = 1

--- a/infra/azure-peerpods/vars.tf
+++ b/infra/azure-peerpods/vars.tf
@@ -9,8 +9,3 @@ variable "image_resource_group_name" {
 variable "subscription_id" {
   type = string
 }
-
-variable "ssh_pub_key_path" {
-  type    = string
-  default = "id_rsa.pub"
-}

--- a/infra/azure-peerpods/vars.tf
+++ b/infra/azure-peerpods/vars.tf
@@ -9,3 +9,8 @@ variable "image_resource_group_name" {
 variable "subscription_id" {
   type = string
 }
+
+variable "ssh_pub_key_path" {
+  type    = string
+  default = "id_rsa.pub"
+}

--- a/justfile
+++ b/justfile
@@ -51,6 +51,12 @@ node-installer platform=default_platform:
             just push "nydus-snapshotter"
             just push "node-installer-kata"
         ;;
+        "AKS-PEER-SNP")
+            nix run -L .#scripts.deploy-caa -- \
+                --kustomization=./infra/azure-peerpods/kustomization.yaml \
+                --workload-identity=./infra/azure-peerpods/workload-identity.yaml \
+                --pub-key=./infra/azure-peerpods/id_rsa.pub
+        ;;
         *)
             echo "Unsupported platform: {{ platform }}"
             exit 1

--- a/justfile
+++ b/justfile
@@ -271,6 +271,9 @@ get-credentials:
         --resource-group "$azure_resource_group" \
         --name "$azure_resource_group"
 
+get-credentials-peerpod:
+    nix run -L .#scripts.merge-kube-config -- ./infra/azure-peerpods/kube.conf
+
 # Load the kubeconfig from the CI AKS cluster.
 get-credentials-ci:
     nix run -L .#azure-cli -- aks get-credentials \

--- a/packages/by-name/azure-no-agent/no-agent.sh
+++ b/packages/by-name/azure-no-agent/no-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/packages/by-name/cloud-api-adaptor/package.nix
+++ b/packages/by-name/cloud-api-adaptor/package.nix
@@ -7,6 +7,9 @@
   fetchFromGitHub,
   pkg-config,
   libvirt,
+  writeShellApplication,
+  gnugrep,
+  runCommand,
 
   # List of supported cloud providers
   builtinCloudProviders ? [
@@ -18,6 +21,8 @@
     # "libvirt"
     # "docker"
   ],
+
+  cloud-api-adaptor,
 }:
 
 let
@@ -57,6 +62,18 @@ buildGoModule rec {
   ldflags = [
     "-X 'github.com/confidential-containers/cloud-api-adaptor/src/cloud-api-adaptor/cmd.VERSION=${version}'"
   ];
+
+  passthru = {
+    kata-agent-clean = writeShellApplication {
+      name = "kata-agent-clean";
+      runtimeInputs = [ gnugrep ];
+      text = builtins.readFile "${cloud-api-adaptor.src}/src/cloud-api-adaptor/podvm/files/usr/local/bin/kata-agent-clean";
+    };
+
+    default-policy = runCommand "default-policy" { } ''
+      cp ${cloud-api-adaptor.src}/src/cloud-api-adaptor/podvm/files/etc/kata-opa/allow-all.rego $out
+    '';
+  };
 
   meta = {
     description = "Ability to create Kata pods using cloud provider APIs aka the peer-pods approach";

--- a/packages/by-name/image-podvm/debug.nix
+++ b/packages/by-name/image-podvm/debug.nix
@@ -19,29 +19,19 @@ in
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
+      busybox
       tpm2-tools
       ncurses
       findutils
       curlMinimal
       util-linux
       coreutils
-      busybox
       strace
-      kata-agent
     ];
-
-    virtualisation.docker.enable = true;
 
     services.getty.autologinUser = "root";
-    users.users.root.initialPassword = "";
 
-    boot.kernelParams = [
-      "console=ttyS0"
-      "console=ttyS1"
-      "console=tty0"
-      "console=tty1"
-    ];
-
+    boot.kernelParams = [ "console=ttyS0" ];
     boot.initrd.systemd.emergencyAccess = true;
     systemd.enableEmergencyMode = true;
   };

--- a/packages/by-name/image-podvm/image.nix
+++ b/packages/by-name/image-podvm/image.nix
@@ -37,6 +37,9 @@
 
       # Root filesystem.
       "10-root" = {
+        contents = {
+          "/pause_bundle".source = "${pkgs.pause-bundle}/pause_bundle";
+        };
         storePaths = [ config.system.build.toplevel ];
         repartConfig = {
           Type = "root";

--- a/packages/by-name/image-podvm/kata.nix
+++ b/packages/by-name/image-podvm/kata.nix
@@ -1,0 +1,90 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+{ lib, pkgs, ... }:
+
+{
+  systemd.services.kata-agent = {
+    description = "Kata Containers Agent";
+    documentation = [
+      "https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/etc/systemd/system/kata-agent.service"
+    ];
+    bindsTo = [ "netns@podns.service" ];
+    wants = [ "process-user-data.service" ];
+    after = [
+      "netns@podns.service"
+      "process-user-data.service"
+    ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "exec"; # Not upstream.
+      ExecStartPre = [ "${pkgs.coreutils}/bin/mkdir -p /run/kata-containers" ];
+      ExecStart = "${lib.getExe pkgs.kata-agent} --config /run/peerpod/agent-config.toml";
+      ExecStopPost = "${lib.getExe pkgs.cloud-api-adaptor.kata-agent-clean} --config /run/peerpod/agent-config.toml";
+      SyslogIdentifier = "kata-agent";
+    };
+    environment = {
+      KATA_AGENT_LOG_LEVEL = "debug";
+      OCICRYPT_KEYPROVIDER_CONFIG = builtins.toFile "policy.json" (
+        lib.strings.toJSON { default = [ { type = "insecureAcceptAnything"; } ]; }
+      );
+    };
+  };
+
+  systemd.services.agent-protocol-forwarder = {
+    description = "Agent Protocol Forwarder";
+    documentation = [
+      "https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/etc/systemd/system/agent-protocol-forwarder.service"
+    ];
+    wants = [ "kata-agent.service" ];
+    after = [ "kata-agent.service" ];
+    wantedBy = [ "multi-user.target" ];
+    unitConfig = {
+      DefaultDependencies = false;
+    };
+    serviceConfig = {
+      Type = "notify";
+      ExecStart = lib.strings.concatStringsSep " " [
+        "${pkgs.cloud-api-adaptor}/bin/agent-protocol-forwarder"
+        "-kata-agent-namespace /run/netns/podns"
+        "-kata-agent-socket /run/kata-containers/agent.sock"
+      ];
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+  };
+
+  systemd.services.process-user-data = {
+    description = "Pull configuration from metadata service";
+    documentation = [
+      "https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/etc/systemd/system/process-user-data.service"
+    ];
+    wants = [ "network-online.target" ];
+    after = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+    unitConfig = {
+      DefaultDependencies = false;
+    };
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.cloud-api-adaptor}/bin/process-user-data provision-files";
+      RemainAfterExit = true;
+    };
+  };
+
+  systemd.services."netns@" = {
+    description = "Create a network namespace for pod networking";
+    documentation = [
+      "https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/etc/systemd/system/netns%40.service"
+    ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStartPre = "${pkgs.iproute2}/bin/ip netns add %I";
+      ExecStart = "${pkgs.iproute2}/bin/ip netns exec %I ${pkgs.iproute2}/bin/ip link set lo up";
+      ExecStop = "${pkgs.iproute2}/bin/ip netns del %I";
+    };
+  };
+
+  environment.etc."kata-opa/default-policy.rego".source = pkgs.cloud-api-adaptor.default-policy;
+}

--- a/packages/by-name/image-podvm/package.nix
+++ b/packages/by-name/image-podvm/package.nix
@@ -8,7 +8,7 @@
   jq,
 
   withDebug ? true,
-  withGPU ? true,
+  withGPU ? false,
   withCSP ? "azure",
 }:
 
@@ -35,6 +35,7 @@ in
       ./debug.nix
       ./gpu.nix
       ./image.nix
+      ./kata.nix
       ./system.nix
     ];
 
@@ -45,7 +46,12 @@ in
     # TODO(katexochen): imporve, see comment above.
     nixpkgs.overlays = [
       (_self: _super: {
-        inherit (outerPkgs) azure-no-agent kernel-podvm-azure;
+        inherit (outerPkgs)
+          azure-no-agent
+          cloud-api-adaptor
+          kernel-podvm-azure
+          pause-bundle
+          ;
         inherit (outerPkgs.kata) kata-agent;
       })
     ];


### PR DESCRIPTION
This adds the kata components to the peerpod image and makes it usable with the upstream coco operator setup for peerpods.

To test, you can create a cluster and deploy with:

```sh
just create AKS-PEER-SNP
just get-credentials-peerpod 
just node-installer AKS-PEER-SNP
```