### PR TITLE
justfile: bump secret version for tdxbm

### DIFF
--- a/justfile
+++ b/justfile
@@ -258,7 +258,7 @@ get-credentials-ci:
 get-credentials-from-gcloud path:
     nix run -L .#scripts.get-credentials {{ path }}
 
-get-credentials-tdxbm: (get-credentials-from-gcloud "projects/796962942582/secrets/m50-ganondorf-kubeconf/versions/2")
+get-credentials-tdxbm: (get-credentials-from-gcloud "projects/796962942582/secrets/m50-ganondorf-kubeconf/versions/5")
 
 get-credentials-snpbm: (get-credentials-from-gcloud "projects/796962942582/secrets/discovery-kubeconf/versions/1")
 


### PR DESCRIPTION
We've recently recreated the k3s on the TDX server in our office, so new credentials are needed.