### PR TITLE
Align policy hash verification between SNP and TDX 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,19 +36,6 @@ jobs:
             runner: TDX
             self-hosted: true
         test_name: [servicemesh, openssl, policy, workloadsecret, volumestatefulset]
-        exclude:
-          # We don't have policies on K3s-qemu yet, so there's no point in
-          # running those tests.
-          - platform:
-              name: K3s-QEMU-SNP
-              runner: SNP
-              self-hosted: true
-            test_name: policy
-          - platform:
-              name: K3s-QEMU-TDX
-              runner: TDX
-              self-hosted: true
-            test_name: policy
       fail-fast: false
     name: "${{ matrix.platform.name }} / ${{ matrix.test_name }}"
     runs-on: ${{ matrix.platform.runner }}

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -99,7 +99,8 @@ func validatorsFromManifest(m *manifest.Manifest, log *slog.Logger, hostData []b
 		return nil, fmt.Errorf("getting SNP validate options: %w", err)
 	}
 	for _, opt := range opts {
-		validators = append(validators, snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, []manifest.HexString{manifest.NewHexString(hostData)},
+		opt.ValidateOpts.HostData = hostData
+		validators = append(validators, snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts,
 			logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"tee-type": "snp"}),
 		))
 	}

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -108,7 +108,10 @@ func validatorsFromManifest(m *manifest.Manifest, log *slog.Logger, hostData []b
 	if err != nil {
 		return nil, fmt.Errorf("generating TDX validation options: %w", err)
 	}
+	var mrConfigID [48]byte
+	copy(mrConfigID[:], hostData)
 	for _, opt := range tdxOpts {
+		opt.TdQuoteBodyOptions.MrConfigID = mrConfigID[:]
 		validators = append(validators, tdx.NewValidator(&tdx.StaticValidateOptsGenerator{Opts: opt}, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"tee-type": "tdx"})))
 	}
 

--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -17,7 +17,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/logger"
-	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/memstore"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -83,13 +82,8 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		return nil, nil, fmt.Errorf("generating SNP validation options: %w", err)
 	}
 
-	var allowedHostDataEntries []manifest.HexString
-	for entry := range state.Manifest.Policies {
-		allowedHostDataEntries = append(allowedHostDataEntries, entry)
-	}
-
 	for _, opt := range opts {
-		validator := snp.NewValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts, allowedHostDataEntries,
+		validator := snp.NewValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts,
 			logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"tee-type": "snp"}),
 			&authInfo)
 		validators = append(validators, validator)

--- a/coordinator/meshapi.go
+++ b/coordinator/meshapi.go
@@ -19,8 +19,10 @@ import (
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 )
 
 type meshAPIServer struct {
@@ -108,7 +110,7 @@ func (i *meshAPIServer) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertR
 	hostData := manifest.NewHexString(report.HostData())
 	entry, ok := state.Manifest.Policies[hostData]
 	if !ok {
-		return nil, fmt.Errorf("report data %s not found in manifest", hostData)
+		return nil, status.Errorf(codes.PermissionDenied, "policy hash %s not found in manifest", hostData)
 	}
 	dnsNames := entry.SANs
 


### PR DESCRIPTION
*BREAKING*: The Prometheus counter `contrast_meshapi_attestation_failures_total` is not incremented anymore if a workload has matching reference values but an untrusted policy hash. These rejections are now visible in the `contrast_grpc_server_handled_total` counter with field `grpc_code=PermissionDenied`. 

---

The policy hash is passed as `HOSTDATA` on SNP and as `MRCONFIGID` on TDX. In the SNP validation, we used to check the `HOSTDATA` too, but we did not introduce this for TDX. As a consequence, the metrics observed on SNP and TDX are different: on SNP, an unknown hash ends up in `attestation_failures_total`, while on TDX it ends up in `grpc_server_handled_total` with an internal error status. Thus, we could not have a simple portable policy test that relied on the metrics.

This PR unifies handling of the policy hash between SNP and TDX by removing the additional validation from SNP. Existence of the hash in the manifest is now only checked in the `NewMeshCert` handler, where failures increment the `grpc_server_handled_total` with a `PermissionDenied` status. Now we can run the policy e2e test on all platforms.

Drive-by fix: the CLI now verifies coordinators on TDX correctly.
