### PR TITLE
ci: rework e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,20 +1,23 @@
 name: e2e test
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       skip-undeploy:
         description: "Skip undeploy"
-        required: false
         type: boolean
-        default: false
-  pull_request:
-    paths-ignore:
-      - dev-docs/**
-      - docs/**
-      - rfc/**
-      - tools/asciinema/**
-      - tools/vale/**
+      test-name:
+        description: "Test Name"
+        type: string
+      platform:
+        description: "Platform"
+        type: string
+      runner:
+        description: "Runner"
+        type: string
+      self-hosted:
+        description: "Self Hosted"
+        type: boolean
 
 env:
   container_registry: ghcr.io/edgelesssys
@@ -22,29 +25,15 @@ env:
   DO_NOT_TRACK: 1
 
 jobs:
-  test_matrix:
-    strategy:
-      matrix:
-        platform:
-          - name: AKS-CLH-SNP
-            runner: ubuntu-22.04
-            self-hosted: false
-          - name: K3s-QEMU-SNP
-            runner: SNP
-            self-hosted: true
-          - name: K3s-QEMU-TDX
-            runner: TDX
-            self-hosted: true
-        test_name: [servicemesh, openssl, policy, workloadsecret, volumestatefulset]
-      fail-fast: false
-    name: "${{ matrix.platform.name }} / ${{ matrix.test_name }}"
-    runs-on: ${{ matrix.platform.runner }}
+  test:
+    name: "${{ inputs.test-name }}"
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - if: ${{ !matrix.platform.self-hosted }}
+      - if: ${{ !inputs.self-hosted }}
         uses: ./.github/actions/setup_nix
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +44,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ !matrix.platform.self-hosted }}
+      - if: ${{ !inputs.self-hosted }}
         name: Login to Azure
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
         with:
@@ -67,11 +56,11 @@ jobs:
           container_registry=${{ env.container_registry }}
           azure_resource_group=${{ env.azure_resource_group }}
           EOF
-      - if: ${{ !matrix.platform.self-hosted }}
+      - if: ${{ !inputs.self-hosted }}
         name: Get credentials for CI cluster
         run: |
           just get-credentials
-      - if: ${{ !matrix.platform.self-hosted }}
+      - if: ${{ !inputs.self-hosted }}
         name: Set sync environment
         run: |
           sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -80,21 +69,27 @@ jobs:
           echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
       - name: Build and prepare deployments
         run: |
-          just coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer ${{ matrix.platform.name }}
+          just coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer ${{ inputs.platform }}
       - name: E2E Test
         run: |
           nix run .#scripts.get-logs workspace/e2e.namespace &
-          nix shell -L .#contrast.e2e --command ${{ matrix.test_name }}.test -test.v \
+          nix shell -L .#contrast.e2e --command ${{ inputs.test-name }}.test -test.v \
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
-            --platform ${{ matrix.platform.name }} \
+            --platform ${{ inputs.platform }} \
             --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: e2e_pod_logs-${{ matrix.platform.name }}-${{ matrix.test_name }}
+          name: e2e_pod_logs-${{ inputs.platform }}-${{ inputs.test-name }}
           path: workspace/namespace-logs
+      - name: Notify teams channel of failure
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: ./.github/actions/post_to_teams
+        with:
+          webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
+          message: "e2e test ${{ inputs.test-name }} failed"
       - name: Cleanup
         if: cancelled() && !inputs.skip-undeploy
         run: |

--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -1,0 +1,76 @@
+name: e2e test
+
+on:
+  workflow_dispatch:
+    inputs:
+      test-name:
+        description: "Test Name"
+        required: true
+        type: choice
+        options:
+          - genpolicy
+          - getdents
+          - openssl
+          - policy
+          - regression
+          - servicemesh
+          - volumestatefulset
+          - workloadsecret
+        default: "openssl"
+      platform:
+        description: "Platform"
+        required: true
+        type: choice
+        options:
+          - AKS-CLH-SNP
+          - K3s-QEMU-SNP
+          - K3s-QEMU-TDX
+      skip-undeploy:
+        description: "Skip undeploy"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  determine-platform-params:
+    runs-on: ubuntu-22.04
+    outputs:
+      runner: ${{ steps.determine-platform-params.outputs.runner }}
+      self-hosted: ${{ steps.determine-platform-params.outputs.self-hosted }}
+    steps:
+      - name: Determine Platform Parameters
+        id: determine-platform-params
+        run: |
+          case ${{ inputs.platform }} in
+            "AKS-CLH-SNP")
+              echo "runner=ubuntu-22.04" >> "$GITHUB_OUTPUT"
+              echo "self-hosted=false" >> "$GITHUB_OUTPUT"
+            ;;
+            "K3s-QEMU-SNP")
+              echo "runner=SNP" >> "$GITHUB_OUTPUT"
+              echo "self-hosted=true" >> "$GITHUB_OUTPUT"
+            ;;
+            "K3s-QEMU-TDX")
+              echo "runner=TDX" >> "$GITHUB_OUTPUT"
+              echo "self-hosted=true" >> "$GITHUB_OUTPUT"
+            ;;
+            *)
+              echo "Unsupported platform: {{ platform }}"
+              exit 1
+            ;;
+          esac
+
+  test:
+    name: "${{ inputs.platform }}"
+    needs: [determine-platform-params]
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      skip-undeploy: ${{ inputs.skip-undeploy }}
+      test-name: ${{ inputs.test-name }}
+      platform: ${{ inputs.platform }}
+      runner: ${{ needs.determine-platform-params.outputs.runner }}
+      self-hosted: ${{ fromJSON(needs.determine-platform-params.outputs.self-hosted) }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -1,0 +1,34 @@
+name: e2e test
+
+on:
+  schedule:
+    - cron: "30 4 * * *" # 4:30 a.m. every day
+
+jobs:
+  test_matrix:
+    strategy:
+      matrix:
+        platform:
+          - name: AKS-CLH-SNP
+            runner: ubuntu-22.04
+            self-hosted: false
+          - name: K3s-QEMU-SNP
+            runner: SNP
+            self-hosted: true
+          - name: K3s-QEMU-TDX
+            runner: TDX
+            self-hosted: true
+        test-name: [servicemesh, openssl, policy, workloadsecret, volumestatefulset]
+      fail-fast: false
+    name: "${{ matrix.platform.name }}"
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      skip-undeploy: false
+      test-name: ${{ matrix.test-name }}
+      platform: ${{ matrix.platform.name }}
+      runner: ${{ matrix.platform.runner }}
+      self-hosted: ${{ matrix.platform.self-hosted }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/e2e_openssl.yml
+++ b/.github/workflows/e2e_openssl.yml
@@ -1,0 +1,38 @@
+name: e2e test
+
+on:
+  pull_request:
+    paths-ignore:
+      - dev-docs/**
+      - docs/**
+      - rfc/**
+      - tools/asciinema/**
+      - tools/vale/**
+
+jobs:
+  test_matrix:
+    strategy:
+      matrix:
+        platform:
+          - name: AKS-CLH-SNP
+            runner: ubuntu-22.04
+            self-hosted: false
+          - name: K3s-QEMU-SNP
+            runner: SNP
+            self-hosted: true
+          - name: K3s-QEMU-TDX
+            runner: TDX
+            self-hosted: true
+      fail-fast: false
+    name: "${{ matrix.platform.name }}"
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      skip-undeploy: false
+      test-name: openssl
+      platform: ${{ matrix.platform.name }}
+      runner: ${{ matrix.platform.runner }}
+      self-hosted: ${{ matrix.platform.self-hosted }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/e2e_regression.yml
+++ b/.github/workflows/e2e_regression.yml
@@ -3,13 +3,6 @@ name: e2e test regression
 on:
   schedule:
     - cron: "16 6 * * 6" # 6:16 on Saturdays
-  workflow_dispatch:
-    inputs:
-      skip-undeploy:
-        description: "Skip undeploy"
-        required: false
-        type: boolean
-        default: false
   pull_request:
     paths:
       - .github/workflows/e2e_regression.yml
@@ -17,16 +10,8 @@ on:
       - e2e/genpolicy/**
       - e2e/regression/**
 
-env:
-  container_registry: ghcr.io/edgelesssys
-  azure_resource_group: contrast-ci
-  DO_NOT_TRACK: 1
-
 jobs:
   regression-test:
-    permissions:
-      contents: read
-      packages: write
     strategy:
       matrix:
         platform:
@@ -39,82 +24,26 @@ jobs:
           - name: K3s-QEMU-TDX
             runner: TDX
             self-hosted: true
-        case:
-          - getdents
-          - genpolicy
-          - regression
+        test-name: [getdents, genpolicy, regression]
         exclude:
           # getdents is a regression test for tardev-snapshotter
           - platform:
               self-hosted: true
-            case: getdents
+            test-name: getdents
           # genpolicy is (currently) a regression test for tardev-snapshotter
           - platform:
               self-hosted: true
-            case: genpolicy
+            test-name: genpolicy
       fail-fast: false
-    name: "${{ matrix.platform.name }} / ${{ matrix.case }}"
-    runs-on: ${{ matrix.platform.runner }}
-    steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - uses: ./.github/actions/setup_nix
-        if: ${{ !matrix.platform.self-hosted }}
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Log in to ghcr.io Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to Azure
-        if: ${{ !matrix.platform.self-hosted }}
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
-        with:
-          creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
-      - uses: nicknovitski/nix-develop@a2060d116a50b36dfab02280af558e73ab52427d # v1.1.0
-      - name: Create justfile.env
-        run: |
-          cat <<EOF > justfile.env
-          container_registry=${{ env.container_registry }}
-          azure_resource_group=${{ env.azure_resource_group }}
-          EOF
-      - name: Get credentials for CI cluster
-        if: ${{ !matrix.platform.self-hosted }}
-        run: |
-          just get-credentials
-      - if: ${{ !matrix.platform.self-hosted }}
-        name: Set sync environment
-        run: |
-          sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-          echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a "$GITHUB_ENV"
-          sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
-          echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
-      - name: Build and prepare deployments
-        run: |
-          just coordinator initializer port-forwarder openssl service-mesh-proxy node-installer ${{ matrix.platform.name }}
-      - name: Run regression test
-        run: |
-          nix run .#scripts.get-logs workspace/e2e.namespace &
-          nix shell -L .#contrast.e2e --command ${{ matrix.case }}.test -test.v \
-            --image-replacements workspace/just.containerlookup \
-            --namespace-file workspace/e2e.namespace \
-            --platform ${{ matrix.platform.name }} \
-            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-        with:
-          name: e2e_pod_logs-${{ matrix.platform.name }}-${{ matrix.case }}
-          path: workspace/namespace-logs
-      - name: Notify teams channel of failure
-        if: ${{ failure() && github.ref == 'main' }}
-        uses: ./.github/actions/post_to_teams
-        with:
-          webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
-          message: "Regression test failed"
-      - name: Cleanup
-        if: cancelled() && !inputs.skip-undeploy
-        run: |
-          kubectl delete ns "$(cat workspace/e2e.namespace)" --timeout 5m
+    name: "${{ matrix.platform.name }}"
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      skip-undeploy: false
+      test-name: ${{ matrix.test-name }}
+      platform: ${{ matrix.platform.name }}
+      runner: ${{ matrix.platform.runner }}
+      self-hosted: ${{ matrix.platform.self-hosted }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/e2e_service_mesh.yml
+++ b/.github/workflows/e2e_service_mesh.yml
@@ -1,0 +1,35 @@
+name: e2e test
+
+on:
+  pull_request:
+    paths:
+      - e2e/servicemesh/**
+      - service-mesh/**
+
+jobs:
+  test_matrix:
+    strategy:
+      matrix:
+        platform:
+          - name: AKS-CLH-SNP
+            runner: ubuntu-22.04
+            self-hosted: false
+          - name: K3s-QEMU-SNP
+            runner: SNP
+            self-hosted: true
+          - name: K3s-QEMU-TDX
+            runner: TDX
+            self-hosted: true
+      fail-fast: false
+    name: "${{ matrix.platform.name }}"
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      skip-undeploy: false
+      test-name: servicemesh
+      platform: ${{ matrix.platform.name }}
+      runner: ${{ matrix.platform.runner }}
+      self-hosted: ${{ matrix.platform.self-hosted }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
This achieves the following goals:
1. Only run the openssl tests for PRs.
2. Only run the servicemesh tests when its files have been touched.
3. Run all other tests every day at night (and send notifications on failure).
4. Keep the manual dispatch workflow.

I don't think it's possible to reasonably achieve all of those with a single workflow file (though I'm open to suggestions), so I've turned `e2e.yaml` into a reusable workflow that's invoked by other workflow files with different parameters.