### PR TITLE
contrast: remove default SVNs for TDX

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -211,11 +211,21 @@ contrast generate --reference-values aks-clh-snp resources/
 ```sh
 contrast generate --reference-values k3s-qemu-snp resources/
 ```
+:::note[Missing TCB values]
+On bare metal SEV-SNP, `contrast generate` is unable to fill in the `MinimumTCB` values as they can vary between platforms.
+They will have to be filled in manually.
+If you don't know the correct values use `{"BootloaderVersion":255,"TEEVersion":255,"SNPVersion":255,"MicrocodeVersion":255}` and observe the real values in the error messages in the following steps. This should only be done in a secure environment. Note that the values will differ between CPU models.
+:::
 </TabItem>
 <TabItem value="k3s-qemu-tdx" label="Bare Metal (TDX)">
 ```sh
 contrast generate --reference-values k3s-qemu-tdx resources/
 ```
+:::note[Missing TCB values]
+On bare metal TDX, `contrast generate` is unable to fill in the `MinimumTeeTcbSvn` and `MrSeam` TCB values as they can vary between platforms.
+They will have to be filled in manually.
+If you don't know the correct values use `ffffffffffffffffffffffffffffffff` and `000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000` respectively and observe the real values in the error messages in the following steps. This should only be done in a secure environment.
+:::
 </TabItem>
 </Tabs>
 

--- a/docs/docs/examples/emojivoto.md
+++ b/docs/docs/examples/emojivoto.md
@@ -101,11 +101,21 @@ contrast generate --reference-values aks-clh-snp deployment/
 ```sh
 contrast generate --reference-values k3s-qemu-snp deployment/
 ```
+:::note[Missing TCB values]
+On bare metal SEV-SNP, `contrast generate` is unable to fill in the `MinimumTCB` values as they can vary between platforms.
+They will have to be filled in manually.
+If you don't know the correct values use `{"BootloaderVersion":255,"TEEVersion":255,"SNPVersion":255,"MicrocodeVersion":255}` and observe the real values in the error messages in the following steps. This should only be done in a secure environment. Note that the values will differ between CPU models.
+:::
 </TabItem>
 <TabItem value="k3s-qemu-tdx" label="Bare Metal (TDX)">
 ```sh
 contrast generate --reference-values k3s-qemu-tdx deployment/
 ```
+:::note[Missing TCB values]
+On bare metal TDX, `contrast generate` is unable to fill in the `MinimumTeeTcbSvn` and `MrSeam` TCB values as they can vary between platforms.
+They will have to be filled in manually.
+If you don't know the correct values use `ffffffffffffffffffffffffffffffff` and `000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000` respectively and observe the real values in the error messages in the following steps. This should only be done in a secure environment.
+:::
 </TabItem>
 </Tabs>
 

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -208,6 +208,14 @@ func (ct *ContrastTest) patchReferenceValues(t *testing.T, platform platforms.Pl
 			snp.MinimumTCB.MicrocodeVersion = toPtr(manifest.SVN(0))
 			m.ReferenceValues.SNP[i] = snp
 		}
+	case platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+		// The generate command doesn't fill in all required fields when
+		// generating a manifest for baremetal TDX. Do that now.
+		for i, tdx := range m.ReferenceValues.TDX {
+			tdx.MinimumTeeTcbSvn = manifest.HexString("04010200000000000000000000000000")
+			tdx.MrSeam = manifest.HexString("1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04")
+			m.ReferenceValues.TDX[i] = tdx
+		}
 	}
 
 	manifestBytes, err = json.Marshal(m)

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -308,7 +308,8 @@ func (c *contrast) patchReferenceValues(t *testing.T, lowerPlatformStr string) {
 	var m manifest.Manifest
 	require.NoError(t, json.Unmarshal(manifestBytes, &m))
 
-	if lowerPlatformStr == "k3s-qemu-snp" {
+	switch lowerPlatformStr {
+	case "k3s-qemu-snp":
 		// The generate command doesn't fill in all required fields when
 		// generating a manifest for baremetal SNP. Do that now.
 		for i, snp := range m.ReferenceValues.SNP {
@@ -317,6 +318,14 @@ func (c *contrast) patchReferenceValues(t *testing.T, lowerPlatformStr string) {
 			snp.MinimumTCB.SNPVersion = toPtr(manifest.SVN(0))
 			snp.MinimumTCB.MicrocodeVersion = toPtr(manifest.SVN(0))
 			m.ReferenceValues.SNP[i] = snp
+		}
+	case "k3s-qemu-tdx", "rke2-qemu-tdx":
+		// The generate command doesn't fill in all required fields when
+		// generating a manifest for baremetal TDX. Do that now.
+		for i, tdx := range m.ReferenceValues.TDX {
+			tdx.MinimumTeeTcbSvn = manifest.HexString("04010200000000000000000000000000")
+			tdx.MrSeam = manifest.HexString("1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04")
+			m.ReferenceValues.TDX[i] = tdx
 		}
 	}
 

--- a/justfile
+++ b/justfile
@@ -120,6 +120,11 @@ generate cli=default_cli platform=default_platform:
             '.ReferenceValues.snp.[].MinimumTCB = {"BootloaderVersion":0,"TEEVersion":0,"SNPVersion":0,"MicrocodeVersion":0}' \
             {{ workspace_dir }}/manifest.json
         ;;
+        "K3s-QEMU-TDX" | "RKE2-QEMU-TDX")
+            yq --inplace \
+            '.ReferenceValues.tdx.[].MinimumTeeTcbSvn = "04010200000000000000000000000000" | .ReferenceValues.tdx.[].MrSeam = "1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04"' \
+            {{ workspace_dir }}/manifest.json
+        ;;
     esac
 
 # Apply Kubernetes manifests from /deployment

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -116,10 +116,6 @@ let
               ];
               minimumQeSvn = 0;
               minimumPceSvn = 0;
-              # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
-              minimumTeeTcbSvn = "04010200000000000000000000000000";
-              # TODO(freax13): Remove this. We should ask the user to fill this in instead of providing our own defaults.
-              mrSeam = "1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04";
               tdAttributes = "0000001000000000";
               xfam = "e702060000000000";
             }


### PR DESCRIPTION
We don't ship minimum default SVNs for bare metal, so we shouldn't have a default for minimumTeeTcbSvn. Having a default for mrSeam is problematic because it legitimately can change as a customer updates their firmware.