### PR TITLE
justfile: bump version for snp kubeconfig secret

### DIFF
--- a/justfile
+++ b/justfile
@@ -291,7 +291,7 @@ get-credentials-from-gcloud path:
 
 get-credentials-tdxbm: (get-credentials-from-gcloud "projects/796962942582/secrets/m50-ganondorf-kubeconf/versions/5")
 
-get-credentials-snpbm: (get-credentials-from-gcloud "projects/796962942582/secrets/discovery-kubeconf/versions/1")
+get-credentials-snpbm: (get-credentials-from-gcloud "projects/796962942582/secrets/discovery-kubeconf/versions/2")
 
 # Destroy a running AKS cluster.
 destroy platform=default_platform:


### PR DESCRIPTION
We had to do a reinstall of the k3s cluster on our SNP server. The new config is available under version 2 of the secret.