### PR TITLE
erofs: pin to 1.7.1

### DIFF
--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -25,4 +25,16 @@ final: prev: {
       hash = "sha256-MsZ4Bl8sW1dZUB9cYPsaLtc8P8RRx4hafSbNB4vXqi4=";
     };
   });
+
+  # There is a reproducibility issue in later versions,
+  # likely https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/commit/?id=0da388cfdc9dcb952c01b0755ab8a1d6d59a5312
+  erofs-utils = prev.erofs-utils.overrideAttrs (
+    finalAttrs: _prevAttrs: {
+      version = "1.7.1";
+      src = final.fetchurl {
+        url = "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${finalAttrs.version}.tar.gz";
+        hash = "sha256-GWCD1j5eIx+1eZ586GqUS7ylZNqrzj3pIlqKyp3K/xU=";
+      };
+    }
+  );
 }

--- a/packages/by-name/buildVerityUKI/package.nix
+++ b/packages/by-name/buildVerityUKI/package.nix
@@ -15,6 +15,9 @@ nixos-config:
   boot.kernelParams = lib.optional (roothashPlaceholder != "") "roothash=${roothashPlaceholder}";
 }).image.overrideAttrs
   (oldAttrs: {
+    preBuild = ''
+      echo Building on file system $(stat -f -c %T .)
+    '';
     nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ jq ];
     # Replace the placeholder with the real root hash.
     # The real root hash is only known after we build the image, so this


### PR DESCRIPTION
There is a reproducibility issue in later versions, likely https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/commit/?id=0da388cfdc9dcb952c01b0755ab8a1d6d59a5312