### PR TITLE
e2e: add a test for checking AKS upstream

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,11 @@ on:
       self-hosted:
         description: "Self Hosted"
         type: boolean
+      run-without-nix:
+        description: "Run the E2E test without using a nix shell"
+        type: boolean
+        required: false
+        default: false
 
 env:
   container_registry: ghcr.io/edgelesssys
@@ -73,11 +78,22 @@ jobs:
       - name: E2E Test
         run: |
           nix run .#scripts.get-logs workspace/e2e.namespace &
-          nix shell -L .#contrast.e2e --command ${{ inputs.test-name }}.test -test.v \
-            --image-replacements workspace/just.containerlookup \
-            --namespace-file workspace/e2e.namespace \
-            --platform ${{ inputs.platform }} \
-            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+          if [[ "${{inputs.run-without-nix}}" == "false" ]]; then
+            echo "Running with nix"
+            nix shell -L .#contrast.e2e --command ${{ inputs.test-name }}.test -test.v \
+              --image-replacements workspace/just.containerlookup \
+              --namespace-file workspace/e2e.namespace \
+              --platform ${{ inputs.platform }} \
+              --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+          else
+            echo "Running without nix"
+            nix build .#contrast.e2e
+            ./result/bin/${{ inputs.test-name }}.test -test.v \
+              --image-replacements workspace/just.containerlookup \
+              --namespace-file workspace/e2e.namespace \
+              --platform ${{ inputs.platform }} \
+              --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+          fi
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,11 +18,6 @@ on:
       self-hosted:
         description: "Self Hosted"
         type: boolean
-      run-without-nix:
-        description: "Run the E2E test without using a nix shell"
-        type: boolean
-        required: false
-        default: false
 
 env:
   container_registry: ghcr.io/edgelesssys
@@ -78,22 +73,11 @@ jobs:
       - name: E2E Test
         run: |
           nix run .#scripts.get-logs workspace/e2e.namespace &
-          if [[ "${{inputs.run-without-nix}}" == "false" ]]; then
-            echo "Running with nix"
-            nix shell -L .#contrast.e2e --command ${{ inputs.test-name }}.test -test.v \
-              --image-replacements workspace/just.containerlookup \
-              --namespace-file workspace/e2e.namespace \
-              --platform ${{ inputs.platform }} \
-              --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
-          else
-            echo "Running without nix"
-            nix build .#contrast.e2e
-            ./result/bin/${{ inputs.test-name }}.test -test.v \
-              --image-replacements workspace/just.containerlookup \
-              --namespace-file workspace/e2e.namespace \
-              --platform ${{ inputs.platform }} \
-              --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
-          fi
+          nix shell -L .#contrast.e2e --command ${{ inputs.test-name }}.test -test.v \
+            --image-replacements workspace/just.containerlookup \
+            --namespace-file workspace/e2e.namespace \
+            --platform ${{ inputs.platform }} \
+            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -9,6 +9,7 @@ on:
       - e2e/aks-runtime/**
 
 jobs:
+  # steps taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
   install-software:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -1,0 +1,25 @@
+name: e2e test aks runtime
+
+on:
+  schedule:
+    - cron: "16 6 * * 6" # 6:16 on Saturdays
+  pull_request:
+    paths:
+      - e2e/aks-runtime/**
+
+jobs:
+  test_matrix:
+    strategy:
+      fail-fast: false
+    name: Test aks runtime
+    uses: ./.github/workflows/e2e.yml
+    with:
+      skip-undeploy: false
+      test-name: aks-runtime
+      platform: AKS-CLH-SNP
+      runner: ubuntu-22.04
+      self-hosted: false
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -43,7 +43,7 @@ jobs:
           echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
       - name: Build and prepare deployments
         run: |
-          nix run .#just -- coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer AKS-CLH-SNP
+          nix shell .#just --command just coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer AKS-CLH-SNP
       # steps taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
       - name: Install `az` with extensions
         run: |

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -9,15 +9,37 @@ on:
 
 jobs:
   test_matrix:
-    name: Test aks runtime
-    uses: ./.github/workflows/e2e.yml
-    with:
-      skip-undeploy: false
-      test-name: aks-runtime
-      platform: AKS-CLH-SNP
-      runner: ubuntu-22.04
-      self-hosted: false
-    secrets: inherit
-    permissions:
-      contents: read
-      packages: write
+    steps:
+      - name: Install `az` with extensions
+        run: |
+          sudo apt-get update
+          sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
+          sudo mkdir -p /etc/apt/keyrings
+          curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+            gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+          sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+          AZ_DIST=$(lsb_release -cs)
+          echo "Types: deb
+          URIs: https://packages.microsoft.com/repos/azure-cli/
+          Suites: ${AZ_DIST}
+          Components: main
+          Architectures: $(dpkg --print-architecture)
+          Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+          sudo apt-get update
+          sudo apt-get install azure-cli
+
+          az extension add --name aks-preview
+          az extension add --name confcom
+      - name: Test aks runtime
+        uses: ./.github/workflows/e2e.yml
+        with:
+          skip-undeploy: false
+          test-name: aks-runtime
+          platform: AKS-CLH-SNP
+          runner: ubuntu-22.04
+          self-hosted: false
+          run-without-nix: true
+        secrets: inherit
+        permissions:
+          contents: read
+          packages: write

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -1,6 +1,7 @@
 name: e2e test aks runtime
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "16 6 * * 6" # 6:16 on Saturdays
   pull_request:

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -9,7 +9,8 @@ on:
       - e2e/aks-runtime/**
 
 jobs:
-  test_matrix:
+  install-software:
+    runs-on: ubuntu-22.04
     steps:
       - name: Install `az` with extensions
         run: |
@@ -17,7 +18,7 @@ jobs:
           sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
           sudo mkdir -p /etc/apt/keyrings
           curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-            gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+          gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
           AZ_DIST=$(lsb_release -cs)
           echo "Types: deb
@@ -31,16 +32,19 @@ jobs:
 
           az extension add --name aks-preview
           az extension add --name confcom
-      - name: Test aks runtime
-        uses: ./.github/workflows/e2e.yml
-        with:
-          skip-undeploy: false
-          test-name: aks-runtime
-          platform: AKS-CLH-SNP
-          runner: ubuntu-22.04
-          self-hosted: false
-          run-without-nix: true
-        secrets: inherit
-        permissions:
-          contents: read
-          packages: write
+
+  test_matrix:
+    name: Test aks runtime
+    needs: install-software
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/e2e.yml
+    with:
+      skip-undeploy: false
+      test-name: aks-runtime
+      platform: AKS-CLH-SNP
+      runner: ubuntu-22.04
+      self-hosted: false
+      run-without-nix: true

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -94,7 +94,7 @@ jobs:
           name: e2e_pod_logs-AKS-CLH-SNP-aks-runtime
           path: workspace/namespace-logs
       - name: Notify teams channel of failure
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() && github.event_name == 'schedule' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install `az` with extensions
         run: |
           sudo apt-get update
-          sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
+          sudo apt-get -y install apt-transport-https ca-certificates curl gnupg lsb-release
           sudo mkdir -p /etc/apt/keyrings
           curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
           gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
@@ -74,7 +74,7 @@ jobs:
           EOF
 
           sudo apt-get update
-          sudo apt-get install azure-cli
+          sudo apt-get -y install azure-cli
 
           az extension add --name aks-preview
           az extension add --name confcom

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup_nix

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -9,8 +9,6 @@ on:
 
 jobs:
   test_matrix:
-    strategy:
-      fail-fast: false
     name: Test aks runtime
     uses: ./.github/workflows/e2e.yml
     with:

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -26,6 +26,12 @@ jobs:
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
         with:
           creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create justfile.env
         run: |
           cat <<EOF > justfile.env

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -22,12 +22,16 @@ jobs:
           gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
           sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
           AZ_DIST=$(lsb_release -cs)
-          echo "Types: deb
+
+          sudo tee /etc/apt/sources.list.d/azure-cli.sources <<EOF
+          Types: deb
           URIs: https://packages.microsoft.com/repos/azure-cli/
           Suites: ${AZ_DIST}
           Components: main
           Architectures: $(dpkg --print-architecture)
-          Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+          Signed-by: /etc/apt/keyrings/microsoft.gpg
+          EOF
+
           sudo apt-get update
           sudo apt-get install azure-cli
 

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - e2e/aks-runtime/**
 
+env:
+  container_registry: ghcr.io/edgelesssys
+  azure_resource_group: contrast-ci
+  DO_NOT_TRACK: 1
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -9,10 +9,37 @@ on:
       - e2e/aks-runtime/**
 
 jobs:
-  # steps taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
-  install-software:
+  test:
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Login to Azure
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
+        with:
+          creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
+      - name: Create justfile.env
+        run: |
+          cat <<EOF > justfile.env
+          container_registry=${{ env.container_registry }}
+          azure_resource_group=${{ env.azure_resource_group }}
+          EOF
+      - name: Get credentials for CI cluster
+        run: |
+          nix run .#just -- get-credentials
+      - name: Set sync environment
+        run: |
+          sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a "$GITHUB_ENV"
+          sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
+          echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
+      - name: Build and prepare deployments
+        run: |
+          nix run .#just -- coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer AKS-CLH-SNP
+      # steps taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
       - name: Install `az` with extensions
         run: |
           sudo apt-get update
@@ -37,19 +64,30 @@ jobs:
 
           az extension add --name aks-preview
           az extension add --name confcom
-
-  test_matrix:
-    name: Test aks runtime
-    needs: install-software
-    secrets: inherit
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/e2e.yml
-    with:
-      skip-undeploy: false
-      test-name: aks-runtime
-      platform: AKS-CLH-SNP
-      runner: ubuntu-22.04
-      self-hosted: false
-      run-without-nix: true
+      - name: E2E test
+        run: |
+          nix run .#scripts.get-logs workspace/e2e.namespace &
+          nix build .#contrast.e2e
+          ./result/bin/aks-runtime.test -test.v \
+            --image-replacements workspace/just.containerlookup \
+            --namespace-file workspace/e2e.namespace \
+            --platform AKS-CLH-SNP \
+            --skip-undeploy="false"
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: e2e_pod_logs-AKS-CLH-SNP-aks-runtime
+          path: workspace/namespace-logs
+      - name: Notify teams channel of failure
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: ./.github/actions/post_to_teams
+        with:
+          webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
+          title: "aks-runtime test failed"
+          message: "e2e test aks-runtime failed"
+          additionalFields: '[{"title": "Platform", "value": "AKS-CLH-SNP"}]'
+      - name: Cleanup
+        if: cancelled()
+        run: |
+          kubectl delete ns "$(cat workspace/e2e.namespace)" --timeout 5m

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//go:build e2e
+///go:build e2e
 
 package aksruntime
 
@@ -116,7 +116,7 @@ func TestAKSRuntime(t *testing.T) {
 
 		// delete the deployment
 		deletePolicy := metav1.DeletePropagationForeground
-		require.NoError(c.Client.AppsV1().Deployments(namespace).Delete(context.Background(), testContainer, metav1.DeleteOptions{
+		require.NoError(c.Client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{
 			PropagationPolicy: &deletePolicy,
 		}))
 	})

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -76,7 +76,7 @@ func TestAKSRuntime(t *testing.T) {
 					WithContainers(kuberesource.Container().
 						WithName(testContainer).
 						WithImage("docker.io/bash@sha256:ce062497c248eb1cf4d32927f8c1780cce158d3ed0658c586a5be7308d583cbb").
-						WithCommand("/usr/local/bin/bash", "-c", "uname -r; while true; do sleep 10; done"),
+						WithCommand("/usr/local/bin/bash", "-c", "uname -r; sleep infinity"),
 					),
 				),
 			),
@@ -97,7 +97,7 @@ func TestAKSRuntime(t *testing.T) {
 	require.NoError(os.WriteFile(path.Join(workdir, "resources.yaml"), resourceBytes, 0o644))
 	require.NoError(az.KataPolicyGen(path.Join(workdir, "resources.yaml")))
 
-	// load in generated resources and patch the runtime handler again
+	// load in generated resources
 	resourceBytes, err = os.ReadFile(path.Join(workdir, "resources.yaml"))
 	require.NoError(err)
 	toApply, err := kubeapi.UnmarshalUnstructuredK8SResource(resourceBytes)

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -116,9 +116,11 @@ func TestAKSRuntime(t *testing.T) {
 
 		// delete the deployment
 		deletePolicy := metav1.DeletePropagationForeground
-		require.NoError(c.Client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{
+		if err = c.Client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{
 			PropagationPolicy: &deletePolicy,
-		}))
+		}); err != nil {
+			t.Fatalf("Failed to delete namespace %s", &namespace)
+		}
 	})
 
 	pods, err := c.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -75,7 +75,7 @@ func TestAKSRuntime(t *testing.T) {
 				WithSpec(kuberesource.PodSpec().
 					WithContainers(kuberesource.Container().
 						WithName(testContainer).
-						WithImage("docker.io/bash@sha256:ce062497c248eb1cf4d32927f8c1780cce158d3ed0658c586a5be7308d583cbb").
+						WithImage("ghcr.io/edgelesssys/bash@sha256:cabc70d68e38584052cff2c271748a0506b47069ebbd3d26096478524e9b270b").
 						WithCommand("/usr/local/bin/bash", "-c", "uname -r; sleep infinity"),
 					),
 				),

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -119,7 +119,7 @@ func TestAKSRuntime(t *testing.T) {
 		if err = c.Client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{
 			PropagationPolicy: &deletePolicy,
 		}); err != nil {
-			t.Fatalf("Failed to delete namespace %s", &namespace)
+			t.Fatalf("Failed to delete namespace %s", namespace)
 		}
 	})
 

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -95,7 +95,7 @@ func TestAKSRuntime(t *testing.T) {
 	resourceBytes, err := kuberesource.EncodeUnstructured(toWrite)
 	require.NoError(err)
 	require.NoError(os.WriteFile(path.Join(workdir, "resources.yaml"), resourceBytes, 0o644))
-	require.NoError(az.KataPolicyGen(t, path.Join(workdir, "resources.yaml")))
+	require.NoError(az.KataPolicyGen(path.Join(workdir, "resources.yaml")))
 
 	// load in generated resources and patch the runtime handler again
 	resourceBytes, err = os.ReadFile(path.Join(workdir, "resources.yaml"))

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -123,7 +123,7 @@ func TestAKSRuntime(t *testing.T) {
 
 	pods, err := c.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(err)
-	require.Equal(len(pods.Items), 1)
+	require.Len(pods.Items, 1)
 	pod := pods.Items[0] // only one pod was deployed
 
 	logs, err := c.Client.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).DoRaw(ctx)

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -6,21 +6,18 @@
 package aksruntime
 
 import (
-	"bytes"
 	"context"
 	"flag"
-	"io"
 	"os"
 	"path"
 	"testing"
 	"time"
 
-	"github.com/edgelesssys/contrast/cli/cmd"
+	"github.com/edgelesssys/contrast/e2e/internal/confcom"
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
 	"github.com/edgelesssys/contrast/internal/kubeapi"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
-	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,22 +71,24 @@ func TestAKSRuntime(t *testing.T) {
 	resourceBytes, err := kuberesource.EncodeUnstructured(toWrite)
 	require.NoError(err)
 	require.NoError(os.WriteFile(path.Join(workdir, "resources.yaml"), resourceBytes, 0o644))
+	require.NoError(confcom.KataPolicyGen(t, path.Join(workdir, "resources.yaml")))
 
-	platform, err := platforms.FromString(platformStr)
-	require.NoError(err)
-	args := []string{
-		"--image-replacements", imageReplacementsFile,
-		"--reference-values", platform.String(),
-		path.Join(workdir, "resources.yaml"),
-	}
-
-	generate := cmd.NewGenerateCmd()
-	generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags
-	generate.Flags().String("log-level", "debug", "")
-	generate.SetArgs(args)
-	generate.SetOut(io.Discard)
-	errBuf := &bytes.Buffer{}
-	generate.SetErr(errBuf)
+	//
+	// platform, err := platforms.FromString(platformStr)
+	// require.NoError(err)
+	// args := []string{
+	// 	"--image-replacements", imageReplacementsFile,
+	// 	"--reference-values", platform.String(),
+	// 	path.Join(workdir, "resources.yaml"),
+	// }
+	//
+	// generate := cmd.NewGenerateCmd()
+	// generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags
+	// generate.Flags().String("log-level", "debug", "")
+	// generate.SetArgs(args)
+	// generate.SetOut(io.Discard)
+	// errBuf := &bytes.Buffer{}
+	// generate.SetErr(errBuf)
 
 	// load in generated resources and patch the runtime handler again
 	resourceBytes, err = os.ReadFile(path.Join(workdir, "resources.yaml"))

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -21,10 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	opensslFrontend = "openssl-frontend"
-	opensslBackend  = "openssl-backend"
-)
+const getdentsTester = "getdents-tester"
 
 var (
 	imageReplacementsFile, namespaceFile, platformStr string
@@ -32,7 +29,6 @@ var (
 )
 
 func TestAKSRuntime(t *testing.T) {
-	// TODO: Log kata information
 	require := require.New(t)
 
 	workdir := t.TempDir()
@@ -57,6 +53,7 @@ func TestAKSRuntime(t *testing.T) {
 	}
 
 	// define resources
+	// TODO: Log kata-agent, guest kernel, node image version with custom container deployment
 	resources := kuberesource.GetDEnts()
 	resources = kuberesource.PatchRuntimeHandlers(resources, "kata-cc-isolation")
 	resources = kuberesource.PatchNamespaces(resources, namespace)
@@ -81,9 +78,7 @@ func TestAKSRuntime(t *testing.T) {
 	defer cancel()
 	err = c.Apply(ctx, toApply...)
 	require.NoError(err)
-	require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, namespace, opensslBackend))
-	require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, namespace, opensslFrontend))
-	c.LogDebugInfo(context.Background())
+	require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, namespace, getdentsTester))
 }
 
 func TestMain(m *testing.M) {

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package aksruntime
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/contrast/cli/cmd"
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
+	"github.com/edgelesssys/contrast/internal/kubeapi"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	opensslFrontend = "openssl-frontend"
+	opensslBackend  = "openssl-backend"
+)
+
+var (
+	imageReplacementsFile, namespaceFile, platformStr string
+	skipUndeploy                                      bool
+)
+
+func TestAKSRuntime(t *testing.T) {
+	// TODO: Log kata information
+	require := require.New(t)
+
+	workdir := t.TempDir()
+
+	f, err := os.Open(imageReplacementsFile)
+	require.NoError(err)
+	imageReplacements, err := kuberesource.ImageReplacementsFromFile(f)
+	require.NoError(err)
+	namespace := contrasttest.MakeNamespace(t)
+
+	c := kubeclient.NewForTest(t)
+
+	// create the namespace
+	ns, err := kuberesource.ResourcesToUnstructured([]any{kuberesource.Namespace(namespace)})
+	require.NoError(err)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	err = c.Apply(ctx, ns...)
+	cancel()
+	require.NoError(err)
+	if namespaceFile != "" {
+		require.NoError(os.WriteFile(namespaceFile, []byte(namespace), 0o644))
+	}
+
+	// define resources
+	resources := kuberesource.OpenSSL()
+	// TODO: check if this can be removed since they are overwritten later
+	resources = kuberesource.PatchRuntimeHandlers(resources, "kata-cc-isolation")
+	resources = kuberesource.PatchNamespaces(resources, namespace)
+	resources = kuberesource.PatchImages(resources, imageReplacements)
+
+	toWrite, err := kuberesource.ResourcesToUnstructured(resources)
+	require.NoError(err)
+
+	t.Log("generating policies...")
+	// generate policies
+	resourceBytes, err := kuberesource.EncodeUnstructured(toWrite)
+	require.NoError(err)
+	require.NoError(os.WriteFile(path.Join(workdir, "resources.yaml"), resourceBytes, 0o644))
+
+	platform, err := platforms.FromString(platformStr)
+	require.NoError(err)
+	args := []string{
+		"--image-replacements", imageReplacementsFile,
+		"--reference-values", platform.String(),
+		path.Join(workdir, "resources.yaml"),
+	}
+
+	generate := cmd.NewGenerateCmd()
+	generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags
+	generate.Flags().String("log-level", "debug", "")
+	generate.SetArgs(args)
+	generate.SetOut(io.Discard)
+	errBuf := &bytes.Buffer{}
+	generate.SetErr(errBuf)
+
+	// load in generated resources and patch the runtime handler again
+	resourceBytes, err = os.ReadFile(path.Join(workdir, "resources.yaml"))
+	require.NoError(err)
+	toApply, err := kubeapi.UnmarshalUnstructuredK8SResource(resourceBytes)
+	require.NoError(err)
+	t.Logf("%#v", toApply)
+
+	t.Log("policies generated!")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	err = c.Apply(ctx, toApply...)
+	require.NoError(err)
+	require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, namespace, opensslBackend))
+	require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, namespace, opensslFrontend))
+	c.LogDebugInfo(context.Background())
+}
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
+	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
+	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
+	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	flag.Parse()
+
+	os.Exit(m.Run())
+}

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-///go:build e2e
+//go:build e2e
 
 package aksruntime
 
@@ -123,6 +123,7 @@ func TestAKSRuntime(t *testing.T) {
 
 	pods, err := c.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(err)
+	require.Equal(len(pods.Items), 1)
 	pod := pods.Items[0] // only one pod was deployed
 
 	logs, err := c.Client.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).DoRaw(ctx)

--- a/e2e/internal/az/aks.go
+++ b/e2e/internal/az/aks.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package az
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// NodeImageVersion gets the node image version from the specified cluster
+// and resource group.
+func NodeImageVersion(clusterName string, rg string) (string, error) {
+	out, err := exec.Command("az", "aks", "nodepool", "list", "--cluster-name", clusterName, "--resource-group", rg).Output()
+	if err != nil {
+		return "", err
+	}
+
+	var outMap []map[string]interface{}
+	err = json.Unmarshal(out, &outMap)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s", outMap[0]["nodeImageVersion"]), nil
+}

--- a/e2e/internal/az/aks.go
+++ b/e2e/internal/az/aks.go
@@ -7,6 +7,7 @@ package az
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -24,6 +25,9 @@ func NodeImageVersion(clusterName string, rg string) (string, error) {
 	err = json.Unmarshal(out, &outMap)
 	if err != nil {
 		return "", err
+	}
+	if len(outMap) == 0 {
+		return "", errors.New("No nodepools could be listed")
 	}
 
 	return strings.TrimSpace(fmt.Sprintf("%s", outMap[0]["nodeImageVersion"])), nil

--- a/e2e/internal/az/aks.go
+++ b/e2e/internal/az/aks.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // NodeImageVersion gets the node image version from the specified cluster
@@ -25,5 +26,5 @@ func NodeImageVersion(clusterName string, rg string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s", outMap[0]["nodeImageVersion"]), nil
+	return strings.TrimSpace(fmt.Sprintf("%s", outMap[0]["nodeImageVersion"])), nil
 }

--- a/e2e/internal/az/confcom.go
+++ b/e2e/internal/az/confcom.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package az
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// KataPolicyGen executes `az confcom katapolicygen --yaml <resourcePath>`.
+func KataPolicyGen(t *testing.T, resourcePath string) error {
+	// log versions and extensions that are used
+	out, err := exec.Command("az", "confcom", "katapolicygen", "--print-version").Output()
+	if err != nil {
+		return err
+	}
+	t.Log(string(out))
+
+	return exec.Command("az", "confcom", "katapolicygen", "--yaml", resourcePath).Run()
+}

--- a/e2e/internal/az/confcom.go
+++ b/e2e/internal/az/confcom.go
@@ -6,6 +6,7 @@
 package az
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -21,5 +22,7 @@ func KataPolicyGenVersion() (string, error) {
 
 // KataPolicyGen executes `az confcom katapolicygen --yaml <resourcePath>`.
 func KataPolicyGen(resourcePath string) error {
-	return exec.Command("az", "confcom", "katapolicygen", "--yaml", resourcePath).Run()
+	cmd := exec.Command("az", "confcom", "katapolicygen", "--yaml", resourcePath)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/e2e/internal/az/confcom.go
+++ b/e2e/internal/az/confcom.go
@@ -8,7 +8,6 @@ package az
 import (
 	"os/exec"
 	"strings"
-	"testing"
 )
 
 // KataPolicyGenVersion gets the version string of `az confcom katapolicygen`.
@@ -21,6 +20,6 @@ func KataPolicyGenVersion() (string, error) {
 }
 
 // KataPolicyGen executes `az confcom katapolicygen --yaml <resourcePath>`.
-func KataPolicyGen(t *testing.T, resourcePath string) error {
+func KataPolicyGen(resourcePath string) error {
 	return exec.Command("az", "confcom", "katapolicygen", "--yaml", resourcePath).Run()
 }

--- a/e2e/internal/az/confcom.go
+++ b/e2e/internal/az/confcom.go
@@ -7,17 +7,20 @@ package az
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 )
 
-// KataPolicyGen executes `az confcom katapolicygen --yaml <resourcePath>`.
-func KataPolicyGen(t *testing.T, resourcePath string) error {
-	// log versions and extensions that are used
+// KataPolicyGenVersion gets the version string of `az confcom katapolicygen`.
+func KataPolicyGenVersion() (string, error) {
 	out, err := exec.Command("az", "confcom", "katapolicygen", "--print-version").Output()
 	if err != nil {
-		return err
+		return "", err
 	}
-	t.Log(string(out))
+	return strings.TrimSpace(string(out)), nil
+}
 
+// KataPolicyGen executes `az confcom katapolicygen --yaml <resourcePath>`.
+func KataPolicyGen(t *testing.T, resourcePath string) error {
 	return exec.Command("az", "confcom", "katapolicygen", "--yaml", resourcePath).Run()
 }

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -52,7 +52,7 @@ type ContrastTest struct {
 // New creates a new contrasttest.T object bound to the given test.
 func New(t *testing.T, imageReplacements, namespaceFile string, platform platforms.Platform, skipUndeploy bool) *ContrastTest {
 	return &ContrastTest{
-		Namespace:             makeNamespace(t),
+		Namespace:             MakeNamespace(t),
 		WorkDir:               t.TempDir(),
 		ImageReplacementsFile: imageReplacements,
 		Platform:              platform,
@@ -372,7 +372,7 @@ func (ct *ContrastTest) FactorPlatformTimeout(timeout time.Duration) time.Durati
 	}
 }
 
-func makeNamespace(t *testing.T) string {
+func MakeNamespace(t *testing.T) string {
 	buf := make([]byte, 4)
 	re := regexp.MustCompile("[a-z0-9-]+")
 	n, err := rand.Reader.Read(buf)

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -372,6 +372,7 @@ func (ct *ContrastTest) FactorPlatformTimeout(timeout time.Duration) time.Durati
 	}
 }
 
+// MakeNamespace creates a namespace string using a given *testing.T.
 func MakeNamespace(t *testing.T) string {
 	buf := make([]byte, 4)
 	re := regexp.MustCompile("[a-z0-9-]+")

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,10 @@
           overlays = [ (import ./overlays/nixpkgs.nix) ];
           config.allowUnfree = true;
           config.nvidia.acceptLicense = true;
+          # TODO(miampf): REMOVE AGAIN ONCE UNNEEDED
+          config.permittedInsecurePackages = [
+            "openssl-1.1.1w"
+          ];
         };
         inherit (pkgs) lib;
         treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -1,7 +1,60 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: AGPL-3.0-only
 
-final: prev: {
+final: prev:
+let
+  # Builder for Azure CLI extensions. Extensions are Python wheels that
+  # outside of nix would be fetched by the CLI itself from various sources.
+  mkAzExtension =
+    {
+      pname,
+      url,
+      sha256,
+      description,
+      ...
+    }@args:
+    prev.python3.pkgs.buildPythonPackage (
+      {
+        format = "wheel";
+        src = prev.fetchurl { inherit url sha256; };
+        meta = {
+          inherit description;
+          inherit (prev.azure-cli.meta) platforms maintainers;
+          homepage = "https://github.com/Azure/azure-cli-extensions";
+          changelog = "https://github.com/Azure/azure-cli-extensions/blob/main/src/${pname}/HISTORY.rst";
+          license = prev.lib.licenses.mit;
+          sourceProvenance = [ prev.lib.sourceTypes.fromSource ];
+        } // args.meta or { };
+      }
+      // (removeAttrs args [
+        "url"
+        "sha256"
+        "description"
+        "meta"
+      ])
+    );
+
+  confcom = mkAzExtension rec {
+    pname = "confcom";
+    version = "1.0.0";
+    url = "https://azcliprod.blob.core.windows.net/cli-extensions/confcom-${version}-py3-none-any.whl";
+    sha256 = "73823e10958a114b4aca84c330b4debcc650c4635e74c568679b6c32c356411d";
+    description = "Microsoft Azure Command-Line Tools Confidential Container Security Policy Generator Extension";
+    nativeBuildInputs = [ prev.autoPatchelfHook ];
+    buildInputs = [ prev.openssl_1_1 ];
+    propagatedBuildInputs = with prev.python3Packages; [
+      pyyaml
+      deepdiff
+      docker
+      tqdm
+    ];
+    postInstall = ''
+      chmod +x $out/${prev.python3.sitePackages}/azext_confcom/bin/genpolicy-linux
+    '';
+    meta.maintainers = with prev.lib.maintainers; [ miampf ];
+  };
+in
+{
   # Use when a version of Go is needed that is not available in the nixpkgs yet.
   # go_1_xx = prev.go_1_xx.overrideAttrs (finalAttrs: _prevAttrs: {
   #   version = "";
@@ -13,7 +66,10 @@ final: prev: {
 
   # Add the required extensions to the Azure CLI.
   azure-cli = prev.azure-cli.override {
-    withExtensions = with final.azure-cli.extensions; [ aks-preview ];
+    withExtensions = with final.azure-cli.extensions; [
+      aks-preview
+      confcom
+    ];
   };
 
   # Use a newer uplosi that has fixes for private galleries.

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 final: prev:
+# TODO(miampf): Remove unneccessary block once https://github.com/NixOS/nixpkgs/pull/345326 is merged into unstable nixpkgs
 let
   # Builder for Azure CLI extensions. Extensions are Python wheels that
   # outside of nix would be fetched by the CLI itself from various sources.

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -48,11 +48,6 @@ let
       "e2e/regression"
       "e2e/aks-runtime"
     ];
-
-    postInstall = ''
-      wrapProgram $out/bin/aks-runtime.test \
-        --prefix PATH : ${lib.makeBinPath [ azure-cli ]}
-    '';
   };
 
   # Reference values that we embed into the Contrast CLI for

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -32,7 +32,7 @@ let
       makeWrapper
     ];
 
-    ldflags = [ 
+    ldflags = [
       "-s"
     ];
 

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -3,6 +3,8 @@
 
 {
   lib,
+  azure-cli,
+  makeWrapper,
   buildGoModule,
   buildGoTest,
   microsoft,
@@ -26,7 +28,13 @@ let
 
     tags = [ "e2e" ];
 
-    ldflags = [ "-s" ];
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+
+    ldflags = [ 
+      "-s"
+    ];
 
     subPackages = [
       "e2e/genpolicy"
@@ -40,6 +48,11 @@ let
       "e2e/regression"
       "e2e/aks-runtime"
     ];
+
+    postInstall = ''
+      wrapProgram $out/bin/aks-runtime.test \
+        --prefix PATH : ${lib.makeBinPath [ azure-cli ]}
+    '';
   };
 
   # Reference values that we embed into the Contrast CLI for

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -3,7 +3,6 @@
 
 {
   lib,
-  azure-cli,
   makeWrapper,
   buildGoModule,
   buildGoTest,

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -38,6 +38,7 @@ let
       "e2e/workloadsecret"
       "e2e/volumestatefulset"
       "e2e/regression"
+      "e2e/aks-runtime"
     ];
   };
 

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -3,7 +3,6 @@
 
 {
   lib,
-  makeWrapper,
   buildGoModule,
   buildGoTest,
   microsoft,
@@ -26,14 +25,6 @@ let
     pname = "${contrast.pname}-e2e";
 
     tags = [ "e2e" ];
-
-    nativeBuildInputs = [
-      makeWrapper
-    ];
-
-    ldflags = [
-      "-s"
-    ];
 
     subPackages = [
       "e2e/genpolicy"


### PR DESCRIPTION
Add a test that checks if something in azure upstream is broken by deploying a simple container with the `kata-cc-isolation` runtime class. You can view a successful workflow run [here](https://github.com/edgelesssys/contrast/actions/runs/11386327564/job/31678275073?pr=939).