### PR TITLE
runtime-k3s-qemu-snp.yml: node-installer has too little memory

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -158,7 +158,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 						WithName("installer").
 						WithImage(nodeInstallerImageURL).
 						WithResources(ResourceRequirements().
-							WithMemoryLimitAndRequest(100),
+							WithMemoryLimitAndRequest(700),
 						).
 						WithSecurityContext(SecurityContext().WithPrivileged(true).SecurityContextApplyConfiguration).
 						WithVolumeMounts(VolumeMount().


### PR DESCRIPTION
The OOM Killer kicks in when below 600M on my Milan. Setting to 700M to have some slack.

You can reproduce this with [runtime-k3s-qemu-snp.yml v1.1.0][1], which limits memory to 100M memory.

[1]: https://github.com/edgelesssys/contrast/releases/download/v1.1.0/runtime-k3s-qemu-snp.yml


