### PR TITLE
infra: better default values

### DIFF
--- a/infra/azure-peerpods/main.tf
+++ b/infra/azure-peerpods/main.tf
@@ -101,6 +101,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
   dns_prefix                = "aks"
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
+  sku_tier                  = var.cluster_type
 
   identity {
     type = "SystemAssigned"

--- a/infra/azure-peerpods/vars.tf
+++ b/infra/azure-peerpods/vars.tf
@@ -13,3 +13,8 @@ variable "subscription_id" {
 variable "image_id" {
   type = string
 }
+
+variable "cluster_type" {
+  type    = string
+  default = "Free"
+}


### PR DESCRIPTION
Improve the default values in the deployment a little:
- Free-tier clusters are not always available, so this makes the deployment default to using a standard-tier cluster.
- GPU instances (which are the only ones we provide a working image for at the moment) are unavailable in germanywestcentral. Therefore, default to a GPU-enabled region here. This should not have any disadvantages compared to germanywestcentral for non-GPU use.