### PR TITLE
podvm-image: don't mount tmpfs on /usr

### DIFF
--- a/packages/nixos/image.nix
+++ b/packages/nixos/image.nix
@@ -45,7 +45,7 @@
           Minimize = "best";
           # We need to ensure that mountpoints are available.
           # TODO (Maybe): This could be done more elegantly with CopyFiles and a skeleton tree in the vcs.
-          MakeDirectories = "/bin /boot /dev /etc /home /lib /lib64 /mnt /nix /opt /proc /root /run /srv /sys /tmp /usr /var";
+          MakeDirectories = "/bin /boot /dev /etc /home /lib /lib64 /mnt /nix /opt /proc /root /run /srv /sys /tmp /usr/bin /var";
         };
       };
 

--- a/packages/nixos/system.nix
+++ b/packages/nixos/system.nix
@@ -60,7 +60,7 @@
           "/var"
           "/etc"
           "/bin"
-          "/usr"
+          "/usr/bin"
           "/tmp"
           "/lib"
           "/root"


### PR DESCRIPTION
This is a prerequisite for using peer pods with GPUs, as they require an OCI hook to facilitate GPU attachment to containers, which is expected in `/usr/share` by default. If we mount a tmpfs on `/usr`, the files placed in the initial image through the `contents` attribute of the repart builder will become invisible, so we now only mount it at `/usr/bin` instead.