### PR TITLE
e2e: add `kata.contrast-node-installer-image` to reproducibility test

### DIFF
--- a/.github/workflows/e2e_runtime-reproducibility.yml
+++ b/.github/workflows/e2e_runtime-reproducibility.yml
@@ -73,6 +73,7 @@ jobs:
           seen = {}
           with open(os.getenv("GITHUB_OUTPUT")) as f:
               for line in f:
+                  print(line)
                   matrix, checksum = line.strip().split("=")
                   if not checksum in seen:
                       seen[checksum] = []

--- a/.github/workflows/e2e_runtime-reproducibility.yml
+++ b/.github/workflows/e2e_runtime-reproducibility.yml
@@ -16,11 +16,7 @@ jobs:
         # is reproducible across individual builds (as the --rebuild flag is used, causing Nix to rebuild the node-installer-image derivation)
         # and across independent builds on Ubuntu 20.04 and 22.04 (which also test the reproducibility of the transitive closure of our packages, as no shared
         # cache is present between the two machines)
-        build-target:
-          [
-            "microsoft.contrast-node-installer-image",
-            "kata.contrast-node-installer-image",
-          ]
+        build-target: ["microsoft.contrast-node-installer-image", "kata.contrast-node-installer-image"]
       fail-fast: false
     # Usually we would define the matrix outputs here, but as GitHub Actions don't seem to allow per-combination outputs,
     # we'll write the outputs without defining them here. See https://github.com/orgs/community/discussions/17245#discussioncomment-3814009.

--- a/.github/workflows/e2e_runtime-reproducibility.yml
+++ b/.github/workflows/e2e_runtime-reproducibility.yml
@@ -16,7 +16,11 @@ jobs:
         # is reproducible across individual builds (as the --rebuild flag is used, causing Nix to rebuild the node-installer-image derivation)
         # and across independent builds on Ubuntu 20.04 and 22.04 (which also test the reproducibility of the transitive closure of our packages, as no shared
         # cache is present between the two machines)
-        build-target: ["microsoft.contrast-node-installer-image"]
+        build-target:
+          [
+            "microsoft.contrast-node-installer-image",
+            "kata.contrast-node-installer-image",
+          ]
       fail-fast: false
     # Usually we would define the matrix outputs here, but as GitHub Actions don't seem to allow per-combination outputs,
     # we'll write the outputs without defining them here. See https://github.com/orgs/community/discussions/17245#discussioncomment-3814009.


### PR DESCRIPTION
Also test the `kata.contrast-node-installer-image` package for reproducibility. A successful run can be found [here](https://github.com/edgelesssys/contrast/actions/runs/11386897346).