### PR TITLE
packages/contrast: prefix version string with v

### DIFF
--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -197,7 +197,7 @@ buildGoModule rec {
   CGO_ENABLED = 0;
   ldflags = [
     "-s"
-    "-X github.com/edgelesssys/contrast/internal/constants.Version=${version}"
+    "-X github.com/edgelesssys/contrast/internal/constants.Version=v${version}"
     "-X github.com/edgelesssys/contrast/internal/constants.MicrosoftGenpolicyVersion=${microsoft.genpolicy.version}"
     "-X github.com/edgelesssys/contrast/internal/constants.KataGenpolicyVersion=${kata.genpolicy.version}"
   ];


### PR DESCRIPTION
Change back to version strings of the form "v1.2.3", instead of just "1.2.3". Only relevant for the version string processed by the CLI.