### PR TITLE
packages/nixos: pin nvidia driver

### DIFF
--- a/packages/nixos/gpu.nix
+++ b/packages/nixos/gpu.nix
@@ -15,7 +15,18 @@ in
   config = lib.mkIf cfg.enable {
     hardware.nvidia = {
       open = true;
-      package = lib.mkDefault config.boot.kernelPackages.nvidiaPackages.production;
+      package = lib.mkDefault (
+        config.boot.kernelPackages.nvidiaPackages.mkDriver {
+          # TODO: Investigate why the latest version breaks
+          # GPU containers.
+          version = "550.90.07";
+          sha256_64bit = "sha256-Uaz1edWpiE9XOh0/Ui5/r6XnhB4iqc7AtLvq4xsLlzM=";
+          sha256_aarch64 = "sha256-uJa3auRlMHr8WyacQL2MyyeebqfT7K6VU0qR7LGXFXI=";
+          openSha256 = "sha256-VLmh7eH0xhEu/AK+Osb9vtqAFni+lx84P/bo4ZgCqj8=";
+          settingsSha256 = "sha256-sX9dHEp9zH9t3RWp727lLCeJLo8QRAGhVb8iN6eX49g=";
+          persistencedSha256 = "sha256-qe8e1Nxla7F0U88AbnOZm6cHxo57pnLCqtjdvOvq9jk=";
+        }
+      );
       nvidiaPersistenced = true;
     };
     hardware.graphics = {


### PR DESCRIPTION
The `production` nvidia driver in nixpkgs got updated to a version that's incompatible with H100s. This pins the nvidia driver to the specific version needed for H100s by using the upstream `mkDriver` abstraction that builds a driver compatible with the used kernel from exact driver sources.