### PR TITLE
ci: only notify teams on first failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
           name: e2e_pod_logs-${{ inputs.platform }}-${{ inputs.test-name }}
           path: workspace/namespace-logs
       - name: Notify teams channel of failure
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() && github.event_name == 'schedule' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}

--- a/.github/workflows/e2e_runtime-reproducibility.yml
+++ b/.github/workflows/e2e_runtime-reproducibility.yml
@@ -51,7 +51,7 @@ jobs:
           name: ${{ matrix.build-target }}-${{ matrix.os }}-rebuild
           path: rebuild
       - name: Notify teams channel of failure
-        if: ${{ failure() && github.ref == 'main' }}
+        if: ${{ failure() && github.ref == 'main' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
@@ -85,7 +85,7 @@ jobs:
 
           print("All checksums were equal")
       - name: Notify teams channel of failure
-        if: ${{ failure() && github.ref == 'main' }}
+        if: ${{ failure() && github.ref == 'main' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}

--- a/.github/workflows/rpm_updates.yml
+++ b/.github/workflows/rpm_updates.yml
@@ -37,7 +37,7 @@ jobs:
           author: edgelessci <edgelessci@users.noreply.github.com>
           token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
       - name: Notify teams channel of failure
-        if: ${{ failure() && github.ref == 'main' }}
+        if: ${{ failure() && github.ref == 'main' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}


### PR DESCRIPTION
On all scheduled workflows, a notification is only sent if the initial run failed. All subsequent runs of the same workflow (manual re-runs) will not send a notification if they fail.