### PR TITLE
add peerpods support for the node-installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,4 @@ id_rsa*
 kube.conf
 out.env
 infra/**/peer-pods-config.yaml
-infra/**/kustomization.yaml
-infra/**/workload-identity.yaml
 uplosi.conf*

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ terraform.tfstate*
 id_rsa*
 kube.conf
 out.env
+infra/**/peer-pods-config.yaml
 infra/**/kustomization.yaml
 infra/**/workload-identity.yaml
 uplosi.conf*

--- a/cli/genpolicy/config.go
+++ b/cli/genpolicy/config.go
@@ -43,7 +43,7 @@ func NewConfig(platform platforms.Platform) *Config {
 			Settings: aksSettings,
 			Bin:      aksGenpolicyBin,
 		}
-	case platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.AKSPeerSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 		return &Config{
 			Rules:    kataRules,
 			Settings: kataSettings,

--- a/cli/main.go
+++ b/cli/main.go
@@ -105,7 +105,7 @@ func buildVersionString() (string, error) {
 		switch platform {
 		case platforms.AKSCloudHypervisorSNP:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.MicrosoftGenpolicyVersion)
-		case platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+		case platforms.AKSPeerSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.KataGenpolicyVersion)
 		}
 	}

--- a/infra/azure-peerpods/main.tf
+++ b/infra/azure-peerpods/main.tf
@@ -69,14 +69,6 @@ resource "azurerm_role_assignment" "ra_network_contributor" {
   principal_id         = azuread_service_principal.sp.object_id
 }
 
-resource "azuread_application_federated_identity_credential" "federated_credentials" {
-  display_name   = local.name
-  application_id = azuread_application.app.id
-  issuer         = azurerm_kubernetes_cluster.cluster.oidc_issuer_url
-  subject        = "system:serviceaccount:confidential-containers-system:cloud-api-adaptor"
-  audiences      = ["api://AzureADTokenExchange"]
-}
-
 resource "azuread_application_password" "cred" {
   application_id = azuread_application.app.id
 }
@@ -127,70 +119,6 @@ resource "local_file" "kubeconfig" {
   filename   = "./kube.conf"
   content    = azurerm_kubernetes_cluster.cluster.kube_config_raw
 }
-
-resource "local_file" "workload_identity" {
-  filename        = "./workload-identity.yaml"
-  file_permission = "0777"
-  content         = <<EOF
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: cloud-api-adaptor-daemonset
-  namespace: confidential-containers-system
-spec:
-  template:
-    metadata:
-      labels:
-        azure.workload.identity/use: "true"
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cloud-api-adaptor
-  namespace: confidential-containers-system
-  annotations:
-    azure.workload.identity/client-id: ${azuread_application.app.client_id}
-EOF
-}
-
-resource "local_file" "kustomization" {
-  filename        = "./kustomization.yaml"
-  file_permission = "0777"
-  content         = <<EOF
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-bases:
-- ../../yamls
-images:
-- name: cloud-api-adaptor
-  newName: quay.io/confidential-containers/cloud-api-adaptor
-  newTag: v0.9.0-amd64
-generatorOptions:
-  disableNameSuffixHash: true
-configMapGenerator:
-- name: peer-pods-cm
-  namespace: confidential-containers-system
-  literals:
-  - CLOUD_PROVIDER=azure
-  - AZURE_SUBSCRIPTION_ID=${data.azurerm_subscription.current.subscription_id}
-  - AZURE_REGION=${data.azurerm_resource_group.rg.location}
-  - AZURE_INSTANCE_SIZE=Standard_DC2as_v5
-  - AZURE_RESOURCE_GROUP=${data.azurerm_resource_group.rg.name}
-  - AZURE_SUBNET_ID=${one(azurerm_virtual_network.main.subnet.*.id)}
-  - AZURE_IMAGE_ID=${var.image_id}
-  - DISABLECVM=false
-secretGenerator:
-- name: peer-pods-secret
-  namespace: confidential-containers-system
-- name: ssh-key-secret
-  namespace: confidential-containers-system
-  files:
-  - id_rsa.pub
-patchesStrategicMerge:
-- workload-identity.yaml
-EOF
-}
-
 
 data "local_file" "id_rsa" {
   filename = "id_rsa.pub"

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -129,18 +129,87 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 			),
 	}
 
+	cloudAPIAdaptor := Container().
+		WithName("cloud-api-adaptor").
+		// TODO(freax13): Don't hard-code this
+		WithImage("quay.io/confidential-containers/cloud-api-adaptor:v0.9.0-amd64").
+		WithVolumeMounts(
+			VolumeMount().
+				WithName("ssh").
+				WithMountPath("/root/.ssh/").
+				WithReadOnly(true),
+			VolumeMount().
+				WithName("pods-dir").
+				WithMountPath("/run/peerpod"),
+			VolumeMount().
+				WithName("netns").
+				WithMountPath("/run/netns").
+				WithMountPropagation(corev1.MountPropagationHostToContainer),
+		).
+		WithArgs(
+			"/usr/local/bin/entrypoint.sh",
+		).
+		WithEnv(
+			NewEnvVar("optionals", fmt.Sprintf("-socket /run/peerpod/hypervisor-%s.sock ", runtimeHandler)),
+		).
+		WithEnvFrom(
+			applycorev1.EnvFromSource().
+				WithConfigMapRef(
+					applycorev1.ConfigMapEnvSource().
+						WithName("peer-pods-cm"),
+				),
+			applycorev1.EnvFromSource().
+				WithSecretRef(applycorev1.SecretEnvSource().
+					WithName("azure-client-secret"),
+				),
+		).
+		WithSecurityContext(
+			applycorev1.SecurityContext().
+				WithCapabilities(
+					applycorev1.Capabilities().
+						WithAdd(
+							corev1.Capability("NET_ADMIN"),
+							corev1.Capability("SYS_ADMIN"),
+						),
+				),
+		)
+	cloudAPIAdaptorVolumes := []*applycorev1.VolumeApplyConfiguration{
+		Volume().
+			WithName("pods-dir").
+			WithHostPath(HostPathVolumeSource().
+				WithPath("/run/peerpod").
+				WithType(corev1.HostPathDirectoryOrCreate),
+			),
+		Volume().
+			WithName("netns").
+			WithHostPath(HostPathVolumeSource().
+				WithPath("/run/netns").
+				WithType(corev1.HostPathDirectory),
+			),
+		Volume().
+			WithName("ssh").
+			WithSecret(applycorev1.SecretVolumeSource().
+				WithDefaultMode(0o600).
+				WithSecretName("ssh-key-secret"),
+			),
+	}
+
 	var nodeInstallerImageURL string
-	var snapshotter *applycorev1.ContainerApplyConfiguration
-	var snapshotterVolumes []*applycorev1.VolumeApplyConfiguration
+	var containers []*applycorev1.ContainerApplyConfiguration
+	var volumes []*applycorev1.VolumeApplyConfiguration
 	switch platform {
 	case platforms.AKSCloudHypervisorSNP:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-microsoft:latest"
-		snapshotter = tardevSnapshotter
-		snapshotterVolumes = tardevSnapshotterVolumes
+		containers = []*applycorev1.ContainerApplyConfiguration{tardevSnapshotter}
+		volumes = tardevSnapshotterVolumes
 	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
-		snapshotter = nydusSnapshotter
-		snapshotterVolumes = nydusSnapshotterVolumes
+		containers = []*applycorev1.ContainerApplyConfiguration{nydusSnapshotter}
+		volumes = nydusSnapshotterVolumes
+	case platforms.AKSPeerSNP:
+		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
+		containers = []*applycorev1.ContainerApplyConfiguration{nydusSnapshotter, cloudAPIAdaptor}
+		volumes = append(nydusSnapshotterVolumes, cloudAPIAdaptorVolumes...)
 	default:
 		return nil, fmt.Errorf("unsupported platform %q", platform)
 	}
@@ -172,10 +241,10 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 						WithCommand("/bin/node-installer", platform.String()),
 					).
 					WithContainers(
-						snapshotter,
+						containers...,
 					).
 					WithVolumes(append(
-						snapshotterVolumes,
+						volumes,
 						Volume().
 							WithName("host-mount").
 							WithHostPath(HostPathVolumeSource().

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -82,6 +82,11 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 			),
 	}
 
+	containerdPath := "/var/lib/rancher/k3s/agent/containerd"
+	if platform == platforms.AKSPeerSNP {
+		containerdPath = "/var/lib/containerd"
+	}
+
 	nydusSnapshotter := Container().
 		WithName("nydus-snapshotter").
 		WithImage("ghcr.io/edgelesssys/contrast/nydus-snapshotter:latest").
@@ -113,7 +118,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		Volume().
 			WithName("var-lib-containerd").
 			WithHostPath(HostPathVolumeSource().
-				WithPath("/var/lib/rancher/k3s/agent/containerd").
+				WithPath(containerdPath).
 				WithType(corev1.HostPathDirectory),
 			),
 		Volume().

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -18,6 +18,8 @@ const (
 	Unknown Platform = iota
 	// AKSCloudHypervisorSNP represents a deployment with Cloud-Hypervisor on SEV-SNP AKS.
 	AKSCloudHypervisorSNP
+	// AKSPeerSNP represents a deployment with peer-pods on SEV-SNP AKS.
+	AKSPeerSNP
 	// K3sQEMUTDX represents a deployment with QEMU on bare-metal TDX K3s.
 	K3sQEMUTDX
 	// K3sQEMUSNP represents a deployment with QEMU on bare-metal SNP K3s.
@@ -28,7 +30,7 @@ const (
 
 // All returns a list of all available platforms.
 func All() []Platform {
-	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX}
+	return []Platform{AKSCloudHypervisorSNP, AKSPeerSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX}
 }
 
 // AllStrings returns a list of all available platforms as strings.
@@ -45,6 +47,8 @@ func (p Platform) String() string {
 	switch p {
 	case AKSCloudHypervisorSNP:
 		return "AKS-CLH-SNP"
+	case AKSPeerSNP:
+		return "AKS-PEER-SNP"
 	case K3sQEMUTDX:
 		return "K3s-QEMU-TDX"
 	case K3sQEMUSNP:
@@ -61,6 +65,8 @@ func FromString(s string) (Platform, error) {
 	switch strings.ToLower(s) {
 	case "aks-clh-snp":
 		return AKSCloudHypervisorSNP, nil
+	case "aks-peer-snp":
+		return AKSPeerSNP, nil
 	case "k3s-qemu-tdx":
 		return K3sQEMUTDX, nil
 	case "k3s-qemu-snp":

--- a/justfile
+++ b/justfile
@@ -47,15 +47,9 @@ node-installer platform=default_platform:
             just push "tardev-snapshotter"
             just push "node-installer-microsoft"
         ;;
-        "K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "AKS-PEER-SNP"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             just push "nydus-snapshotter"
             just push "node-installer-kata"
-        ;;
-        "AKS-PEER-SNP")
-            nix run -L .#scripts.deploy-caa -- \
-                --kustomization=./infra/azure-peerpods/kustomization.yaml \
-                --workload-identity=./infra/azure-peerpods/workload-identity.yaml \
-                --pub-key=./infra/azure-peerpods/id_rsa.pub
         ;;
         *)
             echo "Unsupported platform: {{ platform }}"
@@ -73,7 +67,7 @@ e2e target=default_deploy_target platform=default_platform: soft-clean coordinat
             --skip-undeploy=true
 
 # Generate policies, apply Kubernetes manifests.
-deploy target=default_deploy_target cli=default_cli platform=default_platform: (runtime target platform) (apply "runtime") (populate target platform) (generate cli platform) (apply target)
+deploy target=default_deploy_target cli=default_cli platform=default_platform: (runtime target platform) (apply-runtime target platform) (populate target platform) (generate cli platform) (apply target)
 
 # Populate the workspace with a runtime class deployment
 runtime target=default_deploy_target platform=default_platform:
@@ -127,15 +121,20 @@ generate cli=default_cli platform=default_platform:
         ;;
     esac
 
+# Apply the runtime.
+apply-runtime target=default_deploy_target platform=default_platform:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    kubectl apply -f ./{{ workspace_dir }}/runtime
+    if [[ {{ platform }} == "AKS-PEER-SNP" ]]; then
+        kubectl apply -f ./infra/azure-peerpods/peer-pods-config.yaml --namespace {{ target }}${namespace_suffix-}
+    fi
+
 # Apply Kubernetes manifests from /deployment
 apply target=default_deploy_target:
     #!/usr/bin/env bash
     set -euo pipefail
     case {{ target }} in
-        "runtime")
-            kubectl apply -f ./{{ workspace_dir }}/runtime
-            exit 0
-        ;;
         "openssl" | "emojivoto" | "volume-stateful-set")
             :
         ;;

--- a/nodeinstaller/internal/constants/configuration-peerpod.toml
+++ b/nodeinstaller/internal/constants/configuration-peerpod.toml
@@ -1,0 +1,23 @@
+# upstream source: https://github.com/kata-containers/kata-containers/blob/51bc71b8d96874cf4a555e1084ee07e948bff957/src/runtime/config/configuration-remote.toml.in
+[hypervisor.remote]
+remote_hypervisor_socket = "/run/peerpod/hypervisor.sock"
+remote_hypervisor_timeout = 600
+enable_annotations = ["machine_type", "default_memory", "default_vcpus"]
+firmware = ""
+default_bridges = 1
+disable_selinux = false
+disable_guest_selinux = true
+
+[agent.kata]
+
+[runtime]
+internetworking_model = "none"
+disable_guest_seccomp = true
+disable_new_netns = true
+sandbox_cgroup_only = false
+static_sandbox_resource_mgmt = true
+vfio_mode = "guest-kernel"
+disable_guest_empty_dir = false
+experimental = []
+create_container_timeout = 60
+dan_conf = "/run/edgeless/kata-containers/dans"

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/nodeinstaller/internal/config"
 	"github.com/pelletier/go-toml/v2"
@@ -19,6 +20,11 @@ var (
 	//
 	//go:embed configuration-clh-snp.toml
 	kataCLHSNPBaseConfig string
+
+	// kataPeerpodBaseConfig is the configuration file for the Kata runtime with peerpod.
+	//
+	//go:embed configuration-peerpod.toml
+	kataPeerpodBaseConfig string
 
 	// kataBareMetalQEMUTDXBaseConfig is the configuration file for the Kata runtime on bare-metal TDX
 	// with QEMU.
@@ -95,6 +101,15 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		// Replace the kernel params entirely (and don't append) since that's
 		// also what we do when calculating the launch measurement.
 		config.Hypervisor["qemu"]["kernel_params"] = kernelParams
+	case platforms.AKSPeerSNP:
+		if err := toml.Unmarshal([]byte(kataPeerpodBaseConfig), &config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
+		}
+		runtimeHandlerName, err := manifest.RuntimeHandler(platform)
+		if err != nil {
+			return nil, fmt.Errorf("getting default runtime handler: %w", err)
+		}
+		config.Hypervisor["remote"]["remote_hypervisor_socket"] = filepath.Join("/run", "peerpod", fmt.Sprintf("hypervisor-%s.sock", runtimeHandlerName))
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", platform)
 	}
@@ -137,6 +152,10 @@ func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platf
 	case platforms.K3sQEMUSNP:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-snp.toml"),
+		}
+	case platforms.AKSPeerSNP:
+		cfg.Options = map[string]any{
+			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-peer-snp.toml"),
 		}
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", platform)

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -107,6 +107,9 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	case platforms.AKSCloudHypervisorSNP:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-clh-snp.toml")
 		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
+	case platforms.AKSPeerSNP:
+		kataConfigPath = filepath.Join(kataConfigPath, "configuration-peer-snp.toml")
+		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
 	case platforms.K3sQEMUSNP:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-qemu-snp.toml")
 		containerdConfigPath = filepath.Join(hostMount, "var", "lib", "rancher", "k3s", "agent", "etc", "containerd", "config.toml.tmpl")
@@ -139,7 +142,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	}
 
 	switch platform {
-	case platforms.AKSCloudHypervisorSNP:
+	case platforms.AKSCloudHypervisorSNP, platforms.AKSPeerSNP:
 		return restartHostContainerd(containerdConfigPath, "containerd")
 	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP:
 		if hostServiceExists("k3s") {
@@ -206,7 +209,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	case platforms.AKSCloudHypervisorSNP:
 		snapshotterName = fmt.Sprintf("tardev-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/tardev-snapshotter-%s.sock", runtimeHandler)
-	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
+	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX, platforms.AKSPeerSNP:
 		snapshotterName = fmt.Sprintf("nydus-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/containerd-nydus-grpc-%s.sock", runtimeHandler)
 

--- a/nodeinstaller/node-installer_test.go
+++ b/nodeinstaller/node-installer_test.go
@@ -18,6 +18,8 @@ import (
 var (
 	//go:embed testdata/expected-aks-clh-snp.toml
 	expectedConfAKSCLHSNP []byte
+	//go:embed testdata/expected-aks-peer-snp.toml
+	expectedConfAKSPeerSNP []byte
 	//go:embed testdata/expected-bare-metal-qemu-tdx.toml
 	expectedConfBareMetalQEMUTDX []byte
 	//go:embed testdata/expected-bare-metal-qemu-snp.toml
@@ -33,6 +35,10 @@ func TestPatchContainerdConfig(t *testing.T) {
 		"AKSCLHSNP": {
 			platform: platforms.AKSCloudHypervisorSNP,
 			expected: expectedConfAKSCLHSNP,
+		},
+		"AKSPeerSNP": {
+			platform: platforms.AKSPeerSNP,
+			expected: expectedConfAKSPeerSNP,
 		},
 		"BareMetalQEMUTDX": {
 			platform: platforms.K3sQEMUTDX,

--- a/nodeinstaller/testdata/expected-aks-peer-snp.toml
+++ b/nodeinstaller/testdata/expected-aks-peer-snp.toml
@@ -1,0 +1,81 @@
+version = 2
+
+[debug]
+level = 'debug'
+
+[metrics]
+address = '0.0.0.0:10257'
+
+[plugins]
+[plugins.'io.containerd.grpc.v1.cri']
+sandbox_image = 'mcr.microsoft.com/oss/kubernetes/pause:3.6'
+
+[plugins.'io.containerd.grpc.v1.cri'.cni]
+bin_dir = '/opt/cni/bin'
+conf_dir = '/etc/cni/net.d'
+conf_template = '/etc/containerd/kubenet_template.conf'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd]
+default_runtime_name = 'runc'
+disable_snapshot_annotations = false
+discard_unpacked_layers = false
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes]
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata]
+runtime_type = 'io.containerd.kata.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata-cc]
+pod_annotations = ['io.katacontainers.*']
+privileged_without_host_devices = true
+runtime_type = 'io.containerd.kata-cc.v2'
+snapshotter = 'tardev'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata-cc.options]
+ConfigPath = '/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.katacli]
+runtime_type = 'io.containerd.runc.v1'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.katacli.options]
+BinaryName = '/usr/bin/kata-runtime'
+CriuPath = ''
+IoGid = 0
+IoUid = 0
+NoNewKeyring = false
+NoPivotRoot = false
+Root = ''
+ShimCgroup = ''
+SystemdCgroup = false
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime]
+runtime_type = 'io.containerd.contrast-cc.v2'
+runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
+pod_annotations = ['io.katacontainers.*']
+privileged_without_host_devices = true
+snapshotter = 'nydus-my-runtime'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
+ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-peer-snp.toml'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc]
+runtime_type = 'io.containerd.runc.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc.options]
+BinaryName = '/usr/bin/runc'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.untrusted]
+runtime_type = 'io.containerd.runc.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.untrusted.options]
+BinaryName = '/usr/bin/runc'
+
+[plugins.'io.containerd.grpc.v1.cri'.registry]
+config_path = '/etc/containerd/certs.d'
+
+[plugins.'io.containerd.grpc.v1.cri'.registry.headers]
+X-Meta-Source-Client = ['azure/aks']
+
+[proxy_plugins]
+[proxy_plugins.nydus-my-runtime]
+type = 'snapshot'
+address = '/run/containerd/containerd-nydus-grpc-my-runtime.sock'

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -52,6 +52,7 @@ let
       k3s-qemu-tdx-handler = runtimeHandler "k3s-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       rke2-qemu-tdx-handler = runtimeHandler "rke2-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       k3s-qemu-snp-handler = runtimeHandler "k3s-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
+      aks-peer-snp-handler = runtimeHandler "aks-peer-snp" kata.contrast-node-installer-image.runtimeHash;
 
       aksRefVals = {
         snp = [
@@ -128,6 +129,7 @@ let
         "${k3s-qemu-tdx-handler}" = tdxRefVals;
         "${rke2-qemu-tdx-handler}" = tdxRefVals;
         "${k3s-qemu-snp-handler}" = snpRefVals;
+        "${aks-peer-snp-handler}" = { };
       }
     );
 

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -451,46 +451,6 @@
     '';
   };
 
-  deploy-caa = writeShellApplication {
-    name = "deploy-caa";
-    runtimeInputs = with pkgs; [ kubectl ];
-    text = ''
-      set -euo pipefail
-
-      for i in "$@"; do
-        case $i in
-        --kustomization=*)
-          kustomizationFile="''${i#*=}"
-          shift
-          ;;
-        --workload-identity=*)
-          workloadIdentityFile="''${i#*=}"
-          shift
-          ;;
-        --pub-key=*)
-          pubKeyFile="''${i#*=}"
-          shift
-          ;;
-        *)
-          echo "Unknown option $i"
-          exit 1
-          ;;
-        esac
-      done
-
-      tmpdir=$(mktemp -d)
-      cp -r ${pkgs.cloud-api-adaptor.src}/src/cloud-api-adaptor/install/* "$tmpdir"
-      chmod -R +w "$tmpdir"
-      cp "$kustomizationFile" "$tmpdir/overlays/azure/kustomization.yaml"
-      cp "$workloadIdentityFile" "$tmpdir/overlays/azure/workload-identity.yaml"
-      cp "$pubKeyFile" "$tmpdir/overlays/azure/id_rsa.pub"
-
-      kubectl apply -k "github.com/confidential-containers/operator/config/release?ref=v${pkgs.cloud-api-adaptor.version}"
-      kubectl apply -k "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods?ref=v${pkgs.cloud-api-adaptor.version}"
-      kubectl apply -k "$tmpdir/overlays/azure"
-    '';
-  };
-
   cleanup-bare-metal = writeShellApplication {
     name = "cleanup-bare-metal";
     runtimeInputs = with pkgs; [


### PR DESCRIPTION
This PR adds support for peerpods on SEV-SNP AKS to the node-installer and adjusts our justfile to use the node-installer instead of the coco-operator-based runtime steps.