### PR TITLE
just: use default platform for get-credentials

### DIFF
--- a/.github/workflows/asciinema.yml
+++ b/.github/workflows/asciinema.yml
@@ -36,6 +36,7 @@ jobs:
           cat <<EOF > justfile.env
           container_registry=${{ env.container_registry }}
           azure_resource_group=${{ env.azure_resource_group }}
+          default_platform="AKS-CLH-SNP"
           EOF
       - name: Get credentials for CI cluster
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,7 @@ jobs:
           cat <<EOF > justfile.env
           container_registry=${{ env.container_registry }}
           azure_resource_group=${{ env.azure_resource_group }}
+          default_platform=${{ inputs.platform }}
           EOF
       - if: ${{ !inputs.self-hosted }}
         name: Get credentials for CI cluster

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,7 @@ jobs:
           cat <<EOF > justfile.env
           container_registry=${{ env.container_registry }}
           azure_resource_group=${{ env.azure_resource_group }}
+          default_platform=${{ matrix.platform.name }}
           EOF
       - name: Get credentials for CI cluster
         if: ${{ !matrix.platform.self-hosted }}


### PR DESCRIPTION
Instead of having multiple commands like `get-credentials-tdxbm` or `get-credentials-snpbm`, the platform can simply be read from the `justfile.env` file.