### PR TITLE
erofs: improve reproducibility of podvm images

### DIFF
--- a/overlays/erofs-utils-reproducibility.patch
+++ b/overlays/erofs-utils-reproducibility.patch
@@ -1,0 +1,101 @@
+diff --git a/lib/inode.c b/lib/inode.c
+index b9dbbd6..385d5b2 100644
+--- a/lib/inode.c
++++ b/lib/inode.c
+@@ -1413,69 +1413,63 @@ static void erofs_mkfs_flushjobs(struct erofs_sb_info *sbi)
+ static int erofs_mkfs_handle_directory(struct erofs_inode *dir)
+ {
+ 	struct erofs_sb_info *sbi = dir->sbi;
+-	DIR *_dir;
+ 	struct dirent *dp;
++	struct dirent **entries;
++	int i;
+ 	struct erofs_dentry *d;
+ 	unsigned int nr_subdirs, i_nlink;
+ 	int ret;
+
+-	_dir = opendir(dir->i_srcpath);
+-	if (!_dir) {
+-		erofs_err("failed to opendir at %s: %s",
++	i = scandir(dir->i_srcpath, &entries, NULL, alphasort);
++	if (i == -1) {
++		erofs_err("failed to scandir at %s: %s",
+ 			  dir->i_srcpath, erofs_strerror(-errno));
+ 		return -errno;
+ 	}
+
+ 	nr_subdirs = 0;
+ 	i_nlink = 0;
+-	while (1) {
++	while (i--) {
+ 		char buf[PATH_MAX];
+ 		struct erofs_inode *inode;
+
+-		/*
+-		 * set errno to 0 before calling readdir() in order to
+-		 * distinguish end of stream and from an error.
+-		 */
+-		errno = 0;
+-		dp = readdir(_dir);
+-		if (!dp) {
+-			if (!errno)
+-				break;
+-			ret = -errno;
+-			goto err_closedir;
+-		}
++		dp = entries[i];
+
+ 		if (is_dot_dotdot(dp->d_name)) {
+ 			++i_nlink;
++			free(dp);
+ 			continue;
+ 		}
+
+ 		/* skip if it's a exclude file */
+-		if (erofs_is_exclude_path(dir->i_srcpath, dp->d_name))
++		if (erofs_is_exclude_path(dir->i_srcpath, dp->d_name)) {
++			free(dp);
+ 			continue;
++		}
+
+ 		d = erofs_d_alloc(dir, dp->d_name);
+ 		if (IS_ERR(d)) {
+ 			ret = PTR_ERR(d);
+-			goto err_closedir;
++			goto err_free;
+ 		}
+
+ 		ret = snprintf(buf, PATH_MAX, "%s/%s", dir->i_srcpath, d->name);
+ 		if (ret < 0 || ret >= PATH_MAX)
+-			goto err_closedir;
++			goto err_free;
+
+ 		inode = erofs_iget_from_srcpath(sbi, buf);
+ 		if (IS_ERR(inode)) {
+ 			ret = PTR_ERR(inode);
+-			goto err_closedir;
++			goto err_free;
+ 		}
+ 		d->inode = inode;
+ 		d->type = erofs_mode_to_ftype(inode->i_mode);
+ 		i_nlink += S_ISDIR(inode->i_mode);
+ 		erofs_dbg("file %s added (type %u)", buf, d->type);
+ 		nr_subdirs++;
++		free(dp);
+ 	}
+-	closedir(_dir);
++	free(entries);
+
+ 	ret = erofs_init_empty_dir(dir);
+ 	if (ret)
+@@ -1497,8 +1491,9 @@ static int erofs_mkfs_handle_directory(struct erofs_inode *dir)
+
+ 	return erofs_mkfs_go(sbi, EROFS_MKFS_JOB_DIR, &dir, sizeof(dir));
+
+-err_closedir:
+-	closedir(_dir);
++err_free:
++	free(dp);
++	free(entries);
+ 	return ret;
+ }

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -82,4 +82,10 @@ in
       hash = "sha256-MsZ4Bl8sW1dZUB9cYPsaLtc8P8RRx4hafSbNB4vXqi4=";
     };
   });
+
+  erofs-utils = prev.erofs-utils.overrideAttrs (prev: {
+    patches = final.lib.optionals (prev ? patches) prev.patches ++ [
+      ./erofs-utils-reproducibility.patch
+    ];
+  });
 }


### PR DESCRIPTION
Please verify reproducibility on your local system with 
```
nix build .#image-podvm --builders "" &&
nix build .#image-podvm --builders "" --rebuild && 
[[ $(sha256sum result/image-podvm-gpu_1-rc1.raw | cut -d' ' -f1) == f1f9c021b2aae46771b138b603e269032e9fc6369a7ce17391cc54899e359d0f ]]
```

If you face reproducibility issues, try to optimise your nix store, as the issue might be related to hard linking. There is a (soft) improvement on that already in unstable (but we are currently a bit behind), but it is also a topic of future work.

```
nix store optimise
```
