### PR TITLE
just: ensure peerpod vms are cleaned up on undeploy

### DIFF
--- a/justfile
+++ b/justfile
@@ -142,14 +142,6 @@ apply-runtime target=default_deploy_target platform=default_platform:
 apply target=default_deploy_target:
     #!/usr/bin/env bash
     set -euo pipefail
-    case {{ target }} in
-        "openssl" | "emojivoto" | "volume-stateful-set")
-            :
-        ;;
-        *)
-            kubectl apply -f ./{{ workspace_dir }}/deployment/ns.yml
-        ;;
-    esac
     kubectl apply -f ./{{ workspace_dir }}/deployment
 
 # Delete Kubernetes manifests.
@@ -175,15 +167,7 @@ undeploy platform=default_platform:
             --cascade=foreground \
             --ignore-not-found
     fi
-    if [[ -f ./{{ workspace_dir }}/deployment/ns.yml ]]; then
-        kubectl delete \
-            -f ./{{ workspace_dir }}/deployment \
-            --ignore-not-found \
-            --grace-period=30 \
-            --timeout=10m
-    else
-        kubectl delete namespace $ns
-    fi
+    kubectl delete namespace $ns
 
 upload-image:
     # Ensure that the resource group exists.

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # Undeploy, rebuild, deploy.
-default target=default_deploy_target platform=default_platform cli=default_cli: soft-clean coordinator initializer openssl cryptsetup port-forwarder service-mesh-proxy (node-installer platform) (deploy target cli platform) set verify (wait-for-workload target)
+default target=default_deploy_target platform=default_platform cli=default_cli: (soft-clean platform) coordinator initializer openssl cryptsetup port-forwarder service-mesh-proxy (node-installer platform) (deploy target cli platform) set verify (wait-for-workload target)
 
 # Build and push a container image.
 push target:
@@ -62,7 +62,7 @@ node-installer platform=default_platform:
         ;;
     esac
 
-e2e target=default_deploy_target platform=default_platform: soft-clean coordinator initializer cryptsetup openssl port-forwarder service-mesh-proxy (node-installer platform)
+e2e target=default_deploy_target platform=default_platform: (soft-clean platform) coordinator initializer cryptsetup openssl port-forwarder service-mesh-proxy (node-installer platform)
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "{{ target }}" == "aks-runtime" ]]; then
@@ -153,7 +153,7 @@ apply target=default_deploy_target:
     kubectl apply -f ./{{ workspace_dir }}/deployment
 
 # Delete Kubernetes manifests.
-undeploy:
+undeploy platform=default_platform:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ ! -d ./{{ workspace_dir }} ]]; then
@@ -168,6 +168,12 @@ undeploy:
     if ! kubectl get ns $ns 2> /dev/null; then
         echo "Namespace $ns does not exist, nothing to undeploy."
         exit 0
+    fi
+    if [[ {{ platform }} == "AKS-PEER-SNP" ]]; then
+        kubectl delete \
+            -f ./{{ workspace_dir }}/deployment \
+            --cascade=foreground \
+            --ignore-not-found
     fi
     if [[ -f ./{{ workspace_dir }}/deployment/ns.yml ]]; then
         kubectl delete \
@@ -359,18 +365,18 @@ fmt:
 lint:
     nix run -L .#scripts.golangci-lint -- run
 
-demodir version="latest": undeploy
+demodir version="latest" platform=default_platform: (undeploy platform)
     #!/usr/bin/env bash
     set -euo pipefail
     v="$(echo {{ version }} | sed 's/\./-/g')"
     nix develop -u DIRENV_DIR -u DIRENV_FILE -u DIRENV_DIFF .#demo-$v
 
 # Remove deployment specific files.
-soft-clean: undeploy
+soft-clean platform=default_platform: (undeploy platform)
     rm -rf ./{{ workspace_dir }}
 
 # Cleanup all auxiliary files, caches etc.
-clean: soft-clean
+clean platform=default_platform: (soft-clean platform)
     rm -rf ./{{ workspace_dir }}.cache
     rm -rf ./layers_cache
     rm -f ./layers-cache.json


### PR DESCRIPTION
This ensures the `cloud-api-adaptor` cleanly deletes the created VMs by waiting until the deletion of all other resources has been completed before deleting the node installer and namespace.