### PR TITLE
ci: check for unclean patches

### DIFF
--- a/.github/workflows/check_patches.yml
+++ b/.github/workflows/check_patches.yml
@@ -1,0 +1,40 @@
+name: check patches
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/check_patches.yml
+      - packages/by-name/kata/kata-runtime/package.nix
+      - packages/by-name/kata/kata-runtime/0*.patch
+
+jobs:
+  check-patches:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: contrast
+      - uses: ./contrast/.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - id: kataversion
+        working-directory: contrast
+        run: |
+          echo "v=$(nix eval --raw .#kata.kata-runtime.version)" >> "$GITHUB_OUTPUT"
+      - name: Check out Kata
+        run: |
+          git clone --depth 1 -b "${{ steps.kataversion.outputs.v }}" https://github.com/kata-containers/kata-containers.git kata
+      - name: Apply patches
+        working-directory: kata
+        run: |
+          git config --global user.email "actionsbot@example.invalid"
+          git config --global user.name "Actions Bot"
+          git am --no-3way ../contrast/packages/by-name/kata/kata-runtime/0*.patch
+          git format-patch -N --no-signature --zero-commit --full-index -o ../contrast/packages/by-name/kata/kata-runtime/ "${{ steps.kataversion.outputs.v }}"
+      - name: Check for diff
+        working-directory: contrast
+        run: |
+          git diff --exit-code

--- a/dev-docs/patches.md
+++ b/dev-docs/patches.md
@@ -70,10 +70,14 @@ git checkout $rev
 Apply the existing patch set:
 
 ```sh
-git am --committer-date-is-author-date -3 $pkgDir/*.patch
+git am --no-3way $pkgDir/0*.patch
 ```
 
 This will apply and commit each patch on top of `rev`.
+Some directories contain patches that aren't meant to be applied to the source, those are excluded by the `0` prefix.
+The `--no-3way` flag will abort application of unclean patches.
+If the existing patches can't be applied without a three-way merge, you can pass `-3` instead.
+This situation should then be resolved in a separate commit.
 
 You can then place new commits on top or modify existing commits. Remember to keep the git history clean.
 
@@ -82,8 +86,13 @@ When updating a package, you might need to rebase the current patch set.
 When done, recreate the patch set:
 
 ```sh
-git format-patch -N --no-signature -o $pkgDir $rev
+git format-patch -N --no-signature --zero-commit --full-index -o $pkgDir $rev
 ```
+
+Don't forget to `git add` patches you just added and to `git rm` patches you removed or renamed.
+
+The `static.yml` workflow ensures that patches can be reapplied cleanly.
+If this workflow fails, applying the rendered diff should be sufficient to appease it.
 
 # Patch documentation conventions
 

--- a/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
+++ b/packages/by-name/kata/kata-runtime/0001-govmm-Directly-pass-the-firwmare-using-bios-with-SNP.patch
@@ -1,4 +1,4 @@
-From 099fd9159c03561ed738dacb370d18183f8601aa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Fri, 5 Jul 2024 08:43:13 +0000
 Subject: [PATCH] govmm: Directly pass the firwmare using -bios with SNP
@@ -9,7 +9,7 @@ Subject: [PATCH] govmm: Directly pass the firwmare using -bios with SNP
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/src/runtime/pkg/govmm/qemu/qemu.go b/src/runtime/pkg/govmm/qemu/qemu.go
-index e1070b731..b3b3fb4bd 100644
+index e1070b731920f00625dc58a9ce3e6b985af3a8ba..b3b3fb4bdbe99e6fc1a89db49be984b92a19551c 100644
 --- a/src/runtime/pkg/govmm/qemu/qemu.go
 +++ b/src/runtime/pkg/govmm/qemu/qemu.go
 @@ -395,9 +395,7 @@ func (object Object) QemuParams(config *Config) []string {

--- a/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
+++ b/packages/by-name/kata/kata-runtime/0002-emulate-CPU-model-that-most-closely-matches-the-host.patch
@@ -1,4 +1,4 @@
-From b73c887c4b00d58b1a9bf403c5b2d05b02574731 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 8 Jul 2024 07:35:54 +0000
 Subject: [PATCH] emulate CPU model that most closely matches the host
@@ -12,7 +12,7 @@ attestation.
  1 file changed, 12 insertions(+), 1 deletion(-)
 
 diff --git a/src/runtime/virtcontainers/qemu_amd64.go b/src/runtime/virtcontainers/qemu_amd64.go
-index 1d1be1711..6ebee26ce 100644
+index 1d1be17118f397445941c50a5276fb8aec2411e3..6ebee26ce34b5137f88a78219340b1f0867bc7a8 100644
 --- a/src/runtime/virtcontainers/qemu_amd64.go
 +++ b/src/runtime/virtcontainers/qemu_amd64.go
 @@ -191,7 +191,18 @@ func (q *qemuAmd64) cpuModel() string {

--- a/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
+++ b/packages/by-name/kata/kata-runtime/0003-runtime-agent-verify-the-agent-policy-hash.patch
@@ -1,4 +1,4 @@
-From d3bc2eb74a14272afb10d20c63e4d938538acbfe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 8 Jul 2024 07:51:20 +0000
 Subject: [PATCH] runtime: agent: verify the agent policy hash
@@ -42,7 +42,7 @@ Signed-off-by: Tom Dohrmann <erbse.13@gmx.de>
  create mode 100644 src/agent/src/tdx.rs
 
 diff --git a/src/agent/Cargo.lock b/src/agent/Cargo.lock
-index f55144570..8cf40f7ec 100644
+index f5514457031ed7f0b4d1c5c6bee7ec5ec8b9ad72..8cf40f7ec7d12b6e206d49f4b6adff05d347262d 100644
 --- a/src/agent/Cargo.lock
 +++ b/src/agent/Cargo.lock
 @@ -542,6 +542,12 @@ version = "0.6.3"
@@ -238,7 +238,7 @@ index f55144570..8cf40f7ec 100644
  name = "vsock"
  version = "0.2.6"
 diff --git a/src/agent/Cargo.toml b/src/agent/Cargo.toml
-index a8ed5d081..d5b3db965 100644
+index a8ed5d081cf87b19f4ce5c5bdb9cc4efa694a6e3..d5b3db965fe75cbccc182825a4115bdc57a9705b 100644
 --- a/src/agent/Cargo.toml
 +++ b/src/agent/Cargo.toml
 @@ -85,6 +85,11 @@ regorus = { version = "0.1.4", default-features = false, features = [
@@ -263,7 +263,7 @@ index a8ed5d081..d5b3db965 100644
  
  [[bin]]
 diff --git a/src/agent/src/main.rs b/src/agent/src/main.rs
-index 8a057bb36..22d858c10 100644
+index 8a057bb367537cfac988f20fda86b2e23a681682..22d858c10468478dacb7e7e9b9133a756abc1ea8 100644
 --- a/src/agent/src/main.rs
 +++ b/src/agent/src/main.rs
 @@ -85,6 +85,10 @@ mod tracer;
@@ -278,7 +278,7 @@ index 8a057bb36..22d858c10 100644
  cfg_if! {
      if #[cfg(target_arch = "s390x")] {
 diff --git a/src/agent/src/policy.rs b/src/agent/src/policy.rs
-index ccac317d0..2f1da9ecd 100644
+index ccac317d0ff707c1fd1242a144886d5e8c000a90..2f1da9ecd0d0ee1be06218d5bc9e58cd93defa8c 100644
 --- a/src/agent/src/policy.rs
 +++ b/src/agent/src/policy.rs
 @@ -3,11 +3,14 @@
@@ -351,7 +351,7 @@ index ccac317d0..2f1da9ecd 100644
 +}
 diff --git a/src/agent/src/sev.rs b/src/agent/src/sev.rs
 new file mode 100644
-index 000000000..3257eabaf
+index 0000000000000000000000000000000000000000..3257eabafcc971df7219d71186383616ee19a672
 --- /dev/null
 +++ b/src/agent/src/sev.rs
 @@ -0,0 +1,19 @@
@@ -376,7 +376,7 @@ index 000000000..3257eabaf
 +}
 diff --git a/src/agent/src/tdx.rs b/src/agent/src/tdx.rs
 new file mode 100644
-index 000000000..1531e72a8
+index 0000000000000000000000000000000000000000..1531e72a8b8db6e357d02ecdd431a9b88af3b30d
 --- /dev/null
 +++ b/src/agent/src/tdx.rs
 @@ -0,0 +1,194 @@
@@ -575,7 +575,7 @@ index 000000000..1531e72a8
 +    Ok(mrconfigid)
 +}
 diff --git a/src/runtime/pkg/govmm/qemu/qemu.go b/src/runtime/pkg/govmm/qemu/qemu.go
-index b3b3fb4bd..5070ecd1e 100644
+index b3b3fb4bdbe99e6fc1a89db49be984b92a19551c..5070ecd1e78ca04383637e662b3c8e4f8ec0ae5e 100644
 --- a/src/runtime/pkg/govmm/qemu/qemu.go
 +++ b/src/runtime/pkg/govmm/qemu/qemu.go
 @@ -320,6 +320,11 @@ type Object struct {
@@ -631,7 +631,7 @@ index b3b3fb4bd..5070ecd1e 100644
  
  	return tdxObject.String()
 diff --git a/src/runtime/virtcontainers/hypervisor.go b/src/runtime/virtcontainers/hypervisor.go
-index 5eb922980..0e5205cc9 100644
+index 5eb922980be33de9afc25ffaae65dd222f976c52..0e5205cc99da99e929365cbfe8637465872addb9 100644
 --- a/src/runtime/virtcontainers/hypervisor.go
 +++ b/src/runtime/virtcontainers/hypervisor.go
 @@ -545,7 +545,7 @@ type HypervisorConfig struct {
@@ -666,7 +666,7 @@ index 5eb922980..0e5205cc9 100644
  	tdxProtection
  
 diff --git a/src/runtime/virtcontainers/qemu.go b/src/runtime/virtcontainers/qemu.go
-index ba86c3d63..2c6311c06 100644
+index ba86c3d63a6c5158b3d0f7e6ae6af865dddb9d8d..2c6311c067935a2c5da0a1018420bab684b670e8 100644
 --- a/src/runtime/virtcontainers/qemu.go
 +++ b/src/runtime/virtcontainers/qemu.go
 @@ -681,7 +681,7 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
@@ -679,7 +679,7 @@ index ba86c3d63..2c6311c06 100644
  		return err
  	}
 diff --git a/src/runtime/virtcontainers/qemu_amd64.go b/src/runtime/virtcontainers/qemu_amd64.go
-index 6ebee26ce..0a0451cba 100644
+index 6ebee26ce34b5137f88a78219340b1f0867bc7a8..0a0451cba1565358225875cf6506381f5d221aec 100644
 --- a/src/runtime/virtcontainers/qemu_amd64.go
 +++ b/src/runtime/virtcontainers/qemu_amd64.go
 @@ -9,6 +9,8 @@ package virtcontainers
@@ -754,7 +754,7 @@ index 6ebee26ce..0a0451cba 100644
 +	return base64.StdEncoding.EncodeToString(mrConfigId)
 +}
 diff --git a/src/runtime/virtcontainers/qemu_amd64_test.go b/src/runtime/virtcontainers/qemu_amd64_test.go
-index 1425cb38c..f0a9c691a 100644
+index 1425cb38cfd79ab06b04f1dafbab9b7440901688..f0a9c691a6ffc6356f8f9a335e72b81239a2ef2c 100644
 --- a/src/runtime/virtcontainers/qemu_amd64_test.go
 +++ b/src/runtime/virtcontainers/qemu_amd64_test.go
 @@ -9,6 +9,10 @@ package virtcontainers
@@ -943,7 +943,7 @@ index 1425cb38c..f0a9c691a 100644
 +	assert.Equal(expectedOut, devices)
  }
 diff --git a/src/runtime/virtcontainers/qemu_arch_base.go b/src/runtime/virtcontainers/qemu_arch_base.go
-index fd92be772..662466f58 100644
+index fd92be772446f30058d4424f7a330a0bc23ff433..662466f5846c22b4c7fa6b62b1a272258e2e4143 100644
 --- a/src/runtime/virtcontainers/qemu_arch_base.go
 +++ b/src/runtime/virtcontainers/qemu_arch_base.go
 @@ -162,7 +162,7 @@ type qemuArch interface {
@@ -965,7 +965,7 @@ index fd92be772..662466f58 100644
  	return devices, firmware, nil
  }
 diff --git a/src/runtime/virtcontainers/qemu_arm64.go b/src/runtime/virtcontainers/qemu_arm64.go
-index a9b803f73..112fe358e 100644
+index a9b803f73275c1d5b9212a63fda097ebc33f1c9f..112fe358e4d76700ebe7a1d36e9ae42eb93611b7 100644
 --- a/src/runtime/virtcontainers/qemu_arm64.go
 +++ b/src/runtime/virtcontainers/qemu_arm64.go
 @@ -154,7 +154,7 @@ func (q *qemuArm64) enableProtection() error {
@@ -978,7 +978,7 @@ index a9b803f73..112fe358e 100644
  	if err != nil {
  		hvLogger.WithField("arch", runtime.GOARCH).Error(err)
 diff --git a/src/runtime/virtcontainers/qemu_arm64_test.go b/src/runtime/virtcontainers/qemu_arm64_test.go
-index 07e67ac8c..8b6bd03eb 100644
+index 07e67ac8c1479c67f4b4ffa850dddb8d1e0680e4..8b6bd03eb9d10f0c37dbdbb3fb5fa48585659e96 100644
 --- a/src/runtime/virtcontainers/qemu_arm64_test.go
 +++ b/src/runtime/virtcontainers/qemu_arm64_test.go
 @@ -182,42 +182,77 @@ func TestQemuArm64AppendProtectionDevice(t *testing.T) {
@@ -1066,7 +1066,7 @@ index 07e67ac8c..8b6bd03eb 100644
  	assert.Empty(bios)
  	assert.NoError(err)
 diff --git a/src/runtime/virtcontainers/qemu_ppc64le.go b/src/runtime/virtcontainers/qemu_ppc64le.go
-index d2e0228c8..ed7a14c4d 100644
+index d2e0228c8be8eae3ae24f3aa81b6423735f51320..ed7a14c4dc4262a0f1d77f6efa11310479fa1ecb 100644
 --- a/src/runtime/virtcontainers/qemu_ppc64le.go
 +++ b/src/runtime/virtcontainers/qemu_ppc64le.go
 @@ -157,7 +157,7 @@ func (q *qemuPPC64le) enableProtection() error {
@@ -1079,7 +1079,7 @@ index d2e0228c8..ed7a14c4d 100644
  	case pefProtection:
  		return append(devices,
 diff --git a/src/runtime/virtcontainers/qemu_ppc64le_test.go b/src/runtime/virtcontainers/qemu_ppc64le_test.go
-index 85e1dfe80..0c2f4b923 100644
+index 85e1dfe8050e3c64545e2031420058aad004f2ab..0c2f4b923d5550b67ad8c767124d8414b47d4c0b 100644
 --- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
 +++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
 @@ -60,39 +60,63 @@ func TestQemuPPC64leAppendProtectionDevice(t *testing.T) {
@@ -1174,7 +1174,7 @@ index 85e1dfe80..0c2f4b923 100644
 +	assert.Equal(expectedOut, devices)
  }
 diff --git a/src/runtime/virtcontainers/qemu_s390x.go b/src/runtime/virtcontainers/qemu_s390x.go
-index 29eaafe5b..787a0e589 100644
+index 29eaafe5b3fe0ecf9f10bc49ede3465d2cf8ec3e..787a0e589a71dabb5acaedd66e36bb5f7d9662d0 100644
 --- a/src/runtime/virtcontainers/qemu_s390x.go
 +++ b/src/runtime/virtcontainers/qemu_s390x.go
 @@ -337,7 +337,7 @@ func (q *qemuS390x) enableProtection() error {
@@ -1187,7 +1187,7 @@ index 29eaafe5b..787a0e589 100644
  	case seProtection:
  		return append(devices,
 diff --git a/src/runtime/virtcontainers/qemu_s390x_test.go b/src/runtime/virtcontainers/qemu_s390x_test.go
-index 24a67bdd9..3f5f84aff 100644
+index 24a67bdd9e591ead96fbaea473cb662526dedbf3..3f5f84afffeec6fed0ba624408158425090fe88a 100644
 --- a/src/runtime/virtcontainers/qemu_s390x_test.go
 +++ b/src/runtime/virtcontainers/qemu_s390x_test.go
 @@ -111,40 +111,64 @@ func TestQemuS390xAppendProtectionDevice(t *testing.T) {
@@ -1281,7 +1281,7 @@ index 24a67bdd9..3f5f84aff 100644
 +	assert.Equal(expectedOut, devices)
  }
 diff --git a/src/runtime/virtcontainers/sandbox.go b/src/runtime/virtcontainers/sandbox.go
-index ac0d35e9c..ff7a46b4e 100644
+index ac0d35e9c854d6b5eea52e716137fe62414d51a7..ff7a46b4e05dbef2d8d1981897b04e639fda5527 100644
 --- a/src/runtime/virtcontainers/sandbox.go
 +++ b/src/runtime/virtcontainers/sandbox.go
 @@ -613,6 +613,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor

--- a/packages/by-name/kata/kata-runtime/0004-genpolicy-enable-sysctl-checks.patch
+++ b/packages/by-name/kata/kata-runtime/0004-genpolicy-enable-sysctl-checks.patch
@@ -1,4 +1,4 @@
-From cc68c48a9af8cbdd6ffd8a74d7960adc22150f08 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Wed, 24 Jul 2024 09:48:48 +0200
 Subject: [PATCH] genpolicy: enable sysctl checks
@@ -16,7 +16,7 @@ environment-dependent sysctls in the settings file.
  5 files changed, 62 insertions(+), 1 deletion(-)
 
 diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
-index fe1625bac..e50d5e545 100644
+index fe1625bac119b59ce2094b2220e2a87c486e670a..e50d5e545e3fe42db486771345310d4c2157be2f 100644
 --- a/src/tools/genpolicy/genpolicy-settings.json
 +++ b/src/tools/genpolicy/genpolicy-settings.json
 @@ -39,6 +39,10 @@
@@ -44,7 +44,7 @@ index fe1625bac..e50d5e545 100644
      },
      "volumes": {
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index 1d95bfe69..a89b13ed1 100644
+index 1d95bfe699bb5082f8bbfb2cc4d89c8bde3a08ec..a89b13ed158ad8524e11ffbdad8ccb1ce7692aed 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -112,7 +112,6 @@ allow_create_container_input {
@@ -88,7 +88,7 @@ index 1d95bfe69..a89b13ed1 100644
  # and io.kubernetes.cri.sandbox-id" values with other fields.
  allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages) {
 diff --git a/src/tools/genpolicy/src/containerd.rs b/src/tools/genpolicy/src/containerd.rs
-index 075fced5b..2922ea0ab 100644
+index 075fced5bfec11b27e529f0b1d2dba5e6271ba82..2922ea0ab54671269c8eedab3890ba35529db05a 100644
 --- a/src/tools/genpolicy/src/containerd.rs
 +++ b/src/tools/genpolicy/src/containerd.rs
 @@ -3,6 +3,8 @@
@@ -117,7 +117,7 @@ index 075fced5b..2922ea0ab 100644
      }
  }
 diff --git a/src/tools/genpolicy/src/pod.rs b/src/tools/genpolicy/src/pod.rs
-index 19f882239..5030144c6 100644
+index 19f8822395ca225961bcf77bc3e5ae25e3c31119..5030144c6364cd929c53d18a24459748c1ce20aa 100644
 --- a/src/tools/genpolicy/src/pod.rs
 +++ b/src/tools/genpolicy/src/pod.rs
 @@ -21,6 +21,7 @@ use log::{debug, warn};
@@ -176,7 +176,7 @@ index 19f882239..5030144c6 100644
          ..Default::default()
      };
 diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
-index 973643e1f..adbdf97f3 100644
+index 973643e1f270b589e30e0b2e9235dbfa70df0f20..adbdf97f33c449e905cbf9044a118da4598c69cd 100644
 --- a/src/tools/genpolicy/src/policy.rs
 +++ b/src/tools/genpolicy/src/policy.rs
 @@ -27,6 +27,7 @@ use serde_yaml::Value;

--- a/packages/by-name/kata/kata-runtime/0005-genpolicy-read-bundle-id-from-rootfs.patch
+++ b/packages/by-name/kata/kata-runtime/0005-genpolicy-read-bundle-id-from-rootfs.patch
@@ -1,4 +1,4 @@
-From eed3e15bfd5468480e07b08dbf5266a75a61e076 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Wed, 24 Jul 2024 09:51:57 +0200
 Subject: [PATCH] genpolicy: read bundle-id from rootfs
@@ -14,7 +14,7 @@ NOTE: fixes https://github.com/kata-containers/kata-containers/issues/10065
  1 file changed, 8 insertions(+), 21 deletions(-)
 
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index a89b13ed1..d9b68e3ac 100644
+index a89b13ed158ad8524e11ffbdad8ccb1ce7692aed..d9b68e3ac0758f0d15bc1415300573082d7e1949 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -509,9 +509,6 @@ allow_linux_sysctl(p_linux, i_linux) {

--- a/packages/by-name/kata/kata-runtime/0006-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
+++ b/packages/by-name/kata/kata-runtime/0006-genpolicy-regex-check-contrast-specific-layer-src-pr.patch
@@ -1,4 +1,4 @@
-From 551b4a87596fe66741433424872deefbc251ee59 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
 Date: Thu, 11 Jul 2024 12:05:00 +0200
 Subject: [PATCH] genpolicy: regex check contrast specific layer-src-prefix
@@ -9,7 +9,7 @@ Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index d9b68e3ac..6ddcd18cd 100644
+index d9b68e3ac0758f0d15bc1415300573082d7e1949..6ddcd18cd1334dfabeadd1b0e7a54c723c7cae4d 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -905,7 +905,7 @@ allow_storage_options(p_storage, i_storage, layer_ids, root_hashes) {

--- a/packages/by-name/kata/kata-runtime/0007-genpolicy-settings-bump-OCI-version.patch
+++ b/packages/by-name/kata/kata-runtime/0007-genpolicy-settings-bump-OCI-version.patch
@@ -1,4 +1,4 @@
-From 264156d366f357b71fb697f7f65f9ff84e90c2f8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Wed, 24 Jul 2024 11:16:37 +0200
 Subject: [PATCH] genpolicy-settings: bump OCI version
@@ -9,7 +9,7 @@ Kata hard-codes OCI version 1.1.0, but latest K3S has 1.2.0.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
-index e50d5e545..fcafa46cc 100644
+index e50d5e545e3fe42db486771345310d4c2157be2f..fcafa46cc3b62b74aa5ba08fdbd76fa3370ae77e 100644
 --- a/src/tools/genpolicy/genpolicy-settings.json
 +++ b/src/tools/genpolicy/genpolicy-settings.json
 @@ -312,7 +312,7 @@

--- a/packages/by-name/kata/kata-runtime/0008-genpolicy-settings-change-cpath-for-Nydus-guest-pull.patch
+++ b/packages/by-name/kata/kata-runtime/0008-genpolicy-settings-change-cpath-for-Nydus-guest-pull.patch
@@ -1,4 +1,4 @@
-From cfa3376d255617815b8ef10bdc6026bf38a99889 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Mon, 12 Aug 2024 14:18:43 +0200
 Subject: [PATCH] genpolicy-settings: change cpath for Nydus guest pull
@@ -10,7 +10,7 @@ https://github.com/kata-containers/kata-containers/blob/775f6bd/tests/integratio
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
-index fcafa46cc..4e9f6481d 100644
+index fcafa46cc3b62b74aa5ba08fdbd76fa3370ae77e..4e9f6481d649fc45716f182c394f38059792eb91 100644
 --- a/src/tools/genpolicy/genpolicy-settings.json
 +++ b/src/tools/genpolicy/genpolicy-settings.json
 @@ -243,7 +243,7 @@

--- a/packages/by-name/kata/kata-runtime/0009-genpolicy-allow-image_guest_pull.patch
+++ b/packages/by-name/kata/kata-runtime/0009-genpolicy-allow-image_guest_pull.patch
@@ -1,4 +1,4 @@
-From f9e3e6924f326af2cbac10476f663a6bfb86685a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Thu, 1 Aug 2024 15:58:42 +0200
 Subject: [PATCH] genpolicy: allow image_guest_pull
@@ -26,7 +26,7 @@ don't even bother handling that case.
  create mode 100644 src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/testcases.json
 
 diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
-index 4e9f6481d..e3b36a655 100644
+index 4e9f6481d649fc45716f182c394f38059792eb91..e3b36a6555a646ffefc7733c807d6b0da9967dea 100644
 --- a/src/tools/genpolicy/genpolicy-settings.json
 +++ b/src/tools/genpolicy/genpolicy-settings.json
 @@ -148,7 +148,7 @@
@@ -39,7 +39,7 @@ index 4e9f6481d..e3b36a655 100644
              "source": "local",
              "fstype": "local",
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index 6ddcd18cd..50219c038 100644
+index 6ddcd18cd1334dfabeadd1b0e7a54c723c7cae4d..44af45437f550877652c33019f42b0b29fdcfbdb 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -80,7 +80,7 @@ CreateContainerRequest {
@@ -153,7 +153,7 @@ index 6ddcd18cd..50219c038 100644
 +    p_mount_point := concat("/", [policy_data.common.cpath, bundle_id, "rootfs"])
 +    print("allow_storages 1: i_storage.mount_point =", i_storage.mount_point, "p_mount_point =", p_mount_point)
 +    i_storage.mount_point == p_mount_point
-+    
++
 +    print("allow_storages 1: p_container.image =", p_container.image, "i_storage.source =", i_storage.source)
 +
 +    count(i_storage.driver_options) == 1
@@ -215,7 +215,7 @@ index 6ddcd18cd..50219c038 100644
 +}
 +
 +# Allow tardev-snapshotter storage
-+allow_storages(p_container, i_storages, bundle_id, sandbox_id) {    
++allow_storages(p_container, i_storages, bundle_id, sandbox_id) {
 +    p_storages := p_container.storages
      p_count := count(p_storages)
      i_count := count(i_storages)
@@ -249,7 +249,7 @@ index 6ddcd18cd..50219c038 100644
  
  allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hashes) {
 diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
-index adbdf97f3..c4dc4ac3c 100644
+index adbdf97f33c449e905cbf9044a118da4598c69cd..c4dc4ac3c2a10211909ae8ee8d77050add0e5cc1 100644
 --- a/src/tools/genpolicy/src/policy.rs
 +++ b/src/tools/genpolicy/src/policy.rs
 @@ -270,6 +270,9 @@ pub struct ContainerPolicy {
@@ -271,7 +271,7 @@ index adbdf97f3..c4dc4ac3c 100644
              devices,
              sandbox_pidns,
 diff --git a/src/tools/genpolicy/tests/main.rs b/src/tools/genpolicy/tests/main.rs
-index 565b3e2a0..a3a08d96e 100644
+index 565b3e2a0b0368ccbecd778cb70fa9f94596de51..a3a08d96e865eb992ef5607ec050a58ea0749dfc 100644
 --- a/src/tools/genpolicy/tests/main.rs
 +++ b/src/tools/genpolicy/tests/main.rs
 @@ -9,7 +9,7 @@ use std::path;
@@ -294,7 +294,7 @@ index 565b3e2a0..a3a08d96e 100644
 +}
 diff --git a/src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/pod.yaml b/src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/pod.yaml
 new file mode 100644
-index 000000000..203af19a6
+index 0000000000000000000000000000000000000000..203af19a6f7a200580cdd39cd38e50fe23403710
 --- /dev/null
 +++ b/src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/pod.yaml
 @@ -0,0 +1,11 @@
@@ -311,7 +311,7 @@ index 000000000..203af19a6
 +      privileged: true
 diff --git a/src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/testcases.json b/src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/testcases.json
 new file mode 100644
-index 000000000..2f21e0674
+index 0000000000000000000000000000000000000000..2f21e0674e496f9d496553311cb4c24f96449401
 --- /dev/null
 +++ b/src/tools/genpolicy/tests/testdata/createcontainer/guest_pull/testcases.json
 @@ -0,0 +1,2027 @@

--- a/packages/by-name/kata/kata-runtime/0010-runtime-agent-mounts-Mount-configfs-into-the-contain.patch
+++ b/packages/by-name/kata/kata-runtime/0010-runtime-agent-mounts-Mount-configfs-into-the-contain.patch
@@ -1,4 +1,4 @@
-From 731cb67511c10e51b88d69227d952c4d1c0cb2c8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fabiano=20Fid=C3=AAncio?= <fabiano.fidencio@intel.com>
 Date: Thu, 25 Apr 2024 10:34:26 +0200
 Subject: [PATCH] runtime: agent: mounts: Mount configfs into the container
@@ -23,7 +23,7 @@ Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
  1 file changed, 20 insertions(+)
 
 diff --git a/src/agent/rustjail/src/mount.rs b/src/agent/rustjail/src/mount.rs
-index 14e3d9560..b5f857913 100644
+index 14e3d95608784d18c4978fa2c89d1f523335a7e3..b5f8579132f262be66f2d73baa76a73fdff13e5d 100644
 --- a/src/agent/rustjail/src/mount.rs
 +++ b/src/agent/rustjail/src/mount.rs
 @@ -288,6 +288,26 @@ pub fn init_rootfs(

--- a/packages/by-name/kata/kata-runtime/0011-genpolicy-bump-oci-distribution-to-v0.12.0.patch
+++ b/packages/by-name/kata/kata-runtime/0011-genpolicy-bump-oci-distribution-to-v0.12.0.patch
@@ -1,4 +1,4 @@
-From 3b46844789f76480c030342d37577286a045041e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Mon, 12 Aug 2024 13:45:43 +0200
 Subject: [PATCH] genpolicy: bump oci-distribution to v0.12.0
@@ -18,7 +18,7 @@ Signed-off-by: Markus Rudy <mr@edgeless.systems>
  4 files changed, 183 insertions(+), 87 deletions(-)
 
 diff --git a/src/tools/genpolicy/Cargo.lock b/src/tools/genpolicy/Cargo.lock
-index 7655b8d6e..9d0573c8e 100644
+index 7655b8d6e45fb6544d3c904fe8ad26ff03b04751..9d0573c8ec413e511405c5debd2b8f4df14900c3 100644
 --- a/src/tools/genpolicy/Cargo.lock
 +++ b/src/tools/genpolicy/Cargo.lock
 @@ -98,9 +98,9 @@ dependencies = [
@@ -589,7 +589,7 @@ index 7655b8d6e..9d0573c8e 100644
  
  [[package]]
 diff --git a/src/tools/genpolicy/Cargo.toml b/src/tools/genpolicy/Cargo.toml
-index f14643503..c6c0b94ee 100644
+index f146435032b10c301b99e2e4cf24e6a1b123ad20..c6c0b94eea163fbc8748896def52e1f6eaef85ff 100644
 --- a/src/tools/genpolicy/Cargo.toml
 +++ b/src/tools/genpolicy/Cargo.toml
 @@ -41,7 +41,7 @@ async-trait = "0.1.68"
@@ -602,7 +602,7 @@ index f14643503..c6c0b94ee 100644
  serde_ignored = "0.1.7"
  serde_json = "1.0.39"
 diff --git a/src/tools/genpolicy/src/registry.rs b/src/tools/genpolicy/src/registry.rs
-index 7aa0e66a9..9491b2acf 100644
+index 7aa0e66a9c21d623ccf905de626e4f2b872978dd..9491b2acfb8af1f8c4e4c971a6787c2d803e46ec 100644
 --- a/src/tools/genpolicy/src/registry.rs
 +++ b/src/tools/genpolicy/src/registry.rs
 @@ -15,7 +15,7 @@ use anyhow::{anyhow, Result};
@@ -624,7 +624,7 @@ index 7aa0e66a9..9491b2acf 100644
              }
              Err(e) => {
 diff --git a/src/tools/genpolicy/src/registry_containerd.rs b/src/tools/genpolicy/src/registry_containerd.rs
-index 9a02b5419..6541cfbda 100644
+index 9a02b54193750df4d0190b6d614f01c467bb7746..6541cfbda5379a4caea0361a5993db8f15adf6a2 100644
 --- a/src/tools/genpolicy/src/registry_containerd.rs
 +++ b/src/tools/genpolicy/src/registry_containerd.rs
 @@ -15,7 +15,7 @@ use containerd_client::{services::v1::GetImageRequest, with_namespace};

--- a/packages/by-name/kata/kata-runtime/0012-genpolicy-support-mount-propagation-and-ro-mounts.patch
+++ b/packages/by-name/kata/kata-runtime/0012-genpolicy-support-mount-propagation-and-ro-mounts.patch
@@ -1,4 +1,4 @@
-From d7b170e9bc52af5b595d21246e8cca56dfdb59b1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Tue, 24 Sep 2024 16:05:31 +0200
 Subject: [PATCH] genpolicy: support mount propagation and ro-mounts
@@ -9,7 +9,7 @@ Subject: [PATCH] genpolicy: support mount propagation and ro-mounts
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index 50219c038..9de56a429 100644
+index 44af45437f550877652c33019f42b0b29fdcfbdb..823e5e76d55bac47ad9c79d8916f92702efa316d 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -105,7 +105,8 @@ allow_create_container_input {
@@ -23,7 +23,7 @@ index 50219c038..9de56a429 100644
      is_null(i_linux.IntelRdt)
      is_null(i_linux.Resources.BlockIO)
 diff --git a/src/tools/genpolicy/src/mount_and_storage.rs b/src/tools/genpolicy/src/mount_and_storage.rs
-index 394c06658..8dbe524ae 100644
+index 394c06658565230ba2cde520e850b7bfe44b1637..8dbe524ae2c42172ed08a03bd5e570e8a1accd3d 100644
 --- a/src/tools/genpolicy/src/mount_and_storage.rs
 +++ b/src/tools/genpolicy/src/mount_and_storage.rs
 @@ -189,13 +189,19 @@ fn get_empty_dir_mount_and_storage(

--- a/packages/by-name/kata/kata-runtime/0013-tools-don-t-clean-build-root-when-generating-rootfs.patch
+++ b/packages/by-name/kata/kata-runtime/0013-tools-don-t-clean-build-root-when-generating-rootfs.patch
@@ -1,4 +1,4 @@
-From 75333c341d1a5f34030f4be7c32f6db609f358db Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Fri, 4 Oct 2024 11:27:37 +0200
 Subject: [PATCH] tools: don't clean build root when generating rootfs
@@ -8,7 +8,7 @@ Subject: [PATCH] tools: don't clean build root when generating rootfs
  1 file changed, 6 deletions(-)
 
 diff --git a/tools/osbuilder/rootfs-builder/rootfs.sh b/tools/osbuilder/rootfs-builder/rootfs.sh
-index 04a855a0c..f53b52460 100755
+index 04a855a0ceccf094a36c1b4a79b4dc90e9822d29..f53b524601cdff4b38f41834796856624fac812f 100755
 --- a/tools/osbuilder/rootfs-builder/rootfs.sh
 +++ b/tools/osbuilder/rootfs-builder/rootfs.sh
 @@ -401,12 +401,6 @@ build_rootfs_distro()

--- a/packages/by-name/kata/kata-runtime/0014-kata-sys-util-remove-obsolete-cgroups-dependency.patch
+++ b/packages/by-name/kata/kata-runtime/0014-kata-sys-util-remove-obsolete-cgroups-dependency.patch
@@ -1,4 +1,4 @@
-From d589bc79cae6c05106fac50e07abe83945db1bf5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Tue, 15 Oct 2024 16:11:21 +0200
 Subject: [PATCH] kata-sys-util: remove obsolete cgroups dependency
@@ -21,7 +21,7 @@ Signed-off-by: Markus Rudy <mr@edgeless.systems>
  9 files changed, 148 insertions(+), 105 deletions(-)
 
 diff --git a/src/agent/Cargo.lock b/src/agent/Cargo.lock
-index 8cf40f7ec..8d9877928 100644
+index 8cf40f7ec7d12b6e206d49f4b6adff05d347262d..8d9877928d7dca14f5a072357c6e03da3d2eba89 100644
 --- a/src/agent/Cargo.lock
 +++ b/src/agent/Cargo.lock
 @@ -2877,7 +2877,6 @@ version = "0.1.0"
@@ -33,7 +33,7 @@ index 8cf40f7ec..8d9877928 100644
   "common-path",
   "fail",
 diff --git a/src/libs/Cargo.lock b/src/libs/Cargo.lock
-index 8bf4e8e04..253ffcf94 100644
+index 8bf4e8e0457f047d8b0c4eda957f8fbf56bf8c96..253ffcf94fdad07de7b4cb99524345c72139f735 100644
 --- a/src/libs/Cargo.lock
 +++ b/src/libs/Cargo.lock
 @@ -240,19 +240,6 @@ version = "1.0.0"
@@ -84,7 +84,7 @@ index 8bf4e8e04..253ffcf94 100644
  name = "nix"
  version = "0.26.4"
 diff --git a/src/libs/kata-sys-util/Cargo.toml b/src/libs/kata-sys-util/Cargo.toml
-index 13d860ee4..079339c9c 100644
+index 13d860ee4579415aa37fda9c9a54f0b7823ae8f5..079339c9cfbfbcf7c98688fc60a59767c0c64d99 100644
 --- a/src/libs/kata-sys-util/Cargo.toml
 +++ b/src/libs/kata-sys-util/Cargo.toml
 @@ -13,7 +13,6 @@ edition = "2018"
@@ -96,7 +96,7 @@ index 13d860ee4..079339c9c 100644
  common-path = "=1.0.0"
  fail = "0.5.0"
 diff --git a/src/libs/kata-sys-util/README.md b/src/libs/kata-sys-util/README.md
-index 0c3f887bc..14bebfef8 100644
+index 0c3f887bcbeab53c80dc69af95a1aca57d093016..14bebfef881ff92b6848696aea0fe09b602f425d 100644
 --- a/src/libs/kata-sys-util/README.md
 +++ b/src/libs/kata-sys-util/README.md
 @@ -1,10 +1,9 @@
@@ -112,7 +112,7 @@ index 0c3f887bc..14bebfef8 100644
  - mount
  - NUMA
 diff --git a/src/runtime-rs/Cargo.lock b/src/runtime-rs/Cargo.lock
-index 45e80c388..216c3e41e 100644
+index 45e80c388e05feca6949957d2981069441482a2c..216c3e41e81306885a697ae1463dcb06a00a3e88 100644
 --- a/src/runtime-rs/Cargo.lock
 +++ b/src/runtime-rs/Cargo.lock
 @@ -1839,7 +1839,6 @@ version = "0.1.0"
@@ -124,7 +124,7 @@ index 45e80c388..216c3e41e 100644
   "common-path",
   "fail",
 diff --git a/src/tools/agent-ctl/Cargo.lock b/src/tools/agent-ctl/Cargo.lock
-index 7ecbd1ac0..d931c1b73 100644
+index 7ecbd1ac05e1801b4bf7ccfd9584433ac0fe123e..d931c1b735d56d33f2bed5f9c9447a7fc8b7e4cb 100644
 --- a/src/tools/agent-ctl/Cargo.lock
 +++ b/src/tools/agent-ctl/Cargo.lock
 @@ -1186,7 +1186,6 @@ version = "0.1.0"
@@ -136,7 +136,7 @@ index 7ecbd1ac0..d931c1b73 100644
   "common-path",
   "fail",
 diff --git a/src/tools/genpolicy/Cargo.lock b/src/tools/genpolicy/Cargo.lock
-index 9d0573c8e..8d68348c4 100644
+index 9d0573c8ec413e511405c5debd2b8f4df14900c3..8d68348c495552ba0960ebf26ee889e0f1e3215d 100644
 --- a/src/tools/genpolicy/Cargo.lock
 +++ b/src/tools/genpolicy/Cargo.lock
 @@ -301,19 +301,6 @@ version = "0.2.1"
@@ -187,7 +187,7 @@ index 9d0573c8e..8d68348c4 100644
  name = "nix"
  version = "0.26.4"
 diff --git a/src/tools/kata-ctl/Cargo.lock b/src/tools/kata-ctl/Cargo.lock
-index 2746bf64e..7499a3516 100644
+index 2746bf64ea94009962a070e962b8ab2cdce9018b..7499a3516176193536429663a75f3cc2842c766a 100644
 --- a/src/tools/kata-ctl/Cargo.lock
 +++ b/src/tools/kata-ctl/Cargo.lock
 @@ -27,7 +27,7 @@ dependencies = [
@@ -577,7 +577,7 @@ index 2746bf64e..7499a3516 100644
  name = "subprocess"
  version = "0.2.9"
 diff --git a/src/tools/runk/Cargo.lock b/src/tools/runk/Cargo.lock
-index e1afc6f91..b84227308 100644
+index e1afc6f91c3d62eb639d2b9b8e1e5322dbd27afb..b842273083b04c42b2704b8acd3857683831ced7 100644
 --- a/src/tools/runk/Cargo.lock
 +++ b/src/tools/runk/Cargo.lock
 @@ -1391,7 +1391,6 @@ version = "0.1.0"

--- a/packages/by-name/kata/kata-runtime/0015-kata-sys-util-move-json-parsing-to-protocols-crate.patch
+++ b/packages/by-name/kata/kata-runtime/0015-kata-sys-util-move-json-parsing-to-protocols-crate.patch
@@ -1,4 +1,4 @@
-From 3adff7459b506c8bbf4dd71370bbeb468c299a4d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Tue, 15 Oct 2024 16:11:21 +0200
 Subject: [PATCH] kata-sys-util: move json parsing to protocols crate
@@ -26,7 +26,7 @@ Signed-off-by: Markus Rudy <mr@edgeless.systems>
  10 files changed, 46 insertions(+), 593 deletions(-)
 
 diff --git a/src/agent/Cargo.lock b/src/agent/Cargo.lock
-index 8d9877928..eae6db554 100644
+index 8d9877928d7dca14f5a072357c6e03da3d2eba89..eae6db554824b9de0d9694d583d0b05d610c5d9a 100644
 --- a/src/agent/Cargo.lock
 +++ b/src/agent/Cargo.lock
 @@ -4423,7 +4423,6 @@ name = "protocols"
@@ -38,7 +38,7 @@ index 8d9877928..eae6db554 100644
   "protobuf 3.5.1",
   "serde",
 diff --git a/src/libs/Cargo.lock b/src/libs/Cargo.lock
-index 253ffcf94..ed7184c48 100644
+index 253ffcf94fdad07de7b4cb99524345c72139f735..ed7184c48e33a63005b70215676a486a3358c07f 100644
 --- a/src/libs/Cargo.lock
 +++ b/src/libs/Cargo.lock
 @@ -1290,7 +1290,6 @@ name = "protocols"
@@ -50,7 +50,7 @@ index 253ffcf94..ed7184c48 100644
   "protobuf 3.2.0",
   "serde",
 diff --git a/src/libs/kata-sys-util/src/spec.rs b/src/libs/kata-sys-util/src/spec.rs
-index c7a7ba405..762af62b1 100644
+index c7a7ba405edb2df3954a74e70c9b0d1096c91a54..762af62b1242587c71eaade02787a5c0ff270c8e 100644
 --- a/src/libs/kata-sys-util/src/spec.rs
 +++ b/src/libs/kata-sys-util/src/spec.rs
 @@ -97,11 +97,3 @@ pub fn load_oci_spec() -> Result<oci::Spec, OciSpecError> {
@@ -66,7 +66,7 @@ index c7a7ba405..762af62b1 100644
 -    stripped_str
 -}
 diff --git a/src/libs/protocols/Cargo.toml b/src/libs/protocols/Cargo.toml
-index 366e1bea2..2b945f42c 100644
+index 366e1bea23e0861a5047f7166fb82db51adc454a..2b945f42c75eb61d6949043c0143ffd53bd6b23d 100644
 --- a/src/libs/protocols/Cargo.toml
 +++ b/src/libs/protocols/Cargo.toml
 @@ -7,19 +7,17 @@ license = "Apache-2.0"
@@ -93,7 +93,7 @@ index 366e1bea2..2b945f42c 100644
  ttrpc-codegen = "0.4.2"
  protobuf = { version = "3.2.0" }
 diff --git a/src/libs/protocols/src/trans.rs b/src/libs/protocols/src/trans.rs
-index 38428a880..d7cbba30a 100644
+index 38428a880455cae36bd84a832dd52d84d82f70f5..d7cbba30ac64578c7c06b5f683bea63c87b13a78 100644
 --- a/src/libs/protocols/src/trans.rs
 +++ b/src/libs/protocols/src/trans.rs
 @@ -10,7 +10,6 @@ use std::convert::TryFrom;
@@ -156,7 +156,7 @@ index 38428a880..d7cbba30a 100644
 +    }
  }
 diff --git a/src/runtime-rs/Cargo.lock b/src/runtime-rs/Cargo.lock
-index 216c3e41e..a19e72476 100644
+index 216c3e41e81306885a697ae1463dcb06a00a3e88..a19e7247641fbecd633f4f1a4b4830fad9bcd66f 100644
 --- a/src/runtime-rs/Cargo.lock
 +++ b/src/runtime-rs/Cargo.lock
 @@ -2993,9 +2993,10 @@ name = "protocols"
@@ -172,7 +172,7 @@ index 216c3e41e..a19e72476 100644
   "ttrpc-codegen",
  ]
 diff --git a/src/tools/agent-ctl/Cargo.lock b/src/tools/agent-ctl/Cargo.lock
-index d931c1b73..8dc37616c 100644
+index d931c1b735d56d33f2bed5f9c9447a7fc8b7e4cb..8dc37616cd7c0764a9f1e84453f1b10a6e9e9759 100644
 --- a/src/tools/agent-ctl/Cargo.lock
 +++ b/src/tools/agent-ctl/Cargo.lock
 @@ -1681,7 +1681,6 @@ dependencies = [
@@ -184,7 +184,7 @@ index d931c1b73..8dc37616c 100644
   "protobuf 3.2.0",
   "serde",
 diff --git a/src/tools/genpolicy/Cargo.lock b/src/tools/genpolicy/Cargo.lock
-index 8d68348c4..470859f51 100644
+index 8d68348c495552ba0960ebf26ee889e0f1e3215d..470859f514a303b7efee40f0f96cb342ed8da453 100644
 --- a/src/tools/genpolicy/Cargo.lock
 +++ b/src/tools/genpolicy/Cargo.lock
 @@ -17,17 +17,6 @@ version = "1.0.2"
@@ -1074,7 +1074,7 @@ index 8d68348c4..470859f51 100644
  name = "xattr"
  version = "1.3.1"
 diff --git a/src/tools/kata-ctl/Cargo.lock b/src/tools/kata-ctl/Cargo.lock
-index 7499a3516..bd2de0038 100644
+index 7499a3516176193536429663a75f3cc2842c766a..bd2de00388756dc4ee8193f998ab195f215971e0 100644
 --- a/src/tools/kata-ctl/Cargo.lock
 +++ b/src/tools/kata-ctl/Cargo.lock
 @@ -1944,9 +1944,10 @@ name = "protocols"
@@ -1090,7 +1090,7 @@ index 7499a3516..bd2de0038 100644
   "ttrpc-codegen",
  ]
 diff --git a/src/tools/runk/Cargo.lock b/src/tools/runk/Cargo.lock
-index b84227308..6f41aef6e 100644
+index b842273083b04c42b2704b8acd3857683831ced7..6f41aef6ecab798781e5a0ce1c68c548db2d22d4 100644
 --- a/src/tools/runk/Cargo.lock
 +++ b/src/tools/runk/Cargo.lock
 @@ -2067,9 +2067,10 @@ dependencies = [

--- a/packages/by-name/kata/kata-runtime/0016-protocols-only-build-RLimit-impls-on-Linux.patch
+++ b/packages/by-name/kata/kata-runtime/0016-protocols-only-build-RLimit-impls-on-Linux.patch
@@ -1,4 +1,4 @@
-From 4be30f25ebeb5d843ddc6bcbbbc9eabcbbd71add Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Markus Rudy <mr@edgeless.systems>
 Date: Tue, 15 Oct 2024 16:11:21 +0200
 Subject: [PATCH] protocols: only build RLimit impls on Linux
@@ -15,7 +15,7 @@ Signed-off-by: Markus Rudy <mr@edgeless.systems>
  1 file changed, 6 insertions(+)
 
 diff --git a/src/libs/protocols/src/trans.rs b/src/libs/protocols/src/trans.rs
-index d7cbba30a..e55957244 100644
+index d7cbba30ac64578c7c06b5f683bea63c87b13a78..e559572448ccebd458e20ffe99f84a2e8ae7c7c3 100644
 --- a/src/libs/protocols/src/trans.rs
 +++ b/src/libs/protocols/src/trans.rs
 @@ -97,6 +97,8 @@ impl From<oci::LinuxCapabilities> for grpc::LinuxCapabilities {


### PR DESCRIPTION
The patch workflow we document is unfortunately not yet idempotent across committers: 

1. Commits created by `git am` are recorded with a `Committer: ` tag which depends on who is doing the committing. Since this tag is part of the commit, the commit hash changes and the leading `From <commit>` line of the patch file differs. The committer can't be overridden by a command line arg, afaik.
2. It seems like the number of characters in the `index <hash>..<hash>` lines created by `git format-patch` depends on the git version. 

Overall, the current workflow does not meet its original goal: a patch cherry-picked on the existing stack should not cause a diff in the existing patches.

I suggest the following changes to keep this clean in the future:
* Work around the idempotency by
  * masking the commit hash in the formatted patch and
  * not abbreviating the index hashes.
* Checking for patch cleanliness in a Github action.