### PR TITLE
kata: update checksum for kata-kernel-uvm tarball

### DIFF
--- a/packages/by-name/kata/kata-kernel-uvm/package.nix
+++ b/packages/by-name/kata/kata-kernel-uvm/package.nix
@@ -16,7 +16,7 @@ let
 
     src = fetchzip {
       url = "https://github.com/kata-containers/kata-containers/releases/download/${version}/kata-static-${version}-amd64.tar.xz";
-      hash = "sha256-iy9LaVQyidvi+B9aH8fplchtEBSxvlfFnRxt2ZV4AUQ=";
+      hash = "sha256-VcbOY86p8VkI6XvdhHfZNnWVHKuMLW7Xj7uzHHDiVsk=";
     };
 
     postPatch = ''


### PR DESCRIPTION
The `kata-kernel-uvm` package uses the version from the `kata-runtime` package. We updated the version in #970, but forgot to update the checksum in the former.  