### PR TITLE
node-installer: allow setting contianerd config path via env

### DIFF
--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -119,6 +119,9 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	default:
 		return fmt.Errorf("unsupported platform %q", platform)
 	}
+	if containerdConfigOverridePath := os.Getenv("CONTAINERD_CONFIG_PATH"); containerdConfigOverridePath != "" {
+		containerdConfigPath = containerdConfigOverridePath
+	}
 
 	if err := containerdRuntimeConfig(runtimeBase, kataConfigPath, platform, config.QemuExtraKernelParams, config.DebugRuntime); err != nil {
 		return fmt.Errorf("generating kata runtime configuration: %w", err)


### PR DESCRIPTION
For bare-metal use case, the containerd path will often be the only difference between different distributions we support. Making this configurable hopefully enables users to use the node-installer on platforms with little tweaks and without us having to explicitly add every setup out there.