### PR TITLE
e2e: improve log collection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,7 @@ jobs:
             --namespace-file workspace/e2e.namespace \
             --platform ${{ inputs.platform }} \
             --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+          kill %%
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,13 +73,13 @@ jobs:
           just coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer ${{ inputs.platform }}
       - name: E2E Test
         run: |
-          nix run .#scripts.get-logs workspace/e2e.namespace &
+          nix run .#scripts.get-logs start workspace/e2e.namespace &
           nix shell -L .#contrast.e2e --command ${{ inputs.test-name }}.test -test.v \
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform ${{ inputs.platform }} \
             --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
-          kill %%
+          nix run .#scripts.get-logs download workspace/e2e.namespace
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: e2e_pod_logs-${{ inputs.platform }}-${{ inputs.test-name }}
-          path: workspace/namespace-logs
+          path: workspace/logs/export/logs
       - name: Notify teams channel of failure
         if: ${{ failure() && github.event_name == 'schedule' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -80,14 +80,14 @@ jobs:
           az extension add --name confcom
       - name: E2E test
         run: |
-          nix run .#scripts.get-logs workspace/e2e.namespace &
+          nix run .#scripts.get-logs start workspace/e2e.namespace &
           nix build .#contrast.e2e
           ./result/bin/aks-runtime.test -test.v \
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform AKS-CLH-SNP \
             --skip-undeploy="false"
-          kill %%
+          nix run .#scripts.get-logs download workspace/e2e.namespace
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: e2e_pod_logs-AKS-CLH-SNP-aks-runtime
-          path: workspace/namespace-logs
+          path: workspace/logs/export/logs
       - name: Notify teams channel of failure
         if: ${{ failure() && github.event_name == 'schedule' && github.run_attempt == 1 }}
         uses: ./.github/actions/post_to_teams

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -87,6 +87,7 @@ jobs:
             --namespace-file workspace/e2e.namespace \
             --platform AKS-CLH-SNP \
             --skip-undeploy="false"
+          kill %%
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/packages/by-name/k8s-log-collector/package.nix
+++ b/packages/by-name/k8s-log-collector/package.nix
@@ -10,7 +10,7 @@
   findutils,
   bash,
   gnutar,
-  gzip
+  gzip,
 }:
 
 let
@@ -48,7 +48,7 @@ dockerTools.buildImage {
   tag = "0.1.0";
   copyToRoot = buildEnv {
     name = "bin";
-    paths = [ 
+    paths = [
       bash
       coreutils
       gnutar
@@ -58,6 +58,8 @@ dockerTools.buildImage {
   };
   config = {
     Cmd = [ "${collection-script}/bin/collect-logs" ];
-    Volumes = { "/logs" = {}; };
+    Volumes = {
+      "/logs" = { };
+    };
   };
 }

--- a/packages/by-name/k8s-log-collector/package.nix
+++ b/packages/by-name/k8s-log-collector/package.nix
@@ -1,0 +1,47 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
+{
+  dockerTools,
+  writeShellApplication,
+  inotify-tools,
+  busybox
+}:
+
+let
+  collection-script = writeShellApplication {
+    name = "collect-logs";
+    runtimeInputs = [
+      inotify-tools
+      busybox
+    ];
+    text = ''
+      set -euo pipefail
+      mkdir /export
+      # collect all logs that may have been missed during startup
+      find /logs -name "*.log" |
+        while read -r file; do
+          if [[ -f "$file" && "$file" == *"$POD_NAMESPACE"* ]]; then
+            mkdir -p "/export$(dirname "$file")"
+            tail --follow=name "$file" > "export$file" &
+          fi
+        done
+      inotifywait -m /logs -r -e create -e moved_to |
+        while read -r path _action file; do
+          filepath="$path$file"
+          if [[ -f "$filepath" && "$filepath" == *"$POD_NAMESPACE"* ]]; then
+            mkdir -p "/export$path"
+            tail --follow=name "$filepath" >"/export$filepath" &
+          fi
+        done
+    '';
+  };
+in
+dockerTools.buildLayeredImage {
+  name = "k8s-log-collector";
+  tag = "0.1.0";
+  config = {
+    Cmd = [ "${collection-script}/bin/collect-logs" ];
+    Volumes = { "/logs" = {}; };
+  };
+}

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -30,15 +30,15 @@ spec:
             - /usr/bin/bash
             - -c
             - |
+              mkdir /export
               # TODO(miampf): Prepare an image that already has required tools installed
               apt-get update && apt-get install -y inotify-tools ncompress
-              mkdir /export
               inotifywait -m /logs -r -e create -e moved_to |
                 while read path action file; do
                   filepath="$path$file"
                   if [[ -f "$filepath" ]]; then
                     mkdir -p "/export$path"
-                    tail --follow=name -v "$filepath" | compress > "/export$filepath.Z" &
+                    tail --follow=name -v "$filepath" | compress -f >"/export$filepath" &
                   fi
                 done
       volumes:

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -32,13 +32,13 @@ spec:
             - |
               mkdir /export
               # TODO(miampf): Prepare an image that already has required tools installed
-              apt-get update && apt-get install -y inotify-tools ncompress
+              apt-get update && apt-get install -y inotify-tools
               inotifywait -m /logs -r -e create -e moved_to |
                 while read path action file; do
                   filepath="$path$file"
                   if [[ -f "$filepath" ]]; then
                     mkdir -p "/export$path"
-                    tail --follow=name -v "$filepath" | compress -f >"/export$filepath" &
+                    tail --follow=name "$filepath" >"/export$filepath" &
                   fi
                 done
       volumes:

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         name: log-collector
     spec:
+      priorityClassName: high-priority-logcollector
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -47,3 +48,11 @@ spec:
           hostPath:
             path: /var/log/pods
             type: Directory
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority-logcollector
+value: 10000000
+globalDefault: false
+description: "This priority class is used to prioritise the log collector pod creation before anything else"

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -35,11 +35,8 @@ spec:
               mkdir /export
               inotifywait -m /logs -r -e create -e moved_to |
                 while read path action file; do
-                  echo "DEBUG: $path; $action; $file"
                   filepath="$path$file"
-                  echo "DEBUG: $filepath"
                   if [[ -f "$filepath" ]]; then
-                    echo "$filepath was created."
                     mkdir -p "/export$path"
                     tail --follow=name -v "$filepath" | compress > "/export$filepath.Z" &
                   fi

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -30,7 +30,11 @@ spec:
             - /usr/local/bin/bash
             - -c
             - |
-              ls /logs
+              inotifywait -m /logs -e create -e moved_to |
+                while read path action file; do
+                  echo "$file was created."
+                  tail --follow=name -v "$file" &
+                done
       volumes:
         - name: log-volume
           # mount the nodes logs to the container

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: log-collector
+  namespace: @@NAMESPACE@@
+spec:
+  selector:
+    matchLabels:
+      name: log-collector
+  template:
+    metadata:
+      labels:
+        name: log-collector
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: log-collector
+          image: docker.io/bash:latest # TODO(miampf): Replace with non docker.io image
+          volumeMounts:
+            - mountPath: /logs
+              name: log-volume
+              readOnly: true
+          command:
+            - /usr/local/bin/bash
+            - -c
+            - |
+              ls /logs
+      volumes:
+        - name: log-volume
+          # mount the nodes logs to the container
+          hostPath:
+            path: /var/log/pods
+            type: Directory

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: log-collector
-  namespace: @@NAMESPACE@@
+  namespace: "@@NAMESPACE@@"
 spec:
   selector:
     matchLabels:

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -25,7 +25,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: log-collector
-          image: "ghcr.io/miampf/k8s-log-collector:latest"
+          image: "ghcr.io/edgelesssys/k8s-log-collector@sha256:fd173230870b9e19a342627e31a50a0d6e45e7c8770c133b62e72cb4e898bc3e"
           volumeMounts:
             - mountPath: /logs
               name: log-volume

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -30,8 +30,9 @@ spec:
             - /usr/bin/bash
             - -c
             - |
-              # TODO(miampf): Prepare an image that already has inotify-tools installed
-              apt-get update && apt-get install -y inotify-tools
+              # TODO(miampf): Prepare an image that already has required tools installed
+              apt-get update && apt-get install -y inotify-tools ncompress
+              mkdir /export
               inotifywait -m /logs -r -e create -e moved_to |
                 while read path action file; do
                   echo "DEBUG: $path; $action; $file"
@@ -39,7 +40,8 @@ spec:
                   echo "DEBUG: $filepath"
                   if [[ -f "$filepath" ]]; then
                     echo "$filepath was created."
-                    tail --follow=name -v "$filepath" &
+                    mkdir -p "/export$path"
+                    tail --follow=name -v "$filepath" | compress > "/export$filepath.Z" &
                   fi
                 done
       volumes:

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -21,19 +21,26 @@ spec:
           effect: NoSchedule
       containers:
         - name: log-collector
-          image: docker.io/bash:latest # TODO(miampf): Replace with non docker.io image
+          image: docker.io/ubuntu:oracular # TODO(miampf): Replace with non docker.io image
           volumeMounts:
             - mountPath: /logs
               name: log-volume
               readOnly: true
           command:
-            - /usr/local/bin/bash
+            - /usr/bin/bash
             - -c
             - |
-              inotifywait -m /logs -e create -e moved_to |
+              # TODO(miampf): Prepare an image that already has inotify-tools installed
+              apt-get update && apt-get install -y inotify-tools
+              inotifywait -m /logs -r -e create -e moved_to |
                 while read path action file; do
-                  echo "$file was created."
-                  tail --follow=name -v "$file" &
+                  echo "DEBUG: $path; $action; $file"
+                  filepath="$path$file"
+                  echo "DEBUG: $filepath"
+                  if [[ -f "$filepath" ]]; then
+                    echo "$filepath was created."
+                    tail --follow=name -v "$filepath" &
+                  fi
                 done
       volumes:
         - name: log-volume

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: AGPL-3.0-only
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -27,6 +27,11 @@ spec:
             - mountPath: /logs
               name: log-volume
               readOnly: true
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           command:
             - /usr/bin/bash
             - -c
@@ -34,10 +39,17 @@ spec:
               mkdir /export
               # TODO(miampf): Prepare an image that already has required tools installed
               apt-get update && apt-get install -y inotify-tools
+              # collect all logs that may have been missed during startup
+              for file in $(find /logs -name *.log); do
+                if [[ -f "$file" && "$file" == *"$POD_NAMESPACE"* ]]; then
+                  mkdir -p "/export$(dirname "$file")"
+                  cp "$file" "/export$file"
+                fi
+              done
               inotifywait -m /logs -r -e create -e moved_to |
                 while read path action file; do
                   filepath="$path$file"
-                  if [[ -f "$filepath" ]]; then
+                  if [[ -f "$filepath" && "$filepath" == *"$POD_NAMESPACE"* ]]; then
                     mkdir -p "/export$path"
                     tail --follow=name "$filepath" >"/export$filepath" &
                   fi

--- a/packages/log-collector.yaml
+++ b/packages/log-collector.yaml
@@ -25,7 +25,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: log-collector
-          image: docker.io/ubuntu:oracular # TODO(miampf): Replace with non docker.io image
+          image: "ghcr.io/miampf/k8s-log-collector:latest"
           volumeMounts:
             - mountPath: /logs
               name: log-volume
@@ -35,28 +35,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          command:
-            - /usr/bin/bash
-            - -c
-            - |
-              mkdir /export
-              # TODO(miampf): Prepare an image that already has required tools installed
-              apt-get update && apt-get install -y inotify-tools
-              # collect all logs that may have been missed during startup
-              for file in $(find /logs -name *.log); do
-                if [[ -f "$file" && "$file" == *"$POD_NAMESPACE"* ]]; then
-                  mkdir -p "/export$(dirname "$file")"
-                  cp "$file" "/export$file"
-                fi
-              done
-              inotifywait -m /logs -r -e create -e moved_to |
-                while read path action file; do
-                  filepath="$path$file"
-                  if [[ -f "$filepath" && "$filepath" == *"$POD_NAMESPACE"* ]]; then
-                    mkdir -p "/export$path"
-                    tail --follow=name "$filepath" >"/export$filepath" &
-                  fi
-                done
       volumes:
         - name: log-volume
           # mount the nodes logs to the container

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -431,6 +431,7 @@
       kubectl
     ];
     text = ''
+      set -euo pipefail
       while ! [[ -s "$1" ]]; do
         sleep 1
       done

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -437,7 +437,6 @@
       cp ./packages/log-collector.yaml ./workspace/log-collector.yaml
       sed -i "s/@@NAMESPACE@@/''${namespace}/g" ./workspace/log-collector.yaml
 
-      kubectl get namespace | grep -q "^$namespace" || kubectl create namespace "$namespace"
       kubectl apply -f ./workspace/log-collector.yaml
     '';
   };

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -427,7 +427,7 @@
   # Usage: get-logs $namespaceFile
   get-logs = writeShellApplication {
     name = "get-logs";
-    runtimeInputs = with pkgs; [ 
+    runtimeInputs = with pkgs; [
       kubectl
     ];
     text = ''

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -429,7 +429,6 @@
     name = "get-logs";
     runtimeInputs = with pkgs; [ 
       kubectl
-      ncompress
     ];
     text = ''
       while ! [[ -s "$1" ]]; do
@@ -455,7 +454,6 @@
         kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz #1>/dev/null 2>/dev/null
         echo "DEBUG: downloaded archive"
         tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs #1>/dev/null 2>/dev/null
-        find ./workspace/logs -type f -exec bash -c compress -d {} \;
         echo "DEBUG: extracted archive"
         sleep 3
       done

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -433,17 +433,12 @@
     text = ''
       set -euo pipefail
 
-      if [[ -z "''${1-}" ]]; then
+      if [[ $# -lt 2 ]]; then
         echo "Usage: get-logs [start | download] namespaceFile"
         exit 1
       fi
       case $1 in
       start)
-        if [[ -z "''${2-}" ]]; then
-          echo "Please add the path to the namespace file."
-          echo "Usage: get-logs start namespaceFile"
-          exit 1
-        fi
         while ! [[ -s "$2" ]]; do
           sleep 1
         done
@@ -453,11 +448,6 @@
         kubectl apply -f ./workspace/log-collector.yaml 1>/dev/null 2>/dev/null
         ;;
       download)
-        if [[ -z "''${2-}" ]]; then
-          echo "Please add the path to the namespace file."
-          echo "Usage: get-logs download namespaceFile"
-          exit 1
-        fi
         namespace="$(head -n1 "$2")"
         pod="$(kubectl get pods -o name -n "$namespace" | grep log-collector | cut -c 5-)"
         mkdir -p ./workspace/logs

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -447,7 +447,7 @@
       kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod" 1>/dev/null 2>/dev/null
       # Download and extract the logs every 3 seconds
       while true; do
-        kubectl exec -n "$namespace" "$pod" -- bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export" 1>/dev/null 2>/dev/null
+        kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export" 1>/dev/null 2>/dev/null
         rm -f ./workspace/logs/exported-logs.tar.gz
         kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz 1>/dev/null 2>/dev/null
         tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs 1>/dev/null 2>/dev/null

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -443,7 +443,6 @@
       kubectl apply -f ./workspace/log-collector.yaml 1>/dev/null 2>/dev/null
 
       pod="$(kubectl get pods -o name -n "$namespace" | grep log-collector | cut -c 5-)"
-      echo "$pod"
       mkdir -p ./workspace/logs
       kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod" 1>/dev/null 2>/dev/null
       # Download and extract the logs every 3 seconds

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -439,22 +439,18 @@
       cp ./packages/log-collector.yaml ./workspace/log-collector.yaml
       sed -i "s/@@NAMESPACE@@/''${namespace}/g" ./workspace/log-collector.yaml
 
-      kubectl apply -f ./workspace/log-collector.yaml
+      kubectl apply -f ./workspace/log-collector.yaml 1>/dev/null 2>/dev/null
 
       pod="$(kubectl get pods -o name -n "$namespace" | grep log-collector | cut -c 5-)"
       echo "$pod"
       mkdir -p ./workspace/logs
-      kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod" #1>/dev/null 2>/dev/null
-      echo "DEBUG: Pod $pod running"
+      kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod" 1>/dev/null 2>/dev/null
       # Download and extract the logs every 3 seconds
       while true; do
-        kubectl exec -n "$namespace" "$pod" -- bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export" #1>/dev/null 2>/dev/null
-        echo "DEBUG: compressed archive"
+        kubectl exec -n "$namespace" "$pod" -- bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export" 1>/dev/null 2>/dev/null
         rm -f ./workspace/logs/exported-logs.tar.gz
-        kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz #1>/dev/null 2>/dev/null
-        echo "DEBUG: downloaded archive"
-        tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs #1>/dev/null 2>/dev/null
-        echo "DEBUG: extracted archive"
+        kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz 1>/dev/null 2>/dev/null
+        tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs 1>/dev/null 2>/dev/null
         sleep 3
       done
     '';


### PR DESCRIPTION
Improve the log collection to also collect init container logs. This is done by adding a `log-collector` daemon set to every e2e cluster that saves logs from the host node which then are downloaded to the local machine through the updated `get-logs` script.