### PR TITLE
packages/nixos: add IMDS setup script

### DIFF
--- a/packages/by-name/cloud-api-adaptor/package.nix
+++ b/packages/by-name/cloud-api-adaptor/package.nix
@@ -10,6 +10,9 @@
   writeShellApplication,
   gnugrep,
   iptables,
+  iproute2,
+  sysctl,
+  gawk,
   runCommand,
   applyPatches,
   makeWrapper,
@@ -101,6 +104,22 @@ buildGoModule rec {
         "SC2086"
         "SC2153"
       ];
+    };
+
+    setup-nat-for-imds = writeShellApplication {
+      name = "setup-nat-for-imds";
+      runtimeInputs = [
+        iproute2
+        iptables
+        sysctl
+        gawk
+      ];
+      # TODO(burgerdev): generalize for all link-local IPs and investigate routing simplification
+      text = builtins.readFile "${cloud-api-adaptor.src}/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh";
+      meta = {
+        mainProgram = "setup-nat-for-imds";
+        homepage = "https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh";
+      };
     };
   };
 

--- a/packages/nixos/azure.nix
+++ b/packages/nixos/azure.nix
@@ -85,5 +85,25 @@ in
         ExecStart = "${lib.getExe pkgs.azure-no-agent}";
       };
     };
+
+    systemd.services.setup-nat-for-imds = {
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "netns@podns.service" ];
+      wants = [ "network-online.target" ];
+      after = [
+        "network-online.target"
+        "netns@podns.service"
+      ];
+      description = "Setup NAT for IMDS";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = "yes";
+        # TODO(msanft): Find out why just ordering this after network-online.target
+        # isn't sufficient. (Errors with saying that the network is unreachable)
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStart = "${lib.getExe pkgs.cloud-api-adaptor.setup-nat-for-imds}";
+      };
+    };
   };
 }


### PR DESCRIPTION
Azure needs special care for enabling IMDS within Peerpods. This adds a script to setup IMDS through Proxy ARP (from Peerpods upstream, see https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh), so that all requests to the IMDS from within the pod are routed through an interface that is peered to the Pod VM. Verified to work in 2 distinct Azure peer pods.

It also makes a simplification by excluding `basic.target` in the `wantedBy` list of the Azure readiness report, as it's already contained in the [default dependencies](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Default%20Dependencies).