### PR TITLE
ci: clean up images more often

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -3,7 +3,7 @@ name: push cleanup-bare-metal image
 on:
   pull_request:
     paths:
-      - .github/workflows/cleaup.yml
+      - .github/workflows/cleanup.yml
       - packages/**
 
 env:

--- a/tools/bm-maintenance/deployment_tdx_snp.yml
+++ b/tools/bm-maintenance/deployment_tdx_snp.yml
@@ -39,7 +39,7 @@ kind: CronJob
 metadata:
   name: cleanup-maintenance
 spec:
-  schedule: "0 0 * * 0"
+  schedule: "0 2 * * *" # 2 AM every day
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
We had a lot of e2e regression failures because of pulling the same image with different snapshotters. This PR increases the run frequency of the cleanup job to daily, which should ensure we're running it before the weekly, and not only after.