### PR TITLE
scripts: add publisher info for peer pods image

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -133,6 +133,10 @@
         sharedImageGallery = "contrast_images"
         sharingProfile = "community"
         sharingNamePrefix = "Contrast"
+        publisher = "edgelesssys"
+        offer = "contrast"
+        sku = "peer-pods"
+
         replicationRegions = ["northeurope", "westeurope", "eastus", "westus"]
         EOF
 


### PR DESCRIPTION
The current (default) info is 
"Contoso :: Linux :: contrast-1"

change that to

"edgelesssys :: contrast :: peer-pods"