### PR TITLE
github: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: File a bug report to help us improve
+labels: ["bug", "needs: assignee"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ####
+        Please take a look at the [Troubleshooting Documentation](https://docs.edgeless.systems/contrast/troubleshooting) before reporting a bug.
+        Further please ensure that the provided CLI logs are configured with the `--log-level` command-line flag set to `debug`.
+
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: version
+    attributes:
+      label: Contrast version
+      description: "In which version do you encounter this bug? (first line of output of `contrast --version`) If you are building an unreleased version of Contrast, please additionally provide the latest Github commit hash to allow us to determine your current project state!"
+      placeholder: "v0.0.0"
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Deployment platform
+      description: "On which platform do you encounter this bug?"
+      placeholder: "AKS-CLH-SNP"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Issue description + logs
+      description: A concise description of what you're experiencing. Please upload the logs of CLI(with `--log-level debug`), Coordinator or other components as file.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce the behavior
+      description: Please provide a step-by-step guide on how to reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Having questions or an idea to discuss?
+    url: https://github.com/edgelesssys/contrast/discussions/new?category=q-a
+    about: Open a discussion instead! We will be happy to help you.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest an idea for this project
+body:
+  - type: textarea
+    attributes:
+      label: Use case
+      description: A concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe your solution
+      description: In case you have an idea how to implement this feature.
+  - type: checkboxes
+    attributes:
+      label: Would you be willing to implement this feature?
+      options:
+        - label: Yes, I could contribute this feature.


### PR DESCRIPTION
Add 3 Github issue templates for:

1.  opening bug reports
2.  feature request 
3.  Q&A redirect