### PR TITLE
scripts: use coordinator rules/settings for bare metal

### DIFF
--- a/packages/by-name/kata/genpolicy/genpolicy_rules_coordinator.patch
+++ b/packages/by-name/kata/genpolicy/genpolicy_rules_coordinator.patch
@@ -1,8 +1,8 @@
 diff --git a/genpolicy-rules.rego b/genpolicy-rules.rego
-index c3eb334..a796740 100644
+index 823e5e76d55bac47ad9c79d8916f92702efa316d..e3acc09dd931fd8d028eadf356679a97dfa4e633 100644
 --- a/genpolicy-rules.rego
 +++ b/genpolicy-rules.rego
-@@ -164,9 +164,9 @@ allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, s_name) {
+@@ -199,9 +199,9 @@ allow_by_sandbox_name(p_container, i_oci, i_storages, s_name) {
      p_namespace := p_oci.Annotations[s_namespace]
      i_namespace := i_oci.Annotations[s_namespace]
      print("allow_by_sandbox_name: p_namespace =", p_namespace, "i_namespace =", i_namespace)
@@ -11,5 +11,5 @@ index c3eb334..a796740 100644
 
 -    allow_by_container_types(p_oci, i_oci, s_name, p_namespace)
 +    allow_by_container_types(p_oci, i_oci, s_name, i_namespace)
-     allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages)
+     allow_by_bundle_or_sandbox_id(p_container, i_oci, i_storages)
      allow_process(p_oci, i_oci, s_name)

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -254,8 +254,8 @@
           ${pkgs.microsoft.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"
         ;;
         "k3s-qemu-snp"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
-          cp ${pkgs.kata.genpolicy.rules}/genpolicy-rules.rego rules.rego
-          cp ${pkgs.kata.genpolicy.settings}/genpolicy-settings.json .
+          cp ${pkgs.kata.genpolicy.rules-coordinator}/genpolicy-rules.rego rules.rego
+          cp ${pkgs.kata.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.kata.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"
         ;;
         *)


### PR DESCRIPTION
This fixes a bug where we would publish a coordinator deployment with a policy that can only be deployed in the default namespace.

Bug found by @3u13r 