### PR TITLE
[release/v1.1] node-installer: remove resource limits

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -54,7 +54,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		WithName("tardev-snapshotter").
 		WithImage("ghcr.io/edgelesssys/contrast/tardev-snapshotter:latest").
 		WithResources(ResourceRequirements().
-			WithMemoryLimitAndRequest(800),
+			WithMemoryRequest(800),
 		).
 		WithVolumeMounts(
 			VolumeMount().
@@ -86,7 +86,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		WithName("nydus-snapshotter").
 		WithImage("ghcr.io/edgelesssys/contrast/nydus-snapshotter:latest").
 		WithResources(ResourceRequirements().
-			WithMemoryLimitAndRequest(800),
+			WithMemoryRequest(800),
 		).
 		WithVolumeMounts(
 			VolumeMount().
@@ -158,7 +158,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 						WithName("installer").
 						WithImage(nodeInstallerImageURL).
 						WithResources(ResourceRequirements().
-							WithMemoryLimitAndRequest(100),
+							WithMemoryRequest(700),
 						).
 						WithSecurityContext(SecurityContext().WithPrivileged(true).SecurityContextApplyConfiguration).
 						WithVolumeMounts(VolumeMount().


### PR DESCRIPTION
There's no strong reason for having resource limits on the node-installer and given the unpredictable nature of the kernel's resource accounting, we should remove the resource limits so that we don't run into unexpected OOMs.

Fixes f5da52d

(cherry picked from commit 7f50e0cc566e630bc30775e44b0a42c31b924360)