### PR TITLE
go.work: update go version

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,4 @@
-go 1.22.0
-
-toolchain go1.22.2
+go 1.22.7
 
 use (
 	.


### PR DESCRIPTION
This was missed in https://github.com/edgelesssys/contrast/commit/d1ea612a5024e7e39f4950cb3317fbe26e7b37a8.