### PR TITLE
caa: upgrade to v0.10.0

### DIFF
--- a/infra/azure-peerpods/main.tf
+++ b/infra/azure-peerpods/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_virtual_network" "main" {
 resource "azurerm_kubernetes_cluster" "cluster" {
   name                      = "${local.name}_aks"
   resource_group_name       = data.azurerm_resource_group.rg.name
-  node_resource_group       = "${var.resource_group}_aks_node_rg"
+  node_resource_group       = "${local.name}_aks_node_rg"
   location                  = data.azurerm_resource_group.rg.location
   dns_prefix                = "aks"
   oidc_issuer_enabled       = true

--- a/packages/by-name/cloud-api-adaptor/0001-netops-replace-routes-instead-of-adding-them.patch
+++ b/packages/by-name/cloud-api-adaptor/0001-netops-replace-routes-instead-of-adding-them.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Tue, 19 Nov 2024 18:00:47 +0100
+Subject: [PATCH] netops: replace routes instead of adding them
+
+Some systems create a route if an IP address with prefix mask is added
+to an interface. If this route is then also copied from the worker node,
+a conflict may occur.
+
+A simple fix is to replace the route instead of adding it. The behaviour
+is the same when the route does not exist. When it exists, we are either
+setting the same route again, or overriding a route that's not desirable
+in the first place.
+---
+ src/cloud-api-adaptor/pkg/util/netops/netops.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cloud-api-adaptor/pkg/util/netops/netops.go b/src/cloud-api-adaptor/pkg/util/netops/netops.go
+index 6a761dfef10fcf127ab914ebf0b759e76add3435..f0eaea5713c4a92479eed6a4ca46ff7b4abfe3c5 100644
+--- a/src/cloud-api-adaptor/pkg/util/netops/netops.go
++++ b/src/cloud-api-adaptor/pkg/util/netops/netops.go
+@@ -623,7 +623,7 @@ func (ns *namespace) RouteAdd(route *Route) error {
+ 	if !route.Gateway.IsValid() {
+ 		nlRoute.Scope = netlink.SCOPE_LINK
+ 	}
+-	if err := ns.handle.RouteAdd(nlRoute); err != nil {
++	if err := ns.handle.RouteReplace(nlRoute); err != nil {
+ 		return fmt.Errorf("failed to create a route (table: %d, dest: %s, gw: %s) with flags %d: %w", nlRoute.Table, nlRoute.Dst.String(), nlRoute.Gw.String(), nlRoute.Flags, err)
+ 	}
+ 	return nil


### PR DESCRIPTION
Changes to the network configuration of Azure pod VMs require a NAT gateway in the subnet. Having that is desirable anyway, because default outbound access is deprecated and scheduled for removal in 2025.

Side note: this bumps peer-pods Kata to 3.9.0, which should make it easier to integrate CAA into the node-installer.