### PR TITLE
e2e: don't require e2e on unrelated PRs

### DIFF
--- a/.github/workflows/e2e_openssl.yml
+++ b/.github/workflows/e2e_openssl.yml
@@ -2,12 +2,17 @@ name: e2e test
 
 on:
   pull_request:
-    paths-ignore:
-      - dev-docs/**
-      - docs/**
-      - rfc/**
-      - tools/asciinema/**
-      - tools/vale/**
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/actions/setup_nix.yml"
+      - ".github/workflows/e2e.yml"
+      - ".github/workflows/e2e_openssl.yml"
+      - "!dev-docs/**"
+      - "!docs/**"
+      - "!rfc/**"
+      - "!tools/asciinema/**"
+      - "!tools/vale/**"
 
 jobs:
   test_matrix:


### PR DESCRIPTION
We run e2e tests with a `pull_request` trigger and an explicit list of ignored paths. This makes it tedious to work on code that can't be excluded easily, like other workflows that don't touch e2e.

Moving to a mix of included and excluded paths should fix this issue. In particular, this commit is intended to trigger e2e on PRs that touch anything that's not in the existing ignorelist and not an unrelated Github workflow.