### PR TITLE
kata: support large ConfigMaps

### DIFF
--- a/e2e/regression/testdata/nginx.yml
+++ b/e2e/regression/testdata/nginx.yml
@@ -18,4 +18,32 @@ spec:
           image: ghcr.io/edgelesssys/nginx-unprivileged@sha256:1d5be2aa3c296bd589ddd3c9bf2f560919e31ac32bae799a15dd182b6fdb042b
           ports:
             - containerPort: 8080
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+      volumes:
+        - name: html
+          configMap:
+            name: nginx-html
       runtimeClassName: contrast-cc
+---
+# This ConfigMap is a regression test to verify that a large number of entries can be mounted to
+# a Contrast app.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-html
+  namespace: "@@REPLACE_NAMESPACE@@"
+data:
+  index.html: |
+    <h1>Hello World</h1>
+  1.html: ""
+  2.html: ""
+  3.html: ""
+  4.html: ""
+  5.html: ""
+  6.html: ""
+  7.html: ""
+  8.html: ""
+  9.html: ""

--- a/packages/by-name/kata/kata-runtime/0019-genpolicy-allow-non-watchable-ConfigMaps.patch
+++ b/packages/by-name/kata/kata-runtime/0019-genpolicy-allow-non-watchable-ConfigMaps.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Thu, 21 Nov 2024 19:54:09 +0100
+Subject: [PATCH] genpolicy: allow non-watchable ConfigMaps
+
+If a ConfigMap has more than 8 files it will not be mounted watchable
+[1]. However, genpolicy assumes that ConfigMaps are always mounted at a
+watchable path, so containers with large ConfigMap mounts fail
+verification.
+
+This commit allows mounting ConfigMaps from watchable and non-watchable
+directories. ConfigMap mounts can't be meaningfully verified anyway, so
+the exact location of the data does not matter, except that we stay in
+the sandbox data dirs.
+
+[1]: https://github.com/kata-containers/kata-containers/blob/0ce3f5fc6fd86c53d8b5e197d12887b712ce57d4/docs/design/inotify.md?plain=1#L11-L21
+
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/tools/genpolicy/genpolicy-settings.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
+index ef20413eacc029d4fcb0b1d2f538a13314a25670..a218a4d9c4717e4dd2abdc3fd4b0d1a6d8171661 100644
+--- a/src/tools/genpolicy/genpolicy-settings.json
++++ b/src/tools/genpolicy/genpolicy-settings.json
+@@ -179,7 +179,7 @@
+         "configMap": {
+             "mount_type": "bind",
+             "mount_source": "$(sfprefix)",
+-            "mount_point": "^$(cpath)/watchable/$(bundle-id)-[a-z0-9]{16}-",
++            "mount_point": "^$(cpath)/(watchable/)?$(bundle-id)-[a-z0-9]{16}-",
+             "driver": "watchable-bind",
+             "fstype": "bind",
+             "options": [

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -107,6 +107,13 @@ buildGoModule rec {
       # This avoids printing the entire annotation on log level debug, which resulted in errors of the logtranslator.go
       # TODO(jmxnzo): remove when upstream patch is merged: https://github.com/kata-containers/kata-containers/pull/10647
       ./0018-genpolicy-do-not-log-policy-annotation-in-debug.patch
+
+      # Fixes a bug with ConfigMaps exceeding 8 entries, see description.
+      # The situation upstream is complicated, because the paths relevant for genpolicy differ
+      # between different CI systems and TEE configurations. This makes it hard to reproduce in a
+      # vanilla Kata setting.
+      # Relevant discussion: https://github.com/kata-containers/kata-containers/pull/10614.
+      ./0019-genpolicy-allow-non-watchable-ConfigMaps.patch
     ];
   };
 


### PR DESCRIPTION
Small ConfigMaps are mounted watchable, but large ones are not. We do not really care enough about the exact mount source, since it's provided by the host anyway, so we allow mounting from watchable and non-watchable spaces.