### PR TITLE
ci: descriptive names for tests

### DIFF
--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -1,4 +1,4 @@
-name: e2e test
+name: e2e test manual
 
 on:
   workflow_dispatch:

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -1,4 +1,4 @@
-name: e2e test
+name: e2e test nightly
 
 on:
   schedule:

--- a/.github/workflows/e2e_on_pull_request.yml
+++ b/.github/workflows/e2e_on_pull_request.yml
@@ -1,4 +1,4 @@
-name: e2e test
+name: e2e test PR
 
 on:
   pull_request:

--- a/.github/workflows/e2e_service_mesh.yml
+++ b/.github/workflows/e2e_service_mesh.yml
@@ -1,4 +1,4 @@
-name: e2e test
+name: e2e test service mesh
 
 on:
   pull_request:


### PR DESCRIPTION
Our actions tab has a lot of workflows called `e2e test`, making it hard to navigate. 

* Make the names more descriptive.
* Rename the openssl test so that the intent (execute on PR) is clear.