### PR TITLE
packages/kata-debug-shell: fix templating

### DIFF
--- a/packages/kata-debug-shell.sh
+++ b/packages/kata-debug-shell.sh
@@ -20,6 +20,6 @@ sbx_id=$(echo "$container_info" | jq -r '.Spec.annotations."io.kubernetes.cri.sa
 runtime_class_name=$(echo "$container_info" | jq -r '.Snapshotter' | cut -c7-)
 
 kata_runtime="/opt/edgeless/${runtime_class_name}/bin/kata-runtime"
-config_file=/opt/edgeless/${runtime_class_name}/etc/configuration-*.toml
+config_file=$(ls -1 /opt/edgeless/${runtime_class_name}/etc/configuration-*.toml)
 
-${kata_runtime} --config "/opt/edgeless/${runtime_class_name}/etc/${config_file}" exec ${sbx_id}
+${kata_runtime} --config "${config_file}" exec ${sbx_id}


### PR DESCRIPTION
bash doesn't perform expansion in variables, thus the `*` in `config_file` wasn't expanded correctly (i.e. at all). Go back to the `ls -1` approach, which fixes that. Also, don't template the config path into another path, which is redundant and fails, as it's an absolute path already.