### PR TITLE
kata: remove rustc from agent closure

### DIFF
--- a/packages/by-name/kata/kata-agent/package.nix
+++ b/packages/by-name/kata/kata-agent/package.nix
@@ -64,6 +64,13 @@ rustPlatform.buildRustPackage rec {
     chmod -R +w ../..
   '';
 
+  # https://crates.io/crates/sev produces libsev.so, which is not needed for
+  # the agent binary and pulls in a large dependency on rustc. Thus, we remove
+  # it from the output.
+  postInstall = ''
+    rm -rf $out/lib
+  '';
+
   buildFeatures =
     lib.optional withSeccomp "seccomp"
     ++ lib.optional withAgentPolicy "agent-policy"


### PR DESCRIPTION
The `sev` crate specifies a crate type of `dylib`, which results in a libsev.so library in the output of makeRustPackage. The library is intended for use under FFI (i.e., from C) and not necessary for the agent binary.

Removing the library sheds some 800MiB of rustc from the agent's closure and reduces the podvm-image size by 1.4GiB.

```
$ nix-store --query --size /nix/store/aw6s09mwmbifnxbm6587kgwm46jgmaa6-image-podvm-gpu-1-rc1 # before
2694330064
$ nix-store --query --size /nix/store/z14q27diajh5x3iqkbckcnvp6gb7bkr7-image-podvm-gpu-1-rc1 # after
1264297680
```