### PR TITLE
nixos-img: disable patchelf on executable-marked OS image

### DIFF
--- a/packages/by-name/buildVerityUKI/package.nix
+++ b/packages/by-name/buildVerityUKI/package.nix
@@ -24,4 +24,5 @@ nixos-config:
       realRoothash=$(${lib.getExe jq} -r "[.[] | select(.roothash != null)] | .[0].roothash" $out/repart-output.json)
       sed -i "0,/${roothashPlaceholder}/ s/${roothashPlaceholder}/$realRoothash/" $out/${oldAttrs.pname}_${oldAttrs.version}.raw
     '';
+    dontPatchELF = true;
   })

--- a/packages/by-name/kata/kata-image/package.nix
+++ b/packages/by-name/kata/kata-image/package.nix
@@ -67,6 +67,7 @@ let
       '';
 
     dontInstall = true;
+    dontPatchELF = true;
   };
   packageIndex = builtins.fromJSON (builtins.readFile ./package-index.json);
   rpmSources = lib.forEach packageIndex (
@@ -95,6 +96,7 @@ let
 
       runHook postBuild
     '';
+    dontPatchELF = true;
   };
 
   tdnfConf = writeText "tdnf.conf" ''
@@ -239,6 +241,7 @@ let
         in
         "dm-mod.create=\"dm-verity,,,ro,0 ${toString dataSectors} verity 1 /dev/vda1 /dev/vda2 ${dataBlockSize} ${hashBlockSize} ${dataBlocks} 0 sha256 ${rootHash} ${salt}\" root=/dev/dm-0";
     };
+    dontPatchELF = true;
   };
 in
 kata-image

--- a/packages/by-name/microsoft/kata-igvm/package.nix
+++ b/packages/by-name/microsoft/kata-igvm/package.nix
@@ -57,6 +57,8 @@ let
       '';
     };
 
+    dontPatchELF = true;
+
     meta = {
       description = "The Contrast runtime IGVM file defines the initial state of a pod-VM.";
       license = lib.licenses.asl20;

--- a/packages/by-name/microsoft/kata-image/package.nix
+++ b/packages/by-name/microsoft/kata-image/package.nix
@@ -54,8 +54,8 @@ let
 
       runHook postBuild
     '';
-
     dontInstall = true;
+    dontPatchELF = true;
   };
   packageIndex = builtins.fromJSON (builtins.readFile ./package-index.json);
   rpmSources = lib.forEach packageIndex (
@@ -84,6 +84,7 @@ let
 
       runHook postBuild
     '';
+    dontPatchELF = true;
   };
 
   tdnfConf = writeText "tdnf.conf" ''
@@ -198,4 +199,5 @@ stdenv.mkDerivation rec {
     rm -rf $out
     mv /build/raw.img $out
   '';
+  dontPatchELF = true;
 }


### PR DESCRIPTION
Prior, we tried to run `patchelf` (automatically, due to the Nix stdenv) on the executable-marked OS image. This is not necessary and costs a considerable investment of time. The PR excludes the automatic patchelf hook from the build.