### PR TITLE
sdk: remove Linux dependencies

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/issuer"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/meshapi"
@@ -154,7 +155,7 @@ func newServerMetrics(reg *prometheus.Registry) *grpcprometheus.ServerMetrics {
 }
 
 func newGRPCServer(serverMetrics *grpcprometheus.ServerMetrics, log *slog.Logger) (*grpc.Server, error) {
-	issuer, err := atls.PlatformIssuer(log)
+	issuer, err := issuer.PlatformIssuer(log)
 	if err != nil {
 		return nil, fmt.Errorf("creating issuer: %w", err)
 	}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -155,7 +155,7 @@ func newServerMetrics(reg *prometheus.Registry) *grpcprometheus.ServerMetrics {
 }
 
 func newGRPCServer(serverMetrics *grpcprometheus.ServerMetrics, log *slog.Logger) (*grpc.Server, error) {
-	issuer, err := issuer.PlatformIssuer(log)
+	issuer, err := issuer.New(log)
 	if err != nil {
 		return nil, fmt.Errorf("creating issuer: %w", err)
 	}

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -56,7 +56,7 @@ func run() (retErr error) {
 		return fmt.Errorf("generating key: %w", err)
 	}
 
-	issuer, err := issuer.PlatformIssuer(log)
+	issuer, err := issuer.New(log)
 	if err != nil {
 		return fmt.Errorf("creating issuer: %w", err)
 	}

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/issuer"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/meshapi"
@@ -55,7 +56,7 @@ func run() (retErr error) {
 		return fmt.Errorf("generating key: %w", err)
 	}
 
-	issuer, err := atls.PlatformIssuer(log)
+	issuer, err := issuer.PlatformIssuer(log)
 	if err != nil {
 		return fmt.Errorf("creating issuer: %w", err)
 	}

--- a/internal/atls/issuer/issuer.go
+++ b/internal/atls/issuer/issuer.go
@@ -1,14 +1,16 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package atls
+package issuer
 
 import (
+	"context"
+	"encoding/asn1"
 	"fmt"
 	"log/slog"
 
-	"github.com/edgelesssys/contrast/internal/attestation/snp"
-	"github.com/edgelesssys/contrast/internal/attestation/tdx"
+	snpissuer "github.com/edgelesssys/contrast/internal/attestation/snp/issuer"
+	tdxissuer "github.com/edgelesssys/contrast/internal/attestation/tdx/issuer"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/klauspost/cpuid/v2"
 )
@@ -18,14 +20,25 @@ func PlatformIssuer(log *slog.Logger) (Issuer, error) {
 	cpuid.Detect()
 	switch {
 	case cpuid.CPU.Supports(cpuid.SEV_SNP):
-		return snp.NewIssuer(
+		return snpissuer.New(
 			logger.NewWithAttrs(logger.NewNamed(log, "issuer"), map[string]string{"tee-type": "snp"}),
 		), nil
 	case cpuid.CPU.Supports(cpuid.TDX_GUEST):
-		return tdx.NewIssuer(
+		return tdxissuer.New(
 			logger.NewWithAttrs(logger.NewNamed(log, "issuer"), map[string]string{"tee-type": "tdx"}),
 		), nil
 	default:
 		return nil, fmt.Errorf("unsupported platform: %T", cpuid.CPU)
 	}
+}
+
+// Issuer issues an attestation document.
+type Issuer interface {
+	Getter
+	Issue(ctx context.Context, userData []byte, nonce []byte) (quote []byte, err error)
+}
+
+// Getter returns an ASN.1 Object Identifier.
+type Getter interface {
+	OID() asn1.ObjectIdentifier
 }

--- a/internal/atls/issuer/issuer.go
+++ b/internal/atls/issuer/issuer.go
@@ -15,8 +15,8 @@ import (
 	"github.com/klauspost/cpuid/v2"
 )
 
-// PlatformIssuer creates an attestation issuer for the current platform.
-func PlatformIssuer(log *slog.Logger) (Issuer, error) {
+// New creates an attestation issuer for the current platform.
+func New(log *slog.Logger) (Issuer, error) {
 	cpuid.Detect()
 	switch {
 	case cpuid.CPU.Supports(cpuid.SEV_SNP):

--- a/internal/atls/issuer/issuer_linux.go
+++ b/internal/atls/issuer/issuer_linux.go
@@ -1,7 +1,7 @@
-//go:build linux
-
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build linux
 
 package issuer
 

--- a/internal/atls/issuer/issuer_linux.go
+++ b/internal/atls/issuer/issuer_linux.go
@@ -1,14 +1,15 @@
+//go:build linux
+
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
 package issuer
 
 import (
-	"context"
-	"encoding/asn1"
 	"fmt"
 	"log/slog"
 
+	"github.com/edgelesssys/contrast/internal/atls"
 	snpissuer "github.com/edgelesssys/contrast/internal/attestation/snp/issuer"
 	tdxissuer "github.com/edgelesssys/contrast/internal/attestation/tdx/issuer"
 	"github.com/edgelesssys/contrast/internal/logger"
@@ -16,7 +17,7 @@ import (
 )
 
 // New creates an attestation issuer for the current platform.
-func New(log *slog.Logger) (Issuer, error) {
+func New(log *slog.Logger) (atls.Issuer, error) {
 	cpuid.Detect()
 	switch {
 	case cpuid.CPU.Supports(cpuid.SEV_SNP):
@@ -30,15 +31,4 @@ func New(log *slog.Logger) (Issuer, error) {
 	default:
 		return nil, fmt.Errorf("unsupported platform: %T", cpuid.CPU)
 	}
-}
-
-// Issuer issues an attestation document.
-type Issuer interface {
-	Getter
-	Issue(ctx context.Context, userData []byte, nonce []byte) (quote []byte, err error)
-}
-
-// Getter returns an ASN.1 Object Identifier.
-type Getter interface {
-	OID() asn1.ObjectIdentifier
 }

--- a/internal/atls/issuer/issuer_universal.go
+++ b/internal/atls/issuer/issuer_universal.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package issuer
+
+import (
+	"log/slog"
+
+	"github.com/edgelesssys/contrast/internal/atls"
+)
+
+// New creates an attestation issuer for the current platform.
+func New(_ *slog.Logger) (atls.Issuer, error) {
+	panic("issuing is only supported on Linux")
+}

--- a/internal/atls/issuer/issuer_universal.go
+++ b/internal/atls/issuer/issuer_universal.go
@@ -1,7 +1,7 @@
-//go:build !linux
-
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !linux
 
 package issuer
 

--- a/internal/attestation/snp/issuer/issuer.go
+++ b/internal/attestation/snp/issuer/issuer.go
@@ -1,7 +1,8 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package snp
+// package issuer provides functions to create an aTLS issuer.
+package issuer
 
 import (
 	"context"
@@ -27,8 +28,8 @@ type Issuer struct {
 	logger     *slog.Logger
 }
 
-// NewIssuer returns a new Issuer.
-func NewIssuer(log *slog.Logger) *Issuer {
+// New returns a new Issuer.
+func New(log *slog.Logger) *Issuer {
 	return &Issuer{
 		thimGetter: NewTHIMGetter(http.DefaultClient),
 		logger:     log,

--- a/internal/attestation/snp/issuer/issuer.go
+++ b/internal/attestation/snp/issuer/issuer.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/internal/attestation/snp/issuer/issuer.go
+++ b/internal/attestation/snp/issuer/issuer.go
@@ -1,7 +1,7 @@
-//go:build linux
-
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build linux
 
 // package issuer provides functions to create an aTLS issuer.
 package issuer

--- a/internal/attestation/snp/issuer/thim.go
+++ b/internal/attestation/snp/issuer/thim.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package snp
+package issuer
 
 import (
 	"encoding/json"

--- a/internal/attestation/tdx/issuer/issuer.go
+++ b/internal/attestation/tdx/issuer/issuer.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package tdx
+package issuer
 
 import (
 	"context"
@@ -23,8 +23,8 @@ type Issuer struct {
 	logger *slog.Logger
 }
 
-// NewIssuer returns a new Issuer.
-func NewIssuer(log *slog.Logger) *Issuer {
+// New returns a new Issuer.
+func New(log *slog.Logger) *Issuer {
 	return &Issuer{
 		logger: log,
 	}


### PR DESCRIPTION
## Context

It is currently not possible to build the SDK / CLI on platforms other than Linux. One of the issues is that the imported packages include Linux specific code.

These components don't require it, so they shouldn't depend on it to allow for cross-platform usage.

[AB#4959](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4959)

## Proposed changes
- move the issuer code into its own sub-package
- only let the components that require it (coordinator and initializer) import the issuer package