### PR TITLE
caa: support peerpods in node-installer (again)

### DIFF
--- a/.github/workflows/e2e_peerpods.yml
+++ b/.github/workflows/e2e_peerpods.yml
@@ -18,8 +18,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/setup_nix
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +43,9 @@ jobs:
           azure_image_id: ${{ inputs.image-id }}
           azure_resource_group: contrast-ci
           azure_location: germanywestcentral
+          container_registry: ghcr.io/edgelesssys
           CONTRAST_CACHE_DIR: "./workspace.cache"
+          DO_NOT_TRACK: 1
         run: |
           ssh-keygen -t rsa -f ./infra/azure-peerpods/id_rsa -N ""
           cat >infra/azure-peerpods/iam.auto.tfvars <<EOF

--- a/.github/workflows/e2e_peerpods.yml
+++ b/.github/workflows/e2e_peerpods.yml
@@ -6,6 +6,11 @@ on:
       image-id:
         description: "ID of the guest VM image to test (default: build a fresh image)"
         required: false
+      skip-undeploy:
+        description: "Skip undeploy"
+        required: false
+        type: boolean
+        default: false
   pull_request:
     paths:
       - .github/workflows/e2e_peerpods.yml
@@ -56,6 +61,6 @@ jobs:
           EOF
           nix run .#scripts.test-peerpods
       - name: Terminate cluster
-        if: always()
+        if: always() && !inputs.skip-undeploy
         run: |
           nix run -L .#terraform -- -chdir=infra/azure-peerpods destroy --auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ terraform.tfstate*
 id_rsa*
 kube.conf
 out.env
+infra/**/peer-pods-config.yaml
 infra/**/kustomization.yaml
 uplosi.conf*

--- a/cli/genpolicy/config.go
+++ b/cli/genpolicy/config.go
@@ -43,7 +43,7 @@ func NewConfig(platform platforms.Platform) *Config {
 			Settings: aksSettings,
 			Bin:      aksGenpolicyBin,
 		}
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.AKSPeerSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 		return &Config{
 			Rules:    kataRules,
 			Settings: kataSettings,

--- a/cli/main.go
+++ b/cli/main.go
@@ -105,7 +105,7 @@ func buildVersionString() (string, error) {
 		switch platform {
 		case platforms.AKSCloudHypervisorSNP:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.MicrosoftGenpolicyVersion)
-		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+		case platforms.AKSPeerSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.KataGenpolicyVersion)
 		}
 	}

--- a/infra/azure-peerpods/main.tf
+++ b/infra/azure-peerpods/main.tf
@@ -139,3 +139,47 @@ secretGenerator:
   - id_rsa.pub
 EOF
 }
+
+
+data "local_file" "id_rsa" {
+  filename = "id_rsa.pub"
+}
+
+resource "local_file" "peer-pods-config" {
+  filename        = "./peer-pods-config.yaml"
+  file_permission = "0777"
+  content         = <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: peer-pods-cm
+data:
+  AZURE_CLIENT_ID: ${var.client_id}
+  AZURE_TENANT_ID: ${data.azurerm_subscription.current.tenant_id}
+  AZURE_AUTHORITY_HOST: https://login.microsoftonline.com/
+  AZURE_IMAGE_ID: ${var.image_id}
+  AZURE_INSTANCE_SIZE: Standard_DC2as_v5
+  AZURE_REGION: ${data.azurerm_resource_group.rg.location}
+  AZURE_RESOURCE_GROUP: ${data.azurerm_resource_group.rg.name}
+  AZURE_SUBNET_ID: ${one(azurerm_virtual_network.main.subnet.*.id)}
+  AZURE_SUBSCRIPTION_ID: ${data.azurerm_subscription.current.subscription_id}
+  CLOUD_PROVIDER: azure
+  DISABLECVM: "false"
+---
+apiVersion: v1
+data:
+  AZURE_CLIENT_SECRET: ${base64encode(var.client_secret)}
+kind: Secret
+metadata:
+  name: azure-client-secret
+---
+type: Opaque
+apiVersion: v1
+data:
+  id_rsa.pub: ${data.local_file.id_rsa.content_base64}
+kind: Secret
+metadata:
+  name: ssh-key-secret
+type: Opaque
+EOF
+}

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -82,11 +82,6 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 			),
 	}
 
-	containerdPath := "/var/lib/rancher/k3s/agent/containerd"
-	if platform == platforms.AKSPeerSNP {
-		containerdPath = "/var/lib/containerd"
-	}
-
 	nydusSnapshotter := Container().
 		WithName("nydus-snapshotter").
 		WithImage("ghcr.io/edgelesssys/contrast/nydus-snapshotter:latest").

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -191,11 +191,11 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 	switch platform {
 	case platforms.AKSCloudHypervisorSNP:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-microsoft:latest"
-		snapshotter = tardevSnapshotter
+		containers = append(containers, tardevSnapshotter)
 		volumes = tardevSnapshotterVolumes
 	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
-		snapshotter = nydusSnapshotter
+		containers = append(containers, nydusSnapshotter)
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes, Volume().
 			WithName("var-lib-containerd").
 			WithHostPath(HostPathVolumeSource().
@@ -205,7 +205,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		volumes = nydusSnapshotterVolumes
 	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
-		snapshotter = nydusSnapshotter
+		containers = append(containers, nydusSnapshotter)
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes, Volume().
 			WithName("var-lib-containerd").
 			WithHostPath(HostPathVolumeSource().
@@ -215,7 +215,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		volumes = nydusSnapshotterVolumes
 	case platforms.AKSPeerSNP:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
-		containers = []*applycorev1.ContainerApplyConfiguration{nydusSnapshotter, cloudAPIAdaptor}
+		containers = append(containers, nydusSnapshotter, cloudAPIAdaptor)
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes, Volume().
 			WithName("var-lib-containerd").
 			WithHostPath(HostPathVolumeSource().

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -125,12 +125,11 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 
 	cloudAPIAdaptor := Container().
 		WithName("cloud-api-adaptor").
-		// TODO(freax13): Don't hard-code this
-		WithImage("quay.io/confidential-containers/cloud-api-adaptor:v0.9.0-amd64").
+		WithImage("ghcr.io/edgelesssys/contrast/cloud-api-adaptor:latest").
 		WithVolumeMounts(
 			VolumeMount().
 				WithName("ssh").
-				WithMountPath("/root/.ssh/").
+				WithMountPath("/.ssh/").
 				WithReadOnly(true),
 			VolumeMount().
 				WithName("pods-dir").
@@ -139,9 +138,10 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 				WithName("netns").
 				WithMountPath("/run/netns").
 				WithMountPropagation(corev1.MountPropagationHostToContainer),
-		).
-		WithArgs(
-			"/usr/local/bin/entrypoint.sh",
+			VolumeMount().
+				WithName("netns").
+				WithMountPath("/var/run/netns").
+				WithMountPropagation(corev1.MountPropagationHostToContainer),
 		).
 		WithEnv(
 			NewEnvVar("optionals", fmt.Sprintf("-socket /run/peerpod/hypervisor-%s.sock ", runtimeHandler)),

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -82,6 +82,11 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 			),
 	}
 
+	containerdPath := "/var/lib/rancher/k3s/agent/containerd"
+	if platform == platforms.AKSPeerSNP {
+		containerdPath = "/var/lib/containerd"
+	}
+
 	nydusSnapshotter := Container().
 		WithName("nydus-snapshotter").
 		WithImage("ghcr.io/edgelesssys/contrast/nydus-snapshotter:latest").

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -18,6 +18,8 @@ const (
 	Unknown Platform = iota
 	// AKSCloudHypervisorSNP represents a deployment with Cloud-Hypervisor on SEV-SNP AKS.
 	AKSCloudHypervisorSNP
+	// AKSPeerSNP represents a deployment with peer-pods on SEV-SNP AKS.
+	AKSPeerSNP
 	// K3sQEMUTDX represents a deployment with QEMU on bare-metal TDX K3s.
 	K3sQEMUTDX
 	// K3sQEMUSNP represents a deployment with QEMU on bare-metal SNP K3s.
@@ -32,7 +34,7 @@ const (
 
 // All returns a list of all available platforms.
 func All() []Platform {
-	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX}
+	return []Platform{AKSCloudHypervisorSNP, AKSPeerSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX}
 }
 
 // AllStrings returns a list of all available platforms as strings.
@@ -49,6 +51,8 @@ func (p Platform) String() string {
 	switch p {
 	case AKSCloudHypervisorSNP:
 		return "AKS-CLH-SNP"
+	case AKSPeerSNP:
+		return "AKS-PEER-SNP"
 	case K3sQEMUTDX:
 		return "K3s-QEMU-TDX"
 	case K3sQEMUSNP:
@@ -69,6 +73,8 @@ func FromString(s string) (Platform, error) {
 	switch strings.ToLower(s) {
 	case "aks-clh-snp":
 		return AKSCloudHypervisorSNP, nil
+	case "aks-peer-snp":
+		return AKSPeerSNP, nil
 	case "k3s-qemu-tdx":
 		return K3sQEMUTDX, nil
 	case "k3s-qemu-snp":

--- a/justfile
+++ b/justfile
@@ -51,6 +51,11 @@ node-installer platform=default_platform:
             just push "nydus-snapshotter"
             just push "node-installer-kata"
         ;;
+        "AKS-PEER-SNP")
+            just push "nydus-snapshotter"
+            just push "node-installer-kata"
+            just push "cloud-api-adaptor"
+        ;;
         *)
             echo "Unsupported platform: {{ platform }}"
             exit 1

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ node-installer platform=default_platform:
             just push "tardev-snapshotter"
             just push "node-installer-microsoft"
         ;;
-        "AKS-PEER-SNP"|"Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             just push "nydus-snapshotter"
             just push "node-installer-kata"
         ;;

--- a/nodeinstaller/internal/config/kata_runtime.go
+++ b/nodeinstaller/internal/config/kata_runtime.go
@@ -3,6 +3,8 @@
 
 package config
 
+import "github.com/pelletier/go-toml/v2"
+
 // KataRuntimeConfig is the configuration for the Kata runtime.
 // Source: https://github.com/kata-containers/kata-containers/blob/4029d154ba0c26fcf4a8f9371275f802e3ef522c/src/runtime/pkg/katautils/config.go
 // This is a simplified version of the actual configuration.
@@ -12,6 +14,11 @@ type KataRuntimeConfig struct {
 	Image      Image
 	Factory    Factory
 	Runtime    KataRuntime
+}
+
+// Marshal encodes the configuration as TOML.
+func (k *KataRuntimeConfig) Marshal() ([]byte, error) {
+	return toml.Marshal(k)
 }
 
 // Image is the configuration for the image.

--- a/nodeinstaller/internal/config/kata_runtime_test.go
+++ b/nodeinstaller/internal/config/kata_runtime_test.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/edgelesssys/contrast/nodeinstaller/internal/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigHasKataSection(t *testing.T) {
+	// This is a regression test that ensures the `agent.kata` section is not optimized away. Empty
+	// section and no section are handled differently by Kata, so we make sure that this section is
+	// always present.
+	for _, platform := range platforms.All() {
+		t.Run(platform.String(), func(t *testing.T) {
+			require := require.New(t)
+			cfg, err := constants.KataRuntimeConfig("/", platforms.AKSPeerSNP, "", false)
+			require.NoError(err)
+			configBytes, err := cfg.Marshal()
+			require.NoError(err)
+			require.Contains(string(configBytes), "[Agent.kata]")
+		})
+	}
+}

--- a/nodeinstaller/internal/constants/configuration-peerpod.toml
+++ b/nodeinstaller/internal/constants/configuration-peerpod.toml
@@ -1,0 +1,25 @@
+# upstream source: https://github.com/kata-containers/kata-containers/blob/51bc71b8d96874cf4a555e1084ee07e948bff957/src/runtime/config/configuration-remote.toml.in
+[hypervisor.remote]
+remote_hypervisor_socket = "/run/peerpod/hypervisor.sock"
+remote_hypervisor_timeout = 600
+enable_annotations = ["machine_type", "default_memory", "default_vcpus"]
+firmware = ""
+default_bridges = 1
+disable_selinux = false
+disable_guest_selinux = true
+
+[agent.kata]
+enable_debug = false
+dial_timeout = 600
+
+[runtime]
+internetworking_model = "none"
+disable_guest_seccomp = true
+disable_new_netns = true
+sandbox_cgroup_only = false
+static_sandbox_resource_mgmt = true
+vfio_mode = "guest-kernel"
+disable_guest_empty_dir = false
+experimental = []
+create_container_timeout = 600
+dan_conf = "/run/edgeless/kata-containers/dans"

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -215,11 +215,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	case platforms.AKSCloudHypervisorSNP:
 		snapshotterName = fmt.Sprintf("tardev-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/tardev-snapshotter-%s.sock", runtimeHandler)
-<<<<<<< HEAD
-	case platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
-=======
-	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX, platforms.AKSPeerSNP:
->>>>>>> ad38711d5 (Reapply "node-installer: support AKS-PEER-SNP when patching containerd config")
+	case platforms.AKSPeerSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
 		snapshotterName = fmt.Sprintf("nydus-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/containerd-nydus-grpc-%s.sock", runtimeHandler)
 

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -182,7 +182,7 @@ func containerdRuntimeConfig(basePath, configPath string, platform platforms.Pla
 	if err != nil {
 		return fmt.Errorf("generating kata runtime config: %w", err)
 	}
-	rawConfig, err := toml.Marshal(kataRuntimeConfig)
+	rawConfig, err := kataRuntimeConfig.Marshal()
 	if err != nil {
 		return fmt.Errorf("marshaling kata runtime config: %w", err)
 	}

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -113,6 +113,9 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	case platforms.MetalQEMUTDX:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-qemu-tdx.toml")
 		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
+	case platforms.AKSPeerSNP:
+		kataConfigPath = filepath.Join(kataConfigPath, "configuration-peer-snp.toml")
+		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
 	case platforms.K3sQEMUSNP:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-qemu-snp.toml")
 		containerdConfigPath = filepath.Join(hostMount, "var", "lib", "rancher", "k3s", "agent", "etc", "containerd", "config.toml.tmpl")
@@ -145,7 +148,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	}
 
 	switch platform {
-	case platforms.AKSCloudHypervisorSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX:
+	case platforms.AKSCloudHypervisorSNP, platforms.AKSPeerSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX:
 		return restartHostContainerd(containerdConfigPath, "containerd")
 	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP:
 		if hostServiceExists("k3s") {
@@ -212,7 +215,11 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	case platforms.AKSCloudHypervisorSNP:
 		snapshotterName = fmt.Sprintf("tardev-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/tardev-snapshotter-%s.sock", runtimeHandler)
+<<<<<<< HEAD
 	case platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
+=======
+	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX, platforms.AKSPeerSNP:
+>>>>>>> ad38711d5 (Reapply "node-installer: support AKS-PEER-SNP when patching containerd config")
 		snapshotterName = fmt.Sprintf("nydus-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/containerd-nydus-grpc-%s.sock", runtimeHandler)
 

--- a/nodeinstaller/node-installer_test.go
+++ b/nodeinstaller/node-installer_test.go
@@ -18,6 +18,8 @@ import (
 var (
 	//go:embed testdata/expected-aks-clh-snp.toml
 	expectedConfAKSCLHSNP []byte
+	//go:embed testdata/expected-aks-peer-snp.toml
+	expectedConfAKSPeerSNP []byte
 	//go:embed testdata/expected-bare-metal-qemu-tdx.toml
 	expectedConfBareMetalQEMUTDX []byte
 	//go:embed testdata/expected-bare-metal-qemu-snp.toml
@@ -33,6 +35,10 @@ func TestPatchContainerdConfig(t *testing.T) {
 		"AKSCLHSNP": {
 			platform: platforms.AKSCloudHypervisorSNP,
 			expected: expectedConfAKSCLHSNP,
+		},
+		"AKSPeerSNP": {
+			platform: platforms.AKSPeerSNP,
+			expected: expectedConfAKSPeerSNP,
 		},
 		"BareMetalQEMUTDX": {
 			platform: platforms.K3sQEMUTDX,

--- a/nodeinstaller/testdata/expected-aks-peer-snp.toml
+++ b/nodeinstaller/testdata/expected-aks-peer-snp.toml
@@ -1,0 +1,81 @@
+version = 2
+
+[debug]
+level = 'debug'
+
+[metrics]
+address = '0.0.0.0:10257'
+
+[plugins]
+[plugins.'io.containerd.grpc.v1.cri']
+sandbox_image = 'mcr.microsoft.com/oss/kubernetes/pause:3.6'
+
+[plugins.'io.containerd.grpc.v1.cri'.cni]
+bin_dir = '/opt/cni/bin'
+conf_dir = '/etc/cni/net.d'
+conf_template = '/etc/containerd/kubenet_template.conf'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd]
+default_runtime_name = 'runc'
+disable_snapshot_annotations = false
+discard_unpacked_layers = false
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes]
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata]
+runtime_type = 'io.containerd.kata.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata-cc]
+pod_annotations = ['io.katacontainers.*']
+privileged_without_host_devices = true
+runtime_type = 'io.containerd.kata-cc.v2'
+snapshotter = 'tardev'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata-cc.options]
+ConfigPath = '/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.katacli]
+runtime_type = 'io.containerd.runc.v1'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.katacli.options]
+BinaryName = '/usr/bin/kata-runtime'
+CriuPath = ''
+IoGid = 0
+IoUid = 0
+NoNewKeyring = false
+NoPivotRoot = false
+Root = ''
+ShimCgroup = ''
+SystemdCgroup = false
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime]
+runtime_type = 'io.containerd.contrast-cc.v2'
+runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
+pod_annotations = ['io.katacontainers.*']
+privileged_without_host_devices = true
+snapshotter = 'nydus-my-runtime'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
+ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-peer-snp.toml'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc]
+runtime_type = 'io.containerd.runc.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc.options]
+BinaryName = '/usr/bin/runc'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.untrusted]
+runtime_type = 'io.containerd.runc.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.untrusted.options]
+BinaryName = '/usr/bin/runc'
+
+[plugins.'io.containerd.grpc.v1.cri'.registry]
+config_path = '/etc/containerd/certs.d'
+
+[plugins.'io.containerd.grpc.v1.cri'.registry.headers]
+X-Meta-Source-Client = ['azure/aks']
+
+[proxy_plugins]
+[proxy_plugins.nydus-my-runtime]
+type = 'snapshot'
+address = '/run/containerd/containerd-nydus-grpc-my-runtime.sock'

--- a/packages/by-name/cloud-api-adaptor/package.nix
+++ b/packages/by-name/cloud-api-adaptor/package.nix
@@ -10,9 +10,6 @@
   writeShellApplication,
   gnugrep,
   iptables,
-  iproute2,
-  sysctl,
-  gawk,
   runCommand,
   applyPatches,
   makeWrapper,
@@ -105,22 +102,6 @@ buildGoModule rec {
         "SC2086"
         "SC2153"
       ];
-    };
-
-    setup-nat-for-imds = writeShellApplication {
-      name = "setup-nat-for-imds";
-      runtimeInputs = [
-        iproute2
-        iptables
-        sysctl
-        gawk
-      ];
-      # TODO(burgerdev): generalize for all link-local IPs and investigate routing simplification
-      text = builtins.readFile "${cloud-api-adaptor.src}/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh";
-      meta = {
-        mainProgram = "setup-nat-for-imds";
-        homepage = "https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/podvm/files/usr/local/bin/setup-nat-for-imds.sh";
-      };
     };
   };
 

--- a/packages/by-name/cloud-api-adaptor/package.nix
+++ b/packages/by-name/cloud-api-adaptor/package.nix
@@ -80,6 +80,7 @@ buildGoModule rec {
 
   postInstall = ''
     wrapProgram $out/bin/agent-protocol-forwarder --prefix PATH : ${lib.makeBinPath [ iptables ]}
+    wrapProgram $out/bin/cloud-api-adaptor --prefix PATH : ${lib.makeBinPath [ iptables ]}
   '';
 
   passthru = {

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -57,6 +57,7 @@ let
       rke2-qemu-tdx-handler = runtimeHandler "rke2-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       metal-qemu-snp-handler = runtimeHandler "metal-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
       k3s-qemu-snp-handler = runtimeHandler "k3s-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
+      aks-peer-snp-handler = runtimeHandler "aks-peer-snp" kata.contrast-node-installer-image.runtimeHash;
 
       aksRefVals = {
         snp = [
@@ -135,6 +136,7 @@ let
         "${rke2-qemu-tdx-handler}" = tdxRefVals;
         "${metal-qemu-snp-handler}" = snpRefVals;
         "${k3s-qemu-snp-handler}" = snpRefVals;
+        "${aks-peer-snp-handler}" = { };
       }
     );
 

--- a/packages/nixos/azure.nix
+++ b/packages/nixos/azure.nix
@@ -87,25 +87,5 @@ in
         ExecStart = "${lib.getExe pkgs.azure-no-agent}";
       };
     };
-
-    systemd.services.setup-nat-for-imds = {
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "netns@podns.service" ];
-      wants = [ "network-online.target" ];
-      after = [
-        "network-online.target"
-        "netns@podns.service"
-      ];
-      description = "Setup NAT for IMDS";
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = "yes";
-        # TODO(msanft): Find out why just ordering this after network-online.target
-        # isn't sufficient. (Errors with saying that the network is unreachable)
-        Restart = "on-failure";
-        RestartSec = "5s";
-        ExecStart = "${lib.getExe pkgs.cloud-api-adaptor.setup-nat-for-imds}";
-      };
-    };
   };
 }

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -466,38 +466,27 @@
     '';
   };
 
-  deploy-caa = writeShellApplication {
-    name = "deploy-caa";
+  deploy-caa-rbac = writeShellApplication {
+    name = "deploy-caa-rbac";
     runtimeInputs = with pkgs; [ kubectl ];
     text = ''
       set -euo pipefail
 
-      for i in "$@"; do
-        case $i in
-        --kustomization=*)
-          kustomizationFile="''${i#*=}"
-          shift
-          ;;
-        --pub-key=*)
-          pubKeyFile="''${i#*=}"
-          shift
-          ;;
-        *)
-          echo "Unknown option $i"
-          exit 1
-          ;;
-        esac
-      done
+      namespace="$1"
+
 
       tmpdir=$(mktemp -d)
-      cp -r ${pkgs.cloud-api-adaptor.src}/src/cloud-api-adaptor/install/* "$tmpdir"
+      cp -r ${pkgs.cloud-api-adaptor.src}/src/cloud-api-adaptor/install/rbac "$tmpdir"
       chmod -R +w "$tmpdir"
-      cp "$kustomizationFile" "$tmpdir/overlays/azure/kustomization.yaml"
-      cp "$pubKeyFile" "$tmpdir/overlays/azure/id_rsa.pub"
 
-      kubectl apply -k "github.com/confidential-containers/operator/config/release?ref=v${pkgs.cloud-api-adaptor.version}"
-      kubectl apply -k "github.com/confidential-containers/operator/config/samples/ccruntime/peer-pods?ref=v${pkgs.cloud-api-adaptor.version}"
-      kubectl apply -k "$tmpdir/overlays/azure"
+      cat >"$tmpdir/kustomization.yaml" <<EOF
+      kind: Kustomization
+      resources:
+      - rbac
+      namespace: "$namespace"
+      EOF
+
+      kubectl apply -k "$tmpdir"
     '';
   };
 

--- a/packages/test-peerpods.sh
+++ b/packages/test-peerpods.sh
@@ -62,6 +62,7 @@ spec:
     matchLabels:
       app: alpine
   replicas: 1
+  minReadySeconds: 60
   template:
     metadata:
       labels:
@@ -70,7 +71,7 @@ spec:
       runtimeClassName: "$runtime"
       containers:
       - name: alpine
-        image: alpine/curl
+        image: alpine/curl@sha256:b5b6a32ca3986d4d8f3af31bf9cdb6ec28c345130bd57a7130eaeca7ce64da4e
         imagePullPolicy: Always
         command: ["sleep", "infinity"]
 EOF


### PR DESCRIPTION
This reapplies most of the commits that moved CAA into the node-installer. I've split the commits into the clean reapplies and dedicated `fixup` commits where I found problems in the original commits. These include:

* Ensure that the agent config is not skipped while serializing.
* Add missing environment variable and RBAC on the CAA container.
* Include `iptables` in the CAA container image.
* Deploy RBAC resources from the `apply-runtime` target, which is the point when we know the namespace to apply them to.

The last commit adapts the peer-pods e2e test to the prior changes, which means that the peer-pods workflow is not expected to work for the last 3 commits or so. We could squash this PR, but I think I'd prefer to have the history intact.