### PR TITLE
cli: genpolicy logging: Add debug log level and repository reference to auth failure

### DIFF
--- a/cli/genpolicy/genpolicy.go
+++ b/cli/genpolicy/genpolicy.go
@@ -62,7 +62,7 @@ func (r *Runner) Run(ctx context.Context, yamlPath string, logger *slog.Logger) 
 	genpolicy := exec.CommandContext(ctx, r.genpolicy.Path(), args...)
 	genpolicy.Env = os.Environ()
 	if _, hasRustLog := os.LookupEnv("RUST_LOG"); !hasRustLog {
-		genpolicy.Env = append(genpolicy.Env, "RUST_LOG=info")
+		genpolicy.Env = append(genpolicy.Env, "RUST_LOG=debug")
 	}
 	if _, hasRustBacktrace := os.LookupEnv("RUST_BACKTRACE"); !hasRustBacktrace {
 		genpolicy.Env = append(genpolicy.Env, "RUST_BACKTRACE=1")

--- a/cli/genpolicy/logtranslator.go
+++ b/cli/genpolicy/logtranslator.go
@@ -51,7 +51,9 @@ func (l logTranslator) startTranslate() {
 					l.logger.Error(match[3], "position", match[2])
 				case "WARN":
 					l.logger.Warn(match[3], "position", match[2])
-				case "INFO": // prints quite a lot, only show on debug
+				case "INFO":
+					fallthrough // prints quite a lot, only show on debug
+				case "DEBUG":
 					l.logger.Debug(match[3], "position", match[2])
 				}
 			}

--- a/packages/by-name/microsoft/genpolicy/0008-genpolicy-include-reference-in-logs-when-auth-failure.patch
+++ b/packages/by-name/microsoft/genpolicy/0008-genpolicy-include-reference-in-logs-when-auth-failure.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmxnzo <jakob.lammering@ruhr-uni-bochum.de>
+Date: Mon, 2 Dec 2024 12:38:04 +0100
+Subject: [PATCH] genpolicy: include reference in logs when auth failure
+
+---
+ src/tools/genpolicy/src/registry.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/genpolicy/src/registry.rs b/src/tools/genpolicy/src/registry.rs
+index bdce2d40e3a7c3ec34137ceb3685fcc94aedcb39..9aa1cde98cd28a8c78d652986408e7738e5d96d6 100644
+--- a/src/tools/genpolicy/src/registry.rs
++++ b/src/tools/genpolicy/src/registry.rs
+@@ -125,7 +125,7 @@ impl Container {
+                 })
+             }
+             Err(oci_distribution::errors::OciDistributionError::AuthenticationFailure(message)) => {
+-                panic!("Container image registry authentication failure ({}). Are docker credentials set-up for current user?", &message);
++                panic!("Container image registry authentication failure ({}) for {}. Are docker credentials set-up for current user?", &message, &reference.whole().as_str());
+             }
+             Err(e) => {
+                 panic!(

--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -59,6 +59,13 @@ rustPlatform.buildRustPackage rec {
       # to Microsofts genpolicy.
       # TODO(miampf): remove when picked up by microsoft/kata-containers fork.
       ./0007-genpolicy-support-for-VOLUME-definition-in-container.patch
+
+      # Simple genpolicy logging patch to include the image reference in case of authentication failure
+      # TODO(jmxnzo): remove when authentication failure error logging includes image reference on microsoft/kata-containers fork.
+      # This will be achieved when updating oci_distribution to oci_client crate on microsoft/kata-containers fork.
+      # kata/kata-runtime/0011-genpolicy-bump-oci-distribution-to-v0.12.0.patch introduces this update to kata-containers.
+      # After upstreaming, microsoft/kata-containers fork would need to pick up the changes.
+      ./0008-genpolicy-include-reference-in-logs-when-auth-failure.patch
     ];
   };
 


### PR DESCRIPTION
The PR includes the debug log level of genpolicy into the Contrast CLI. Thus the resulting mapping is:

Contrast info == Genpolicy warning
Contrast debug == Genpolicy info/debug

As well it patches the existing genpolicy error message in case of an authentication failure, to include the reference to the repository. 