### PR TITLE
e2e: fix log collection download

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -100,6 +100,6 @@ jobs:
           message: "e2e test ${{ inputs.test-name }} failed"
           additionalFields: '[{"title": "Platform", "value": "${{ inputs.platform }}"}]'
       - name: Cleanup
-        if: cancelled() && !inputs.skip-undeploy
+        if: always() && !inputs.skip-undeploy
         run: |
-          kubectl delete ns "$(cat workspace/e2e.namespace)" --timeout 5m
+          kubectl delete ns "$(cat workspace/e2e.namespace)" --timeout 10m

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,7 +79,6 @@ jobs:
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform ${{ inputs.platform }} \
-            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}" \
             --namespace-suffix="-ci"
       - name: Download logs
         if: always()

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -110,6 +110,6 @@ jobs:
           message: "e2e test aks-runtime failed"
           additionalFields: '[{"title": "Platform", "value": "AKS-CLH-SNP"}]'
       - name: Cleanup
-        if: cancelled()
+        if: always()
         run: |
           kubectl delete ns "$(cat workspace/e2e.namespace)" --timeout 5m

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -89,7 +89,6 @@ jobs:
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform AKS-CLH-SNP \
-            --skip-undeploy="false" \
             --namespace-suffix="-ci"
       - name: Download logs
         if: always()

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const testContainer = "testcontainer"
@@ -103,20 +102,6 @@ func TestAKSRuntime(t *testing.T) {
 	err = c.Apply(ctx, toApply...)
 	require.NoError(err)
 	require.NoError(c.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, namespace, testContainer))
-
-	t.Cleanup(func() {
-		if contrasttest.Flags.SkipUndeploy {
-			return
-		}
-
-		// delete the deployment
-		deletePolicy := metav1.DeletePropagationForeground
-		if err = c.Client.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{
-			PropagationPolicy: &deletePolicy,
-		}); err != nil {
-			t.Fatalf("Failed to delete namespace %s", namespace)
-		}
-	})
 
 	pods, err := c.PodsFromDeployment(ctx, namespace, testContainer)
 	require.NoError(err)

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -41,7 +41,6 @@ type testFlags struct {
 	ImageReplacementsFile string
 	NamespaceFile         string
 	NamespaceSuffix       string
-	SkipUndeploy          bool
 }
 
 // RegisterFlags registers the flags that are shared between all tests.
@@ -50,7 +49,6 @@ func RegisterFlags() {
 	flag.StringVar(&Flags.NamespaceFile, "namespace-file", "", "file to store the namespace in")
 	flag.StringVar(&Flags.NamespaceSuffix, "namespace-suffix", "", "suffix to append to the namespace")
 	flag.StringVar(&Flags.PlatformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&Flags.SkipUndeploy, "skip-undeploy", false, "Skip undeploying the test namespace")
 }
 
 // ContrastTest is the Contrast test helper struct.
@@ -62,7 +60,6 @@ type ContrastTest struct {
 	ImageReplacementsFile string
 	Platform              platforms.Platform
 	NamespaceFile         string
-	SkipUndeploy          bool
 	Kubeclient            *kubeclient.Kubeclient
 
 	// outputs of contrast subcommands
@@ -81,7 +78,6 @@ func New(t *testing.T) *ContrastTest {
 		ImageReplacementsFile: Flags.ImageReplacementsFile,
 		Platform:              platform,
 		NamespaceFile:         Flags.NamespaceFile,
-		SkipUndeploy:          Flags.SkipUndeploy,
 		Kubeclient:            kubeclient.NewForTest(t),
 	}
 }
@@ -133,20 +129,6 @@ func (ct *ContrastTest) Init(t *testing.T, resources []any) {
 
 		if t.Failed() {
 			ct.Kubeclient.LogDebugInfo(ctx)
-		}
-
-		if !ct.SkipUndeploy {
-			// Deleting the namespace sometimes fails when the cluster is
-			// unavailable (e.g. after a K3s restart). Retry deleting for up to
-			// 30 seconds.
-			for range 30 {
-				if err := ct.Kubeclient.Delete(ctx, namespace...); err != nil {
-					t.Logf("Could not delete namespace %q: %v", ct.Namespace, err)
-					time.Sleep(1 * time.Second)
-				} else {
-					break
-				}
-			}
 		}
 
 		if fifo != nil {

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -453,10 +453,10 @@
         namespace="$(head -n1 "$2")"
         pod="$(kubectl get pods -o name -n "$namespace" | grep log-collector | cut -c 5-)"
         mkdir -p ./workspace/logs
-        kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod" 1>/dev/null 2>/dev/null
-        kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export" 1>/dev/null 2>/dev/null
-        kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz 1>/dev/null 2>/dev/null
-        tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs 1>/dev/null 2>/dev/null
+        kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod"
+        kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export"
+        kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz
+        tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs
         ;;
       *)
         echo "Unknown option $1"


### PR DESCRIPTION
Currently, downloading logs from an e2e cluster may fail since the cluster may be undeployed before the download is initiated. This PR fixes that problem by undeploying the cluster _after_ the logs were downloaded.