### PR TITLE
kds-cache: add fallback cache for CRLs on request failure

### DIFF
--- a/internal/attestation/certcache/cached_client_test.go
+++ b/internal/attestation/certcache/cached_client_test.go
@@ -4,6 +4,7 @@
 package certcache
 
 import (
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/memstore"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
+	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -19,25 +21,16 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
-func TestMemcachedHTTPSGetter(t *testing.T) {
-	t.Run("Get", func(t *testing.T) {
-		assert := assert.New(t)
+const crlURLMatch string = "https://kdsintf.amd.com/vcek/v1/test/crl"
 
-		fakeGetter := &fakeHTTPSGetter{
-			content: map[string][]byte{
-				"foo": []byte("bar"),
-			},
-			hits: map[string]int{},
-		}
-		stepTime := 5 * time.Minute
-		testClock := testingclock.NewFakeClock(time.Now())
-		ticker := testClock.NewTicker(stepTime)
-		client := &CachedHTTPSGetter{
-			HTTPSGetter: fakeGetter,
-			gcTicker:    ticker,
-			cache:       memstore.New[string, []byte](),
-			logger:      slog.Default(),
-		}
+func TestMemcachedHTTPSGetter(t *testing.T) {
+	stepTime := 5 * time.Minute
+	testClock := testingclock.NewFakeClock(time.Now())
+	ticker := testClock.NewTicker(stepTime)
+
+	t.Run("Get VCEK by request and from cache", func(t *testing.T) {
+		assert := assert.New(t)
+		fakeGetter, client := getFakeHTTPSGetters(ticker)
 
 		res, err := client.Get("foo")
 		assert.NoError(err)
@@ -57,46 +50,66 @@ func TestMemcachedHTTPSGetter(t *testing.T) {
 		assert.Equal([]byte("bar"), res)
 		assert.Equal(2, fakeGetter.hits["foo"])
 	})
-	t.Run("Get error", func(t *testing.T) {
-		fakeGetter := &fakeHTTPSGetter{
-			getErr:  assert.AnError,
-			content: map[string][]byte{},
-			hits:    map[string]int{},
-		}
-		testClock := testingclock.NewFakeClock(time.Now())
-		ticker := testClock.NewTicker(5 * time.Minute)
-		client := &CachedHTTPSGetter{
-			HTTPSGetter: fakeGetter,
-			gcTicker:    ticker,
-			cache:       memstore.New[string, []byte](),
-			logger:      slog.Default(),
-		}
 
+	t.Run("VCEK request fails and VCEK not in cache", func(t *testing.T) {
 		assert := assert.New(t)
+		fakeGetter, client := getFakeHTTPSGetters(ticker)
+
+		// Simulate a request failure by returning an error
+		fakeGetter.getErr = errors.New("VCEK request failure")
 
 		_, err := client.Get("foo")
 		assert.Error(err)
 		assert.Equal(1, fakeGetter.hits["foo"])
 	})
+
+	t.Run("Check CRLs are still requested after caching", func(t *testing.T) {
+		assert := assert.New(t)
+		fakeGetter, client := getFakeHTTPSGetters(ticker)
+
+		res, err := client.Get(crlURLMatch)
+		assert.NoError(err)
+		assert.Equal([]byte("bar"), res)
+		assert.Equal(1, fakeGetter.hits[crlURLMatch])
+
+		// Even after the CRL is cached, the CRL should be requested(hit counter increase).
+		res, err = client.Get(crlURLMatch)
+		assert.NoError(err)
+		assert.Equal([]byte("bar"), res)
+		assert.Equal(2, fakeGetter.hits[crlURLMatch])
+	})
+
+	t.Run("Check CRLs can be loaded by cache when request fails", func(t *testing.T) {
+		assert := assert.New(t)
+		fakeGetter, client := getFakeHTTPSGetters(ticker)
+
+		// Preload CRL into the cache
+		client.cache.Set(crlURLMatch, []byte("bar"))
+		fakeGetter.getErr = errors.New("CRL request failure")
+
+		// The CRL should be loaded from the cache and client.Get() won't result in an error
+		res, err := client.Get(crlURLMatch)
+		assert.NoError(err)
+		assert.Equal([]byte("bar"), res)
+		assert.Equal(1, fakeGetter.hits[crlURLMatch])
+	})
+
+	t.Run("CRL request fails and CRL not in cache", func(t *testing.T) {
+		assert := assert.New(t)
+		fakeGetter, client := getFakeHTTPSGetters(ticker)
+
+		fakeGetter.getErr = errors.New("CRL request failure")
+
+		// No CRL cache and request failure results in error
+		_, err := client.Get(crlURLMatch)
+		assert.Error(err)
+		assert.Equal(1, fakeGetter.hits[crlURLMatch])
+	})
+
 	t.Run("Concurrent access", func(t *testing.T) {
 		assert := assert.New(t)
-
-		fakeGetter := &fakeHTTPSGetter{
-			content: map[string][]byte{
-				"foo": []byte("bar"),
-			},
-			hits: map[string]int{},
-		}
+		_, client := getFakeHTTPSGetters(ticker)
 		numGets := 5
-		stepTime := 5 * time.Minute
-		testClock := testingclock.NewFakeClock(time.Now())
-		ticker := testClock.NewTicker(stepTime)
-		client := &CachedHTTPSGetter{
-			HTTPSGetter: fakeGetter,
-			gcTicker:    ticker,
-			cache:       memstore.New[string, []byte](),
-			logger:      slog.Default(),
-		}
 
 		var wg sync.WaitGroup
 		getFunc := func() {
@@ -122,6 +135,24 @@ type fakeHTTPSGetter struct {
 
 	hitsMux sync.Mutex
 	hits    map[string]int
+}
+
+// Returns the fakeHTTPSGetter for test assertions and its wrapper CachedHTTPSGetter.
+func getFakeHTTPSGetters(ticker clock.Ticker) (*fakeHTTPSGetter, *CachedHTTPSGetter) {
+	fakeGetter := &fakeHTTPSGetter{
+		content: map[string][]byte{
+			"foo":       []byte("bar"),
+			crlURLMatch: []byte("bar"),
+		},
+		hits: map[string]int{},
+	}
+
+	return fakeGetter, &CachedHTTPSGetter{
+		HTTPSGetter: fakeGetter,
+		gcTicker:    ticker,
+		cache:       memstore.New[string, []byte](),
+		logger:      slog.Default(),
+	}
 }
 
 func (f *fakeHTTPSGetter) Get(url string) ([]byte, error) {


### PR DESCRIPTION
This PR adds logic to the cached_client.go to allow caching Certificate Revocation Lists (CRLs). Still the CRLs are always queried from the AMD's certification server (KDS) first.
Only in case of an request failure, the cache is used as fallback to allow continuing. When the cache of the CRL is expired, the HTTPs request failure is returned as an error.

In addition the test cases where adapted to cover the different branches of VCEK and CRL caching. 