### PR TITLE
packages/kata-image: specify correct fs-type in error message

### DIFF
--- a/packages/by-name/kata/kata-image/package.nix
+++ b/packages/by-name/kata/kata-image/package.nix
@@ -155,7 +155,7 @@ let
       runHook preBuild
 
       # Check if filesystem is ext.*
-      fstype=$(stat -f -c %T .)
+      fstype=$(df -T . | awk '{print $2}' | tail -n 1)
       if [[ $fstye == "ext4" || $fstype == "ext2/ext3" ]]; then
         echo "Due to a bug in the image build, kata-image can unfortunately not be built on $fstype filesystems."
         echo "As a workaround, you can build the derivation on a different filesystem with the following:"


### PR DESCRIPTION
Previously, we used `stat` as a heuristic to detect the filesystem type, which is sub-optimal, as it will report `ext2/ext3` on `ext4` filesystems, leaving the reader of the error message in incertainty about the error. Switch to `df`, which is a better heuristic. \[1\]

\[1\]: https://unix.stackexchange.com/questions/256920/stat-f-show-a-ext4-file-system-type-as-ext2-ext3/274030#274030