### PR TITLE
cli/genpolicy: by default do not include log-level 'debug' in Contras…

### DIFF
--- a/cli/genpolicy/genpolicy.go
+++ b/cli/genpolicy/genpolicy.go
@@ -62,7 +62,7 @@ func (r *Runner) Run(ctx context.Context, yamlPath string, logger *slog.Logger) 
 	genpolicy := exec.CommandContext(ctx, r.genpolicy.Path(), args...)
 	genpolicy.Env = os.Environ()
 	if _, hasRustLog := os.LookupEnv("RUST_LOG"); !hasRustLog {
-		genpolicy.Env = append(genpolicy.Env, "RUST_LOG=debug")
+		genpolicy.Env = append(genpolicy.Env, "RUST_LOG=info")
 	}
 	if _, hasRustBacktrace := os.LookupEnv("RUST_BACKTRACE"); !hasRustBacktrace {
 		genpolicy.Env = append(genpolicy.Env, "RUST_BACKTRACE=1")


### PR DESCRIPTION
This PR changes the default logging level of the genpolicy tool back to "info", because re-running the generate step on a deployment with policy annotation results in a runtime error in the Contrast CLI, when matching the genpolicy logging prefix.  The runtime error grounds in the regex used for log translation, see https://github.com/edgelesssys/contrast/blob/main/cli/genpolicy/logtranslator.go/#L36 .

Still the RUST_LOG env variable can manually be set to "debug" to allow parsing the debug logs of genpolicy into the Contrast CLI for better troubleshooting, when no policy annotation is already present in the .yml file. Therefore the translation logic added in #1044 is kept in the Contrast CLI for now.