### PR TITLE
ci: suffix ci k8s namespaces with "-ci"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,7 +79,8 @@ jobs:
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform ${{ inputs.platform }} \
-            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}"
+            --skip-undeploy="${{ inputs.skip-undeploy && 'true' || 'false' }}" \
+            --namespace-suffix="-ci"
       - name: Download logs
         if: always()
         run: |

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -87,7 +87,8 @@ jobs:
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform AKS-CLH-SNP \
-            --skip-undeploy="false"
+            --skip-undeploy="false" \
+            --namespace-suffix="-ci"
       - name: Download logs
         if: always()
         run: |

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -34,7 +34,7 @@ func TestAKSRuntime(t *testing.T) {
 	require.NoError(err)
 	imageReplacements, err := kuberesource.ImageReplacementsFromFile(f)
 	require.NoError(err)
-	namespace := contrasttest.MakeNamespace(t)
+	namespace := contrasttest.MakeNamespace(t, contrasttest.Flags.NamespaceSuffix)
 
 	// Log versions
 	kataPolicyGenV, err := az.KataPolicyGenVersion()

--- a/e2e/genpolicy/genpolicy_test.go
+++ b/e2e/genpolicy/genpolicy_test.go
@@ -24,23 +24,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 // TestGenpolicy runs regression tests for generated policies.
 func TestGenpolicy(t *testing.T) {
 	testCases := kuberesource.GenpolicyRegressionTests()
 
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
 
 	for name, deploy := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+			ct := contrasttest.New(t)
 
 			ct.Init(t, kuberesource.PatchRuntimeHandlers([]any{deploy}, runtimeHandler))
 
@@ -72,10 +67,7 @@ func TestGenpolicy(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/getdents/getdents_test.go
+++ b/e2e/getdents/getdents_test.go
@@ -28,15 +28,10 @@ const (
 	getdent = "getdents-tester"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 func TestGetDEnts(t *testing.T) {
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
@@ -89,10 +84,7 @@ func TestGetDEnts(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -35,16 +35,11 @@ const (
 	rootCAFile = "coordinator-root-ca.pem"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 // TestOpenSSL runs e2e tests on the example OpenSSL deployment.
 func TestOpenSSL(t *testing.T) {
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
@@ -245,10 +240,7 @@ func TestOpenSSL(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/policy/deterministic_test.go
+++ b/e2e/policy/deterministic_test.go
@@ -20,10 +20,9 @@ import (
 
 func TestDeterminsticPolicyGeneration(t *testing.T) {
 	require := require.New(t)
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(err)
-	skipUndeploy := true // doesn't matter, because we don't deploy
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	// create K8s resources
 	runtimeHandler, err := manifest.RuntimeHandler(platform)

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -36,15 +36,10 @@ const (
 	coordinatorPod = "coordinator-0"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 func TestPolicy(t *testing.T) {
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
@@ -197,10 +192,7 @@ func TestPolicy(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/regression/regression_test.go
+++ b/e2e/regression/regression_test.go
@@ -24,23 +24,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	_skipUndeploy                                     bool // just here for interoptability, ignored in this test
-)
-
 func TestRegression(t *testing.T) {
 	yamlDir := "./e2e/regression/testdata/"
 	files, err := os.ReadDir(yamlDir)
 	require.NoError(t, err)
 
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
 
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, false)
+	ct := contrasttest.New(t)
 
 	// Initially just deploy the coordinator bundle
 
@@ -97,12 +92,7 @@ func TestRegression(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-
-	// ignored and just here for interoptability, we always undeploy to save resources
-	flag.BoolVar(&_skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -26,16 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 // TestIngressEgress tests that the ingress and egress proxies work as configured.
 func TestIngressEgress(t *testing.T) {
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
@@ -153,10 +148,7 @@ func TestIngressEgress(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/volumestatefulset/volumestatefulset_test.go
+++ b/e2e/volumestatefulset/volumestatefulset_test.go
@@ -21,16 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 // TestWorkloadSecrets tests that secrets are correctly injected into workloads.
 func TestVolumeStatefulSet(t *testing.T) {
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
@@ -106,10 +101,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", true, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -24,16 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	imageReplacementsFile, namespaceFile, platformStr string
-	skipUndeploy                                      bool
-)
-
 // TestWorkloadSecrets tests that secrets are correctly injected into workloads.
 func TestWorkloadSecrets(t *testing.T) {
-	platform, err := platforms.FromString(platformStr)
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
-	ct := contrasttest.New(t, imageReplacementsFile, namespaceFile, platform, skipUndeploy)
+	ct := contrasttest.New(t)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	require.NoError(t, err)
@@ -138,10 +133,7 @@ func TestWorkloadSecrets(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&imageReplacementsFile, "image-replacements", "", "path to image replacements file")
-	flag.StringVar(&namespaceFile, "namespace-file", "", "file to store the namespace in")
-	flag.StringVar(&platformStr, "platform", "", "Deployment platform")
-	flag.BoolVar(&skipUndeploy, "skip-undeploy", false, "skip undeploy step in the test")
+	contrasttest.RegisterFlags()
 	flag.Parse()
 
 	os.Exit(m.Run())

--- a/justfile
+++ b/justfile
@@ -72,7 +72,8 @@ e2e target=default_deploy_target platform=default_platform: soft-clean coordinat
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
             --namespace-file ./{{ workspace_dir }}/just.namespace \
             --platform {{ platform }} \
-            --skip-undeploy=true
+            --skip-undeploy=true \
+            --namespace-suffix=${namespace_suffix-}
 
 # Generate policies, apply Kubernetes manifests.
 deploy target=default_deploy_target cli=default_cli platform=default_platform: (runtime target platform) (apply "runtime") (populate target platform) (generate cli platform) (apply target)


### PR DESCRIPTION
We invoke different e2e tests with the same nix command. This nix command already defines flags that are therefore shared between all current (and future) e2e tests. Let's make it easy to introduce new shared flags while maintaining the possibility that some tests define their own additional flags.

Also introduce a new namespace suffix flag.