### PR TITLE
kata-image: allow remount service to manage /run

### DIFF
--- a/packages/nixos/system.nix
+++ b/packages/nixos/system.nix
@@ -47,6 +47,7 @@
       "/" = {
         device = "/dev/mapper/root";
         fsType = "erofs";
+        options = [ "ro" ];
       };
     }
     # Create tmpfs on directories that need to be writable for activation.
@@ -71,10 +72,6 @@
           "/lib64"
         ]
     );
-
-  # We cant remount anything in the userspace, as we already
-  # have the rootfs mounted read-only from the initrd.
-  systemd.suppressedSystemUnits = [ "systemd-remount-fs.service" ];
 
   networking.firewall.enable = false;
 


### PR DESCRIPTION
We're configuring a tmpfs with 50% of the VMs memory capacity in kata.nix, but this configuration is only applied by systemd-remount-fs.service, which we thus need to enable. That service tries to remount all filesystems, though, so we need to define them correctly in the first place so that they can be remounted. In our case, that meant defining the / mount as read-only.

This fixes the regression test failures on main: https://github.com/edgelesssys/contrast/actions/runs/12250498650.