### PR TITLE
packages/nixos: minimize image size

### DIFF
--- a/packages/nixos/kata.nix
+++ b/packages/nixos/kata.nix
@@ -87,12 +87,8 @@ in
     };
 
     networking.resolvconf.enable = false;
-    systemd.tmpfiles.settings."10-etc-resolvconf"."/etc/resolv.conf".f = {
-      group = "root";
-      mode = "0755";
-      user = "root";
-    };
 
+    environment.etc."resolv.conf".text = "dummy file, to be bind-mounted by the Kata agent when writing network configuration";
     environment.etc."kata-opa/default-policy.rego".source = "${pkgs.kata-runtime.src}/src/kata-opa/allow-set-policy.rego";
   };
 }

--- a/packages/nixos/system.nix
+++ b/packages/nixos/system.nix
@@ -63,7 +63,6 @@
         })
         [
           "/var"
-          "/etc"
           "/bin"
           "/usr/bin"
           "/tmp"
@@ -77,6 +76,38 @@
 
   # Images are immutable, so no need to include Nix.
   nix.enable = false;
+
+  # Interpreter-less activation bits, tailored to our needs:
+  # Source: https://github.com/NixOS/nixpkgs/blob/a4741ea333f97cca0680d1eb485907f0e4a0eb3a/nixos/modules/profiles/perlless.nix
+  # We do not include the upstream module as-is, as we don't need sophisticated user generation, for example.
+
+  # Remove perl from activation
+  system.etc.overlay = {
+    enable = true;
+    mutable = false;
+  };
+
+  # simple replacement for update-users-groups.pl
+  systemd.sysusers.enable = true;
+
+  # Random perl remnants
+  system.disableInstallerTools = true;
+  programs.less.lessopen = null;
+  programs.command-not-found.enable = false;
+  boot.enableContainers = false;
+  environment.defaultPackages = [ ];
+  documentation.enable = false;
+
+  # Check that the system does not contain a Nix store path that contains the
+  # string "perl" or "python".
+  system.forbiddenDependenciesRegexes =
+    [
+      "perl"
+    ]
+    ++ lib.optionals (!config.contrast.debug.enable) [
+      # Some of the debug packages need Python.
+      "python"
+    ];
 
   nixpkgs.hostPlatform.system = "x86_64-linux";
   system.switch.enable = false;

--- a/packages/nixos/system.nix
+++ b/packages/nixos/system.nix
@@ -75,6 +75,9 @@
 
   networking.firewall.enable = false;
 
+  # Images are immutable, so no need to include Nix.
+  nix.enable = false;
+
   nixpkgs.hostPlatform.system = "x86_64-linux";
   system.switch.enable = false;
   system.stateVersion = "24.05";


### PR DESCRIPTION
Previously, our bare-metal Kata image weighed in at around 838MB. This PR reduces its size to about 561MB. It does so by incorporating the following changes:

- Remove Nix (CLI, daemon and store database) from the image closure. Since our image is immutable anyways, we do not need to include this anyways. Removing this saves around 188MB in image size.
- Remove Perl and Python interpreters from the image closure. These are only required for parts Nix' traditional "activation" mechanism, all of which have non-interpreter alternatives available. A tangible example for this is the population of `/etc`, which traditionally was implemented in Perl, but now has an overlayfs-based alternative for available. This saves around 90MB in image size.

Minimizations for the GPU-enabled image are intentionally deferred to be implemented in a follow-up PR.