### PR TITLE
ci: correctly trigger peerpods e2e on image changes

### DIFF
--- a/.github/workflows/e2e_peerpods.yml
+++ b/.github/workflows/e2e_peerpods.yml
@@ -13,7 +13,7 @@ on:
       - packages/by-name/cloud-api-adaptor/**
       - packages/by-name/kata/**
       - packages/by-name/image-podvm/**
-      - packages/nixos
+      - packages/nixos/**
 
 jobs:
   test:


### PR DESCRIPTION
Directory paths in the `pull_request` trigger need to include wildcards, otherwise actions will look for a file of that name and never match.

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-file-paths
