### PR TITLE
node-installer: add test for kata config

### DIFF
--- a/nodeinstaller/internal/config/kata_runtime.go
+++ b/nodeinstaller/internal/config/kata_runtime.go
@@ -3,6 +3,8 @@
 
 package config
 
+import "github.com/pelletier/go-toml/v2"
+
 // KataRuntimeConfig is the configuration for the Kata runtime.
 // Source: https://github.com/kata-containers/kata-containers/blob/4029d154ba0c26fcf4a8f9371275f802e3ef522c/src/runtime/pkg/katautils/config.go
 // This is a simplified version of the actual configuration.
@@ -12,6 +14,11 @@ type KataRuntimeConfig struct {
 	Image      Image
 	Factory    Factory
 	Runtime    KataRuntime
+}
+
+// Marshal encodes the configuration as TOML.
+func (k *KataRuntimeConfig) Marshal() ([]byte, error) {
+	return toml.Marshal(k)
 }
 
 // Image is the configuration for the image.

--- a/nodeinstaller/internal/config/kata_runtime_test.go
+++ b/nodeinstaller/internal/config/kata_runtime_test.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/edgelesssys/contrast/nodeinstaller/internal/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKataConfig(t *testing.T) {
+	// This is a regression test that ensures the `agent.kata` section is not optimized away. Empty
+	// section and no section are handled differently by Kata, so we make sure that this section is
+	// always present.
+	for _, platform := range platforms.All() {
+		t.Run(platform.String(), func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			cfg, err := constants.KataRuntimeConfig("/", platform, "", false)
+			require.NoError(err)
+			configBytes, err := cfg.Marshal()
+			require.NoError(err)
+			assert.Contains(string(configBytes), "[Agent.kata]")
+			assert.Contains(string(configBytes), "[Runtime]")
+
+			switch platform {
+			case platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.RKE2QEMUTDX:
+				assert.Contains(string(configBytes), "[Hypervisor.qemu]")
+			case platforms.AKSCloudHypervisorSNP:
+				assert.Contains(string(configBytes), "[Hypervisor.clh]")
+			default:
+				assert.Fail("missing hypervisor test expectations")
+			}
+		})
+	}
+}

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -182,7 +182,7 @@ func containerdRuntimeConfig(basePath, configPath string, platform platforms.Pla
 	if err != nil {
 		return fmt.Errorf("generating kata runtime config: %w", err)
 	}
-	rawConfig, err := toml.Marshal(kataRuntimeConfig)
+	rawConfig, err := kataRuntimeConfig.Marshal()
 	if err != nil {
 		return fmt.Errorf("marshaling kata runtime config: %w", err)
 	}


### PR DESCRIPTION
This is a cherry-pick from #1043. We don't have that particular bug in the other configs, but better to have the test than not.