### PR TITLE
deps: downgrade softprops/action-gh-release to v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,7 @@ jobs:
             workspace/emojivoto-demo.yml
             workspace/mysql-demo.yml
       - name: Create draft release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           draft: true
           generate_release_notes: true


### PR DESCRIPTION
There is some bug in v2.2.0, see https://github.com/softprops/action-gh-release/issues/555

 Reverting the bump from https://github.com/edgelesssys/contrast/commit/d19413cd18aba8dac6a1b5dbad19c04d0975d513#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L334