### PR TITLE
kds-cache: adjust cache expiration time to 9 months

### DIFF
--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -36,7 +36,8 @@ type Credentials struct {
 
 // Credentials creates new transport credentials that validate peers according to the latest manifest.
 func (a *Authority) Credentials(reg *prometheus.Registry, issuer atls.Issuer) (*Credentials, func()) {
-	ticker := clock.RealClock{}.NewTicker(24 * time.Hour)
+	month := 30 * 24 * time.Hour
+	ticker := clock.RealClock{}.NewTicker(9 * month)
 	kdsGetter := certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(a.logger, "kds-getter"))
 	attestationFailuresCounter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Subsystem: "contrast_meshapi",


### PR DESCRIPTION
This PR updates the fixed expiration timespan of the kds-cache inside of the coordinator to 9 months, which allows to keep Contrast's attestation running even if the KDS server is unavailable at the moment. The expected cache size will be 40 MB,  estimated for a upper bound of 5000 nodes in the deployment. 