### PR TITLE
e2e/vmss: align test path with volume path 

### DIFF
--- a/e2e/volumestatefulset/volumestatefulset_test.go
+++ b/e2e/volumestatefulset/volumestatefulset_test.go
@@ -59,7 +59,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))
 	}), "deployments need to be ready for subsequent tests")
 
-	filePath := "/srv/state/test"
+	filePath := "/state/test"
 	t.Run("can create file in mounted path", func(t *testing.T) {
 		require := require.New(t)
 

--- a/justfile
+++ b/justfile
@@ -72,7 +72,6 @@ e2e target=default_deploy_target platform=default_platform: soft-clean coordinat
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
             --namespace-file ./{{ workspace_dir }}/just.namespace \
             --platform {{ platform }} \
-            --skip-undeploy=true \
             --namespace-suffix=${namespace_suffix-}
 
 # Generate policies, apply Kubernetes manifests.


### PR DESCRIPTION
In https://github.com/edgelesssys/contrast/pull/1045 we changed where we mount the stateful volume from `/srv/state` to `/state`. Adjust the path where we create the test file accordingly. Since we don't ship any deployment that sets up this path anywhere, expect for the newly written example, there are no customers that can depend on it, apart from us. Generally, while our deployment is only an example, we should try to keep the path stable.

Additionally, remove the unused `--skip-undeploy` flag from the e2e target in the justfile in order for the target to work again.

To test: `just e2e volumestatefulset`