### PR TITLE
packages/nixos: write Kata agent output to console and journal

### DIFF
--- a/packages/nixos/kata.nix
+++ b/packages/nixos/kata.nix
@@ -50,7 +50,8 @@ in
       after = [ "systemd-tmpfiles-setup.service" ]; # Not upstream, but required for /etc/resolv.conf bind mount.
       serviceConfig = {
         Type = "exec"; # Not upstream.
-        StandardOutput = "tty";
+        StandardOutput = "journal+console";
+        StandardError = "inherit";
         ExecStart = "${lib.getExe pkgs.kata-agent}";
         LimitNOFILE = 1048576;
         ExecStop = "${pkgs.coreutils}/bin/sync ; ${config.systemd.package}/bin/systemctl --force poweroff";


### PR DESCRIPTION
Previously, we only wrote Kata agent output to the console / TTY (which is also what it does upstream [^1]). This makes the output appear in the Kata runtime logs on the Host via the `vmconsole=` field. However, when debugging from within the pod VM, it's helpful to also have the logs in there so that they can be searched in with `journalctl`. This makes it so the output of the agent is written to both the console _and_ the journal.

[^1]: https://github.com/kata-containers/kata-containers/blob/3.10.1/src/agent/kata-agent.service.in