### PR TITLE
packages/kata-runtime: add guest hook support to genpolicy

### DIFF
--- a/packages/by-name/kata/kata-runtime/0020-genpolicy-support-guest-hooks.patch
+++ b/packages/by-name/kata/kata-runtime/0020-genpolicy-support-guest-hooks.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Fri, 6 Dec 2024 17:14:57 +0100
+Subject: [PATCH] genpolicy: support guest hooks
+
+Some custom images come with guest hooks that are required to set up
+VM-level resources for containers, such as GPU support.
+
+This commit adds a new setting, `allowed_guest_hooks`, which controls
+what paths may be set for hooks.
+
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/tools/genpolicy/genpolicy-settings.json |  3 ++-
+ src/tools/genpolicy/rules.rego              | 17 ++++++++++++++++-
+ src/tools/genpolicy/src/policy.rs           |  2 ++
+ 3 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
+index a218a4d9c4717e4dd2abdc3fd4b0d1a6d8171661..a9ca4960e9e6879109a4f0b50b9aebe33430e674 100644
+--- a/src/tools/genpolicy/genpolicy-settings.json
++++ b/src/tools/genpolicy/genpolicy-settings.json
+@@ -240,7 +240,8 @@
+                 "mount_point": "/run/kata-containers/sandbox/shm",
+                 "fs_group": null
+             }
+-        ]
++        ],
++        "allowed_guest_hooks": ["/usr/share/oci/hooks"]
+     },
+     "common": {
+         "cpath": "/run/kata-containers",
+diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
+index 6cabea53a52c2e0b9b52a086d166613d3440d5c4..810fb327b06d654b48ce8e76eb7d325cd39de52a 100644
+--- a/src/tools/genpolicy/rules.rego
++++ b/src/tools/genpolicy/rules.rego
+@@ -1217,7 +1217,7 @@ CopyFileRequest {
+ 
+ CreateSandboxRequest {
+     print("CreateSandboxRequest: input.guest_hook_path =", input.guest_hook_path)
+-    count(input.guest_hook_path) == 0
++    allow_hook(input.guest_hook_path)
+ 
+     print("CreateSandboxRequest: input.kernel_modules =", input.kernel_modules)
+     count(input.kernel_modules) == 0
+@@ -1228,6 +1228,21 @@ CreateSandboxRequest {
+     allow_sandbox_storages(input.storages)
+ }
+ 
++allow_hook(i_hook) {
++    print("allow_hook 1: start")
++    count(i_hook) == 0
++    print("allow_hook 1: true")
++}
++
++allow_hook(i_hook) {
++    print("allow_hook 2: start")
++    p_hooks := policy_data.sandbox.allowed_guest_hooks
++    print("allow_hook 2: p_hooks =", p_hooks)
++    print("allow_hook 2: i_hook =", i_hook)
++    i_hook in p_hooks
++    print("allow_hook 2: true")
++}
++
+ ExecProcessRequest {
+     print("ExecProcessRequest 1: input =", input)
+ 
+diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
+index 9e69126d9008f361e77086018414abc75a8cc092..9f4accaca8c57620f9becd1d10d9606004be3adb 100644
+--- a/src/tools/genpolicy/src/policy.rs
++++ b/src/tools/genpolicy/src/policy.rs
+@@ -408,6 +408,8 @@ pub struct ClusterConfig {
+ pub struct SandboxData {
+     /// Expected value of the CreateSandboxRequest storages field.
+     pub storages: Vec<agent::Storage>,
++    /// Guest hook paths that are allowed to be set in all CreateContainerRequests.
++    pub allowed_guest_hooks: Vec<String>,
+ }
+ 
+ impl AgentPolicy {

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -114,6 +114,12 @@ buildGoModule rec {
       # vanilla Kata setting.
       # Relevant discussion: https://github.com/kata-containers/kata-containers/pull/10614.
       ./0019-genpolicy-allow-non-watchable-ConfigMaps.patch
+
+      # Guest hooks are required for GPU support, but unsupported in
+      # upstream Kata / genpolicy as of now. This patch adds a new
+      # `allowed_guest_hooks` setting , which controls what paths may be set for hooks.
+      # Upstream issue: https://github.com/kata-containers/kata-containers/issues/10633
+      ./0020-genpolicy-support-guest-hooks.patch
     ];
   };
 


### PR DESCRIPTION
This adds a patch that integrates support for setting guest hooks to genpolicy, which is a prerequisite for GPU containers, which require guest hooks.