### PR TITLE
Add {Metal,K3s}-QEMU-SNP-GPU platforms

### DIFF
--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -48,7 +48,7 @@ jobs:
               echo "runner=ubuntu-22.04" >> "$GITHUB_OUTPUT"
               echo "self-hosted=false" >> "$GITHUB_OUTPUT"
             ;;
-            "K3s-QEMU-SNP")
+            "K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU")
               echo "runner=SNP" >> "$GITHUB_OUTPUT"
               echo "self-hosted=true" >> "$GITHUB_OUTPUT"
             ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
       - name: Create coordinator resource definitions
         run: |
           mkdir -p workspace
-          for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp rke2-qemu-tdx; do
+          for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp k3s-qemu-snp-gpu rke2-qemu-tdx; do
             nix run .#scripts.write-coordinator-yaml -- "${coordinatorImgTagged}" "${platform}" > workspace/coordinator-$platform.yml
             echo -n "${platform} " >> workspace/coordinator-policy.hash
             yq < workspace/coordinator-$platform.yml \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
       - name: Create coordinator resource definitions
         run: |
           mkdir -p workspace
-          for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp k3s-qemu-snp-gpu rke2-qemu-tdx; do
+          for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp k3s-qemu-snp-gpu rke2-qemu-tdx metal-qemu-snp-gpu; do
             nix run .#scripts.write-coordinator-yaml -- "${coordinatorImgTagged}" "${platform}" > workspace/coordinator-$platform.yml
             echo -n "${platform} " >> workspace/coordinator-policy.hash
             yq < workspace/coordinator-$platform.yml \

--- a/cli/genpolicy/config.go
+++ b/cli/genpolicy/config.go
@@ -43,7 +43,9 @@ func NewConfig(platform platforms.Platform) *Config {
 			Settings: aksSettings,
 			Bin:      aksGenpolicyBin,
 		}
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP,
+		platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX,
+		platforms.MetalQEMUSNPGPU:
 		return &Config{
 			Rules:    kataRules,
 			Settings: kataSettings,

--- a/cli/genpolicy/config.go
+++ b/cli/genpolicy/config.go
@@ -43,7 +43,7 @@ func NewConfig(platform platforms.Platform) *Config {
 			Settings: aksSettings,
 			Bin:      aksGenpolicyBin,
 		}
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 		return &Config{
 			Rules:    kataRules,
 			Settings: kataSettings,

--- a/cli/main.go
+++ b/cli/main.go
@@ -105,7 +105,9 @@ func buildVersionString() (string, error) {
 		switch platform {
 		case platforms.AKSCloudHypervisorSNP:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.MicrosoftGenpolicyVersion)
-		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
+		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP,
+			platforms.K3sQEMUTDX, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX,
+			platforms.MetalQEMUSNPGPU:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.KataGenpolicyVersion)
 		}
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -105,7 +105,7 @@ func buildVersionString() (string, error) {
 		switch platform {
 		case platforms.AKSCloudHypervisorSNP:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.MicrosoftGenpolicyVersion)
-		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.KataGenpolicyVersion)
 		}
 	}

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -213,7 +213,7 @@ func patchReferenceValues(platform platforms.Platform) PatchManifestFunc {
 				SNPVersion:        toPtr(manifest.SVN(255)),
 				MicrocodeVersion:  toPtr(manifest.SVN(255)),
 			}
-		case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
+		case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 			// The generate command doesn't fill in all required fields when
 			// generating a manifest for baremetal SNP. Do that now.
 			for i, snp := range m.ReferenceValues.SNP {
@@ -381,7 +381,9 @@ func (ct *ContrastTest) FactorPlatformTimeout(timeout time.Duration) time.Durati
 	switch ct.Platform {
 	case platforms.AKSCloudHypervisorSNP: // AKS defined is the baseline
 		return timeout
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP,
+		platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX,
+		platforms.MetalQEMUSNPGPU:
 		return 2 * timeout
 	default:
 		return timeout

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -213,7 +213,7 @@ func patchReferenceValues(platform platforms.Platform) PatchManifestFunc {
 				SNPVersion:        toPtr(manifest.SVN(255)),
 				MicrocodeVersion:  toPtr(manifest.SVN(255)),
 			}
-		case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP:
+		case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 			// The generate command doesn't fill in all required fields when
 			// generating a manifest for baremetal SNP. Do that now.
 			for i, snp := range m.ReferenceValues.SNP {
@@ -381,7 +381,7 @@ func (ct *ContrastTest) FactorPlatformTimeout(timeout time.Duration) time.Durati
 	switch ct.Platform {
 	case platforms.AKSCloudHypervisorSNP: // AKS defined is the baseline
 		return timeout
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 		return 2 * timeout
 	default:
 		return timeout

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -126,7 +126,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-microsoft:latest"
 		snapshotter = tardevSnapshotter
 		snapshotterVolumes = tardevSnapshotterVolumes
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
 		snapshotter = nydusSnapshotter
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes, Volume().

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -136,7 +136,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 				WithType(corev1.HostPathDirectory),
 			))
 		snapshotterVolumes = nydusSnapshotterVolumes
-	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
+	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
 		snapshotter = nydusSnapshotter
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes, Volume().

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -143,11 +143,11 @@ func platformFromHandler(handler string) (platforms.Platform, error) {
 	}
 
 	parts := strings.Split(rest, "-")
-	if len(parts) != 4 {
+	if len(parts) != 4 && len(parts) != 5 {
 		return platforms.Unknown, fmt.Errorf("invalid handler name: %s", handler)
 	}
 
-	rawPlatform := fmt.Sprintf("%s-%s-%s", parts[0], parts[1], parts[2])
+	rawPlatform := strings.Join(parts[:len(parts)-1], "-")
 
 	platform, err := platforms.FromString(rawPlatform)
 	if err != nil {

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -28,11 +28,13 @@ const (
 	MetalQEMUSNP
 	// MetalQEMUTDX is the generic platform for bare-metal TDX deployments.
 	MetalQEMUTDX
+	// K3sQEMUSNPGPU represents a deployment with QEMU on bare-metal SNP K3s with GPU passthrough.
+	K3sQEMUSNPGPU
 )
 
 // All returns a list of all available platforms.
 func All() []Platform {
-	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX}
+	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX, K3sQEMUSNPGPU}
 }
 
 // AllStrings returns a list of all available platforms as strings.
@@ -53,6 +55,8 @@ func (p Platform) String() string {
 		return "K3s-QEMU-TDX"
 	case K3sQEMUSNP:
 		return "K3s-QEMU-SNP"
+	case K3sQEMUSNPGPU:
+		return "K3s-QEMU-SNP-GPU"
 	case RKE2QEMUTDX:
 		return "RKE2-QEMU-TDX"
 	case MetalQEMUSNP:
@@ -73,6 +77,8 @@ func FromString(s string) (Platform, error) {
 		return K3sQEMUTDX, nil
 	case "k3s-qemu-snp":
 		return K3sQEMUSNP, nil
+	case "k3s-qemu-snp-gpu":
+		return K3sQEMUSNPGPU, nil
 	case "rke2-qemu-tdx":
 		return RKE2QEMUTDX, nil
 	case "metal-qemu-snp":

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -30,11 +30,13 @@ const (
 	MetalQEMUTDX
 	// K3sQEMUSNPGPU represents a deployment with QEMU on bare-metal SNP K3s with GPU passthrough.
 	K3sQEMUSNPGPU
+	// MetalQEMUSNPGPU is the generic platform for bare-metal SNP deployments with GPU passthrough.
+	MetalQEMUSNPGPU
 )
 
 // All returns a list of all available platforms.
 func All() []Platform {
-	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX, K3sQEMUSNPGPU}
+	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX, K3sQEMUSNPGPU, MetalQEMUSNPGPU}
 }
 
 // AllStrings returns a list of all available platforms as strings.
@@ -61,6 +63,8 @@ func (p Platform) String() string {
 		return "RKE2-QEMU-TDX"
 	case MetalQEMUSNP:
 		return "Metal-QEMU-SNP"
+	case MetalQEMUSNPGPU:
+		return "Metal-QEMU-SNP-GPU"
 	case MetalQEMUTDX:
 		return "Metal-QEMU-TDX"
 	default:
@@ -83,6 +87,8 @@ func FromString(s string) (Platform, error) {
 		return RKE2QEMUTDX, nil
 	case "metal-qemu-snp":
 		return MetalQEMUSNP, nil
+	case "metal-qemu-snp-gpu":
+		return MetalQEMUSNPGPU, nil
 	case "metal-qemu-tdx":
 		return MetalQEMUTDX, nil
 	default:

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ node-installer platform=default_platform:
             just push "tardev-snapshotter"
             just push "node-installer-microsoft"
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"Metal-QEMU-SNP-GPU"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             just push "nydus-snapshotter"
             just push "node-installer-kata"
         ;;
@@ -117,7 +117,7 @@ generate cli=default_cli platform=default_platform:
 
     # On baremetal SNP, we don't have default values for MinimumTCB, so we need to set some here.
     case {{ platform }} in
-        "Metal-QEMU-SNP"|"K3s-QEMU-SNP")
+        "Metal-QEMU-SNP"|"Metal-QEMU-SNP-GPU"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU")
             yq --inplace \
             '.ReferenceValues.snp.[].MinimumTCB = {"BootloaderVersion":0,"TEEVersion":0,"SNPVersion":0,"MicrocodeVersion":0}' \
             {{ workspace_dir }}/manifest.json
@@ -186,7 +186,7 @@ create-pre platform=default_platform:
             # TODO(burgerdev): this should create the resource group for consistency
             :
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"Metal-QEMU-SNP-GPU"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             :
         ;;
         "AKS-PEER-SNP")
@@ -215,7 +215,7 @@ create platform=default_platform:
         "AKS-CLH-SNP")
             nix run -L .#scripts.create-coco-aks -- --name="$azure_resource_group" --location="$azure_location"
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"Metal-QEMU-SNP-GPU"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             :
         ;;
         "AKS-PEER-SNP")

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ node-installer platform=default_platform:
             just push "tardev-snapshotter"
             just push "node-installer-microsoft"
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             just push "nydus-snapshotter"
             just push "node-installer-kata"
         ;;
@@ -186,7 +186,7 @@ create-pre platform=default_platform:
             # TODO(burgerdev): this should create the resource group for consistency
             :
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             :
         ;;
         "AKS-PEER-SNP")
@@ -215,7 +215,7 @@ create platform=default_platform:
         "AKS-CLH-SNP")
             nix run -L .#scripts.create-coco-aks -- --name="$azure_resource_group" --location="$azure_location"
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             :
         ;;
         "AKS-PEER-SNP")
@@ -328,7 +328,7 @@ get-credentials platform=default_platform:
         "K3s-QEMU-TDX")
             nix run -L .#scripts.get-credentials "projects/796962942582/secrets/m50-ganondorf-kubeconf/versions/5"
         ;;
-        "K3s-QEMU-SNP")
+        "K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU")
             nix run -L .#scripts.get-credentials "projects/796962942582/secrets/discovery-kubeconf/versions/2"
         ;;
         *)
@@ -352,7 +352,7 @@ destroy platform=default_platform:
         "AKS-CLH-SNP")
             nix run -L .#scripts.destroy-coco-aks -- --name="$azure_resource_group"
         ;;
-        "K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             :
         ;;
         "AKS-PEER-SNP")
@@ -377,7 +377,7 @@ destroy-post platform=default_platform:
             # TODO(burgerdev): this should destroy the resource group for consistency.
             :
         ;;
-        "K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             :
         ;;
         "AKS-PEER-SNP")

--- a/nodeinstaller/internal/config/kata_runtime_test.go
+++ b/nodeinstaller/internal/config/kata_runtime_test.go
@@ -28,7 +28,9 @@ func TestKataConfig(t *testing.T) {
 			assert.Contains(string(configBytes), "[Runtime]")
 
 			switch platform {
-			case platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.RKE2QEMUTDX:
+			case platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX,
+				platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.RKE2QEMUTDX,
+				platforms.MetalQEMUSNPGPU:
 				assert.Contains(string(configBytes), "[Hypervisor.qemu]")
 			case platforms.AKSCloudHypervisorSNP:
 				assert.Contains(string(configBytes), "[Hypervisor.clh]")

--- a/nodeinstaller/internal/config/kata_runtime_test.go
+++ b/nodeinstaller/internal/config/kata_runtime_test.go
@@ -28,7 +28,7 @@ func TestKataConfig(t *testing.T) {
 			assert.Contains(string(configBytes), "[Runtime]")
 
 			switch platform {
-			case platforms.K3sQEMUSNP, platforms.K3sQEMUTDX, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.RKE2QEMUTDX:
+			case platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.RKE2QEMUTDX:
 				assert.Contains(string(configBytes), "[Hypervisor.qemu]")
 			case platforms.AKSCloudHypervisorSNP:
 				assert.Contains(string(configBytes), "[Hypervisor.clh]")

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -137,6 +137,10 @@ func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platf
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-snp.toml"),
 		}
+		// For GPU support, we need to pass through the CDI annotations.
+		if platform == platforms.K3sQEMUSNPGPU {
+			cfg.PodAnnotations = append(cfg.PodAnnotations, "cdi.k8s.io/*")
+		}
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", platform)
 	}

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -94,6 +94,14 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		if debug {
 			config.Hypervisor["qemu"]["enable_debug"] = true
 		}
+		// GPU-specific settings
+		if platform == platforms.K3sQEMUSNPGPU {
+			config.Hypervisor["qemu"]["guest_hook_path"] = "/usr/share/oci/hooks"
+			config.Hypervisor["qemu"]["cold_plug_vfio"] = "root-port"
+			// GPU images tend to be larger, so give a better default timeout that
+			// allows for pulling those.
+			config.Runtime["create_container_timeout"] = 600
+		}
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", platform)
 	}

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -75,7 +75,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		if debug {
 			config.Hypervisor["qemu"]["enable_debug"] = true
 		}
-	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP:
+	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 		if err := toml.Unmarshal([]byte(kataBareMetalQEMUSNPBaseConfig), &config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
@@ -133,7 +133,7 @@ func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platf
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-tdx.toml"),
 		}
-	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP:
+	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-snp.toml"),
 		}

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -75,7 +75,8 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		if debug {
 			config.Hypervisor["qemu"]["enable_debug"] = true
 		}
-	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
+	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU,
+		platforms.MetalQEMUSNPGPU:
 		if err := toml.Unmarshal([]byte(kataBareMetalQEMUSNPBaseConfig), &config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
@@ -95,7 +96,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 			config.Hypervisor["qemu"]["enable_debug"] = true
 		}
 		// GPU-specific settings
-		if platform == platforms.K3sQEMUSNPGPU {
+		if platform == platforms.K3sQEMUSNPGPU || platform == platforms.MetalQEMUSNPGPU {
 			config.Hypervisor["qemu"]["guest_hook_path"] = "/usr/share/oci/hooks"
 			config.Hypervisor["qemu"]["cold_plug_vfio"] = "root-port"
 			// GPU images tend to be larger, so give a better default timeout that
@@ -141,12 +142,13 @@ func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platf
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-tdx.toml"),
 		}
-	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
+	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU,
+		platforms.MetalQEMUSNPGPU:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-snp.toml"),
 		}
 		// For GPU support, we need to pass through the CDI annotations.
-		if platform == platforms.K3sQEMUSNPGPU {
+		if platform == platforms.K3sQEMUSNPGPU || platform == platforms.MetalQEMUSNPGPU {
 			cfg.PodAnnotations = append(cfg.PodAnnotations, "cdi.k8s.io/*")
 		}
 	default:

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -107,7 +107,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	case platforms.AKSCloudHypervisorSNP:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-clh-snp.toml")
 		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
-	case platforms.MetalQEMUSNP:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-qemu-snp.toml")
 		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
 	case platforms.MetalQEMUTDX:
@@ -145,7 +145,8 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	}
 
 	switch platform {
-	case platforms.AKSCloudHypervisorSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX:
+	case platforms.AKSCloudHypervisorSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX,
+		platforms.MetalQEMUSNPGPU:
 		return restartHostContainerd(containerdConfigPath, "containerd")
 	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 		if hostServiceExists("k3s") {
@@ -212,7 +213,9 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	case platforms.AKSCloudHypervisorSNP:
 		snapshotterName = fmt.Sprintf("tardev-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/tardev-snapshotter-%s.sock", runtimeHandler)
-	case platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX,
+		platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX,
+		platforms.MetalQEMUSNPGPU:
 		snapshotterName = fmt.Sprintf("nydus-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/containerd-nydus-grpc-%s.sock", runtimeHandler)
 

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -113,7 +113,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	case platforms.MetalQEMUTDX:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-qemu-tdx.toml")
 		containerdConfigPath = filepath.Join(hostMount, "etc", "containerd", "config.toml")
-	case platforms.K3sQEMUSNP:
+	case platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 		kataConfigPath = filepath.Join(kataConfigPath, "configuration-qemu-snp.toml")
 		containerdConfigPath = filepath.Join(hostMount, "var", "lib", "rancher", "k3s", "agent", "etc", "containerd", "config.toml.tmpl")
 	case platforms.K3sQEMUTDX:
@@ -147,7 +147,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform,
 	switch platform {
 	case platforms.AKSCloudHypervisorSNP, platforms.MetalQEMUSNP, platforms.MetalQEMUTDX:
 		return restartHostContainerd(containerdConfigPath, "containerd")
-	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP:
+	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
 		if hostServiceExists("k3s") {
 			return restartHostContainerd(containerdConfigPath, "k3s")
 		} else if hostServiceExists("k3s-agent") {
@@ -212,7 +212,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	case platforms.AKSCloudHypervisorSNP:
 		snapshotterName = fmt.Sprintf("tardev-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/tardev-snapshotter-%s.sock", runtimeHandler)
-	case platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUTDX, platforms.MetalQEMUSNP, platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
 		snapshotterName = fmt.Sprintf("nydus-%s", runtimeHandler)
 		socketName = fmt.Sprintf("/run/containerd/containerd-nydus-grpc-%s.sock", runtimeHandler)
 

--- a/nodeinstaller/node-installer_test.go
+++ b/nodeinstaller/node-installer_test.go
@@ -36,15 +36,15 @@ func TestPatchContainerdConfig(t *testing.T) {
 			platform: platforms.AKSCloudHypervisorSNP,
 			expected: expectedConfAKSCLHSNP,
 		},
-		"BareMetalQEMUTDX": {
+		"K3sQEMUTDX": {
 			platform: platforms.K3sQEMUTDX,
 			expected: expectedConfBareMetalQEMUTDX,
 		},
-		"BareMetalQEMUSNP": {
+		"K3sQEMUSNP": {
 			platform: platforms.K3sQEMUSNP,
 			expected: expectedConfBareMetalQEMUSNP,
 		},
-		"BareMetalQEMUSNPGPU": {
+		"K3sQEMUSNPGPU": {
 			platform: platforms.K3sQEMUSNPGPU,
 			expected: expectedConfBareMetalQEMUSNPGPU,
 		},

--- a/nodeinstaller/node-installer_test.go
+++ b/nodeinstaller/node-installer_test.go
@@ -22,6 +22,8 @@ var (
 	expectedConfBareMetalQEMUTDX []byte
 	//go:embed testdata/expected-bare-metal-qemu-snp.toml
 	expectedConfBareMetalQEMUSNP []byte
+	//go:embed testdata/expected-bare-metal-qemu-snp-gpu.toml
+	expectedConfBareMetalQEMUSNPGPU []byte
 )
 
 func TestPatchContainerdConfig(t *testing.T) {
@@ -44,7 +46,7 @@ func TestPatchContainerdConfig(t *testing.T) {
 		},
 		"BareMetalQEMUSNPGPU": {
 			platform: platforms.K3sQEMUSNPGPU,
-			expected: expectedConfBareMetalQEMUSNP,
+			expected: expectedConfBareMetalQEMUSNPGPU,
 		},
 		"Unknown": {
 			platform: platforms.Unknown,

--- a/nodeinstaller/node-installer_test.go
+++ b/nodeinstaller/node-installer_test.go
@@ -42,6 +42,10 @@ func TestPatchContainerdConfig(t *testing.T) {
 			platform: platforms.K3sQEMUSNP,
 			expected: expectedConfBareMetalQEMUSNP,
 		},
+		"BareMetalQEMUSNPGPU": {
+			platform: platforms.K3sQEMUSNPGPU,
+			expected: expectedConfBareMetalQEMUSNP,
+		},
 		"Unknown": {
 			platform: platforms.Unknown,
 			wantErr:  true,

--- a/nodeinstaller/testdata/expected-bare-metal-qemu-snp-gpu.toml
+++ b/nodeinstaller/testdata/expected-bare-metal-qemu-snp-gpu.toml
@@ -1,0 +1,81 @@
+version = 2
+
+[debug]
+level = 'debug'
+
+[metrics]
+address = '0.0.0.0:10257'
+
+[plugins]
+[plugins.'io.containerd.grpc.v1.cri']
+sandbox_image = 'mcr.microsoft.com/oss/kubernetes/pause:3.6'
+
+[plugins.'io.containerd.grpc.v1.cri'.cni]
+bin_dir = '/opt/cni/bin'
+conf_dir = '/etc/cni/net.d'
+conf_template = '/etc/containerd/kubenet_template.conf'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd]
+default_runtime_name = 'runc'
+disable_snapshot_annotations = false
+discard_unpacked_layers = false
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes]
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata]
+runtime_type = 'io.containerd.kata.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata-cc]
+pod_annotations = ['io.katacontainers.*']
+privileged_without_host_devices = true
+runtime_type = 'io.containerd.kata-cc.v2'
+snapshotter = 'tardev'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.kata-cc.options]
+ConfigPath = '/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.katacli]
+runtime_type = 'io.containerd.runc.v1'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.katacli.options]
+BinaryName = '/usr/bin/kata-runtime'
+CriuPath = ''
+IoGid = 0
+IoUid = 0
+NoNewKeyring = false
+NoPivotRoot = false
+Root = ''
+ShimCgroup = ''
+SystemdCgroup = false
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime]
+runtime_type = 'io.containerd.contrast-cc.v2'
+runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
+pod_annotations = ['io.katacontainers.*', 'cdi.k8s.io/*']
+privileged_without_host_devices = true
+snapshotter = 'nydus-my-runtime'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
+ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-qemu-snp.toml'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc]
+runtime_type = 'io.containerd.runc.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc.options]
+BinaryName = '/usr/bin/runc'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.untrusted]
+runtime_type = 'io.containerd.runc.v2'
+
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.untrusted.options]
+BinaryName = '/usr/bin/runc'
+
+[plugins.'io.containerd.grpc.v1.cri'.registry]
+config_path = '/etc/containerd/certs.d'
+
+[plugins.'io.containerd.grpc.v1.cri'.registry.headers]
+X-Meta-Source-Client = ['azure/aks']
+
+[proxy_plugins]
+[proxy_plugins.nydus-my-runtime]
+type = 'snapshot'
+address = '/run/containerd/containerd-nydus-grpc-my-runtime.sock'

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -57,6 +57,7 @@ let
       rke2-qemu-tdx-handler = runtimeHandler "rke2-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       metal-qemu-snp-handler = runtimeHandler "metal-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
       k3s-qemu-snp-handler = runtimeHandler "k3s-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
+      k3s-qemu-snp-gpu-handler = runtimeHandler "k3s-qemu-snp-gpu" kata.contrast-node-installer-image.runtimeHash;
 
       aksRefVals = {
         snp = [
@@ -135,6 +136,7 @@ let
         "${rke2-qemu-tdx-handler}" = tdxRefVals;
         "${metal-qemu-snp-handler}" = snpRefVals;
         "${k3s-qemu-snp-handler}" = snpRefVals;
+        "${k3s-qemu-snp-gpu-handler}" = snpRefVals;
       }
     );
 

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -56,9 +56,9 @@ let
       k3s-qemu-tdx-handler = runtimeHandler "k3s-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       rke2-qemu-tdx-handler = runtimeHandler "rke2-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       metal-qemu-snp-handler = runtimeHandler "metal-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
+      metal-qemu-snp-gpu-handler = runtimeHandler "metal-qemu-snp-gpu" kata.contrast-node-installer-image.runtimeHash;
       k3s-qemu-snp-handler = runtimeHandler "k3s-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
       k3s-qemu-snp-gpu-handler = runtimeHandler "k3s-qemu-snp-gpu" kata.contrast-node-installer-image.runtimeHash;
-
       aksRefVals = {
         snp = [
           {
@@ -135,6 +135,7 @@ let
         "${k3s-qemu-tdx-handler}" = tdxRefVals;
         "${rke2-qemu-tdx-handler}" = tdxRefVals;
         "${metal-qemu-snp-handler}" = snpRefVals;
+        "${metal-qemu-snp-gpu-handler}" = snpRefVals;
         "${k3s-qemu-snp-handler}" = snpRefVals;
         "${k3s-qemu-snp-gpu-handler}" = snpRefVals;
       }

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -80,7 +80,7 @@ let
                     if (platform == "metal-qemu-tdx" || platform == "metal-qemu-snp") then
                       (builtins.compareVersions "v1.2.1" version) <= 0
                     # TODO(msanft): Check back on this on v1.3.0 release
-                    else if (platform == "k3s-qemu-snp-gpu") then
+                    else if (platform == "metal-qemu-snp-gpu" || platform == "k3s-qemu-snp-gpu") then
                       (builtins.compareVersions "v1.3.0" version) <= 0
                     else
                       (builtins.compareVersions "v1.1.0" version) <= 0;
@@ -99,6 +99,7 @@ let
               [
                 "aks-clh-snp"
                 "metal-qemu-snp"
+                "metal-qemu-snp-gpu"
                 "metal-qemu-tdx"
                 "k3s-qemu-tdx"
                 "k3s-qemu-snp"

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -79,6 +79,9 @@ let
                   exist =
                     if (platform == "metal-qemu-tdx" || platform == "metal-qemu-snp") then
                       (builtins.compareVersions "v1.2.1" version) <= 0
+                    # TODO(msanft): Check back on this on v1.3.0 release
+                    else if (platform == "k3s-qemu-snp-gpu") then
+                      (builtins.compareVersions "v1.3.0" version) <= 0
                     else
                       (builtins.compareVersions "v1.1.0" version) <= 0;
                   coordinator = fetchurl {
@@ -99,6 +102,7 @@ let
                 "metal-qemu-tdx"
                 "k3s-qemu-tdx"
                 "k3s-qemu-snp"
+                "k3s-qemu-snp-gpu"
                 "rke2-qemu-tdx"
               ]
           );

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -259,7 +259,7 @@
           cp ${pkgs.microsoft.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.microsoft.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"
         ;;
-        "metal-qemu-snp"|"k3s-qemu-snp"|"metal-qemu-tdx"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
+        "metal-qemu-snp"|"k3s-qemu-snp"|"k3s-qemu-snp-gpu"|"metal-qemu-tdx"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
           cp ${pkgs.kata.genpolicy.rules-coordinator}/genpolicy-rules.rego rules.rego
           cp ${pkgs.kata.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.kata.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -259,7 +259,7 @@
           cp ${pkgs.microsoft.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.microsoft.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"
         ;;
-        "metal-qemu-snp"|"k3s-qemu-snp"|"k3s-qemu-snp-gpu"|"metal-qemu-tdx"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
+        "metal-qemu-snp"|"metal-qemu-snp-gpu"|"k3s-qemu-snp"|"k3s-qemu-snp-gpu"|"metal-qemu-tdx"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
           cp ${pkgs.kata.genpolicy.rules-coordinator}/genpolicy-rules.rego rules.rego
           cp ${pkgs.kata.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.kata.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"

--- a/packages/update-contrast-releases.sh
+++ b/packages/update-contrast-releases.sh
@@ -21,7 +21,7 @@ fields["runtime.yml"]="./workspace/runtime.yml"
 fields["emojivoto-demo.zip"]="./workspace/emojivoto-demo.zip"
 fields["emojivoto-demo.yml"]="./workspace/emojivoto-demo.yml"
 fields["mysql-demo.yml"]="./workspace/mysql-demo.yml"
-for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp rke2-qemu-tdx; do
+for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp k3s-qemu-snp-gpu rke2-qemu-tdx; do
   fields["coordinator-${platform}.yml"]="./workspace/coordinator-${platform}.yml"
   fields["runtime-${platform}.yml"]="./workspace/runtime-${platform}.yml"
 done

--- a/packages/update-contrast-releases.sh
+++ b/packages/update-contrast-releases.sh
@@ -21,7 +21,7 @@ fields["runtime.yml"]="./workspace/runtime.yml"
 fields["emojivoto-demo.zip"]="./workspace/emojivoto-demo.zip"
 fields["emojivoto-demo.yml"]="./workspace/emojivoto-demo.yml"
 fields["mysql-demo.yml"]="./workspace/mysql-demo.yml"
-for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp k3s-qemu-snp-gpu rke2-qemu-tdx; do
+for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp metal-qemu-snp-gpu k3s-qemu-snp k3s-qemu-snp-gpu rke2-qemu-tdx; do
   fields["coordinator-${platform}.yml"]="./workspace/coordinator-${platform}.yml"
   fields["runtime-${platform}.yml"]="./workspace/runtime-${platform}.yml"
 done


### PR DESCRIPTION
This adds a new `K3s-QEMU-SNP-GPU` platform that can be used for testing GPU-specific features on our on-prem infrastructure that uses this setup. This intentionally does not yet add any specific actions done if that platform is selected.