### PR TITLE
[release/v1.2] attestation.snp: reflect dependency of validators on productLine in verify.Options

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -214,6 +214,11 @@ func (m *Manifest) SNPValidateOpts(kdsGetter trust.HTTPSGetter) ([]ValidatorOpti
 		}
 
 		verifyOpts := verify.DefaultOptions()
+		// Setting the productLine explicitly, because of full dependence of trustedMeasurements and derivation of trustedRoots on productLine.
+		verifyOpts.Product, err = kds.ParseProductLine(string(refVal.ProductName))
+		if err != nil {
+			return nil, fmt.Errorf("SNP reference values: %w", err)
+		}
 		verifyOpts.TrustedRoots, err = trustedRoots(refVal.ProductName)
 		if err != nil {
 			return nil, fmt.Errorf("determine trusted roots: %w", err)


### PR DESCRIPTION
Backport of #1082 to `release/v1.2`.

Original description:

---

Our reference values of SNP attestation have a hard dependency on the productLine used during attestation. This includes the derivation of trustedRoots, as well as the trustedMeasurements.  By design, we start a validator configured with specific verifyOpts for each reference value. 
This led to the error "VCEK could not be verified by any trusted roots", because validators configured with the wrong productLine tried to fulfill the attestation verification. Therefore this PR adds the explicit setting of the productLine in verifyOpts, to reflect the dependency of our reference values on the productLine. As expected we then run into the error below prior to validation, which reveals that a validator is configured for the wrong productLine:
 `time=2024-12-18T10:46:20.815Z level=ERROR msg="Validation failed" mesh-authority.validator.tee-type=snp mesh-authority.validator.nonce=6881501f40cebdb1492a87316e5a11cbb1bb9dfc2939240a9df098dacdab8b6a mesh-authority.validator.error="verifying report: expected product name SEV_PRODUCT_MILAN, got SEV_PRODUCT_GENOA"
`

Logging considerations were moved to #1095
