### PR TITLE
Revert "e2e: remove `skip-undeploy` flag and go cleanup logic"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,7 +417,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          nix shell -L .#contrast.e2e --command release.test -test.v --tag ${{ inputs.version }} --platform ${{ matrix.platform.name }}
+          nix shell -L .#contrast.e2e --command release.test -test.v --tag ${{ inputs.version }} --platform ${{ matrix.platform.name }} --skip-undeploy=false
 
   create-github-stuff:
     name: Create backport label and milestone


### PR DESCRIPTION
This partially reverts commit 213a7e517c1e5e80beb7821ca86f30941f83ff51.

The release test action does not have a cleanup step, and implementing one would be difficult because it uses the default namespace which we can't just delete. Instead, we add the skip-undeploy flag again, flip its default so that most tests are not cleaned up from go and add the flag to the release e2e.

- [ ] [release test](https://github.com/edgelesssys/contrast/actions/runs/12430214897)