### PR TITLE
[release/v1.2] e2e: create DynamicClient directly

### DIFF
--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -491,7 +491,6 @@ func isPodReady(pod *corev1.Pod) bool {
 }
 
 func (c *Kubeclient) resourceInterfaceFor(obj *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
-	dyn := dynamic.New(c.Client.RESTClient())
 	gvk := obj.GroupVersionKind()
 
 	mapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -499,7 +498,7 @@ func (c *Kubeclient) resourceInterfaceFor(obj *unstructured.Unstructured) (dynam
 		return nil, fmt.Errorf("getting resource for %#v: %w", gvk, err)
 	}
 	c.log.Info("found mapping", "resource", mapping.Resource)
-	ri := dyn.Resource(mapping.Resource)
+	ri := c.dyn.Resource(mapping.Resource)
 	if mapping.Scope.Name() == "namespace" {
 		namespace := obj.GetNamespace()
 		if namespace == "" {


### PR DESCRIPTION
Backport of #1100 to `release/v1.2`.

Original description:

---

The DynamicClient created from the embedded RESTClient was lacking an encoder which resulted in 

```
encoding is not allowed for this codec: *versioning.codec
```

errors during test cleanup. Afaict this is a breaking change with `client-go@v0.32.0`, introduced by https://github.com/kubernetes/kubernetes/pull/124059 (the constructor from config uses `UnversionedRESTClientForConfigAndClient`, which the embedded RESTClient does not, apparently).

- [x] [release workflow](https://github.com/edgelesssys/contrast/actions/runs/12434856212)