### PR TITLE
[release/v1.2] release: publish runtime.yml for metal platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Create coordinator resource definitions
         run: |
           mkdir -p workspace
-          for platform in aks-clh-snp k3s-qemu-tdx k3s-qemu-snp rke2-qemu-tdx; do
+          for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp rke2-qemu-tdx; do
             nix run .#scripts.write-coordinator-yaml -- "${coordinatorImgTagged}" "${platform}" > workspace/coordinator-$platform.yml
             echo -n "${platform} " >> workspace/coordinator-policy.hash
             yq < workspace/coordinator-$platform.yml \

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -259,13 +259,13 @@
           cp ${pkgs.microsoft.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.microsoft.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"
         ;;
-        "k3s-qemu-snp"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
+        "metal-qemu-snp"|"k3s-qemu-snp"|"metal-qemu-tdx"|"k3s-qemu-tdx"|"rke2-qemu-tdx")
           cp ${pkgs.kata.genpolicy.rules-coordinator}/genpolicy-rules.rego rules.rego
           cp ${pkgs.kata.genpolicy.settings-coordinator}/genpolicy-settings.json .
           ${pkgs.kata.genpolicy}/bin/genpolicy < "$tmpdir/coordinator_base.yml"
         ;;
         *)
-          echo "Unsupported platform: {{ platform }}"
+          echo "Unsupported platform: {{ platform }}" >&2
           exit 1
         ;;
       esac


### PR DESCRIPTION
Backport of #1107 to `release/v1.2`.

Original description:

---

While we introduced a new platform with the last release, we missed to publish the runtime.yml for those platforms.