### PR TITLE
[release/v1.2] contrast-releases: add mysql demo and runtime.yml for metal platforms

### DIFF
--- a/packages/contrast-releases.json
+++ b/packages/contrast-releases.json
@@ -239,6 +239,12 @@
       "hash": "sha256-kPVlu+RyADUfQ6PPfR2NANR0BCuarfwDEe/VOvuI48g="
     }
   ],
+  "mysql-demo.yml": [
+    {
+      "version": "v1.2.0",
+      "hash": "sha256-20oA0xafefkRQhz69E3d9kS1XV0WOBMQockcADA9l+Y="
+    }
+  ],
   "runtime-aks-clh-snp.yml": [
     {
       "version": "v1.1.0",

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -62,13 +62,19 @@ let
             passthru.exists = (builtins.compareVersions "v0.8.0" version) <= 0;
           };
 
-          # starting with version v1.1.0 all files has a platform-specific suffix.
+          # starting with version v1.1.0 all files have a platform-specific suffix.
           platformSpecificFiles = builtins.listToAttrs (
             lib.lists.map
               (
                 platform:
                 lib.attrsets.nameValuePair platform {
-                  exist = (builtins.compareVersions "v1.1.0" version) <= 0;
+                  exist =
+                    ((builtins.compareVersions "v1.1.0" version) <= 0)
+                    && (
+                      # These platforms were introduced as part of the v1.2.1 release.
+                      (platform == "metal-qemu-tdx" || platform == "metal-qemu-snp")
+                      && (builtins.compareVersions "v1.2.1" version) <= 0
+                    );
                   coordinator = fetchurl {
                     inherit version;
                     url = "https://github.com/edgelesssys/contrast/releases/download/${version}/coordinator-${platform}.yml";
@@ -83,6 +89,8 @@ let
               )
               [
                 "aks-clh-snp"
+                "metal-qemu-snp"
+                "metal-qemu-tdx"
                 "k3s-qemu-tdx"
                 "k3s-qemu-snp"
                 "rke2-qemu-tdx"
@@ -94,7 +102,7 @@ let
             buildInputs = [
               unzip
               installShellFiles
-            ]; # needed to unzip emojivoto-demo.zip
+            ];
           }
           (
             ''

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -62,6 +62,14 @@ let
             passthru.exists = (builtins.compareVersions "v0.8.0" version) <= 0;
           };
 
+          mysql-demo = fetchurl {
+            inherit version;
+            url = "https://github.com/edgelesssys/contrast/releases/download/${version}/mysql-demo.yml";
+            inherit (findVersion "mysql-demo.yml" version) hash;
+            # mysql-demo.yml was introduced in version v1.2.0
+            passthru.exists = (builtins.compareVersions "v1.2.0" version) <= 0;
+          };
+
           # starting with version v1.1.0 all files have a platform-specific suffix.
           platformSpecificFiles = builtins.listToAttrs (
             lib.lists.map
@@ -125,6 +133,10 @@ let
             + lib.optionalString emojivoto.exists ''
               mkdir -p $out/deployment
               install -m 644 ${emojivoto} $out/deployment/emojivoto-demo.yml
+            ''
+            + lib.optionalString mysql-demo.exists ''
+              mkdir -p $out/deployment
+              install -m 644 ${mysql-demo} $out/deployment/mysql-demo.yml
             ''
             + lib.concatStrings (
               lib.attrsets.mapAttrsToList (

--- a/packages/update-contrast-releases.sh
+++ b/packages/update-contrast-releases.sh
@@ -20,7 +20,7 @@ fields["coordinator.yml"]="./workspace/coordinator.yml"
 fields["runtime.yml"]="./workspace/runtime.yml"
 fields["emojivoto-demo.zip"]="./workspace/emojivoto-demo.zip"
 fields["emojivoto-demo.yml"]="./workspace/emojivoto-demo.yml"
-for platform in aks-clh-snp k3s-qemu-tdx k3s-qemu-snp rke2-qemu-tdx; do
+for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp rke2-qemu-tdx; do
   fields["coordinator-${platform}.yml"]="./workspace/coordinator-${platform}.yml"
   fields["runtime-${platform}.yml"]="./workspace/runtime-${platform}.yml"
 done

--- a/packages/update-contrast-releases.sh
+++ b/packages/update-contrast-releases.sh
@@ -20,6 +20,7 @@ fields["coordinator.yml"]="./workspace/coordinator.yml"
 fields["runtime.yml"]="./workspace/runtime.yml"
 fields["emojivoto-demo.zip"]="./workspace/emojivoto-demo.zip"
 fields["emojivoto-demo.yml"]="./workspace/emojivoto-demo.yml"
+fields["mysql-demo.yml"]="./workspace/mysql-demo.yml"
 for platform in aks-clh-snp metal-qemu-tdx k3s-qemu-tdx metal-qemu-snp k3s-qemu-snp rke2-qemu-tdx; do
   fields["coordinator-${platform}.yml"]="./workspace/coordinator-${platform}.yml"
   fields["runtime-${platform}.yml"]="./workspace/runtime-${platform}.yml"


### PR DESCRIPTION
Backport of #1110 to `release/v1.2`.

Original description:

---

We now have both demos in deployment, we'll have to see if that fits our needs.