### PR TITLE
[release/v1.2] ci/release: allow setting main ref for testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         type: boolean
         required: false
         default: false
+      checkout_main_ref:
+        description: Checkout this git ref as main branch (some workflows run on this state)
+        type: string
+        required: false
+        default: main
 
 env:
   container_registry: ghcr.io/edgelesssys
@@ -130,7 +135,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: main
+          ref: ${{ inputs.checkout_main_ref }}
           path: contrast-main
       - uses: ./contrast-working/.github/actions/setup_nix
         with:


### PR DESCRIPTION
Backport of #1118 to `release/v1.2`.

Original description:

---

Some workflows are executed from main branch, which makes the workflow difficult to test. This PR adds the ability to set the ref explicitly so it can be pointed to the same branch when testing the workflow.