### PR TITLE
cli: remove unused skip initializer variable

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -28,9 +28,8 @@ import (
 )
 
 const (
-	kataPolicyAnnotationKey      = "io.katacontainers.config.agent.policy"
-	contrastRoleAnnotationKey    = "contrast.edgeless.systems/pod-role"
-	skipInitializerAnnotationKey = "contrast.edgeless.systems/skip-initializer"
+	kataPolicyAnnotationKey   = "io.katacontainers.config.agent.policy"
+	contrastRoleAnnotationKey = "contrast.edgeless.systems/pod-role"
 )
 
 // NewGenerateCmd creates the contrast generate subcommand.


### PR DESCRIPTION
The same variable is only used in https://github.com/edgelesssys/contrast/blob/main/internal/kuberesource/mutators.go#L36 and not referenced here.