### PR TITLE
just: enable deploying custom resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ kube.conf
 out.env
 infra/**/kustomization.yaml
 uplosi.conf*
+.custom/


### PR DESCRIPTION
This allows fast testing of custom resource yaml. 

Namespace of resources in .custom should be `custom-<namespace-suffix>`. (Or hack the just.namespace manually, if required for testing.)

Currently tested to work with `just default custom`.