### PR TITLE
service-mesh: pass args to envoy, set log level to debug

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -471,6 +471,9 @@ func ServiceMeshProxy() *applycorev1.ContainerApplyConfiguration {
 			WithFailureThreshold(5).
 			WithTCPSocket(TCPSocketAction().
 				WithPort(intstr.FromInt(15006))),
+		).
+		WithArgs(
+			"-l", "debug",
 		)
 }
 

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -112,7 +112,8 @@ let
         iptables-legacy
       ];
       config = {
-        Cmd = [ "${pkgs.service-mesh}/bin/service-mesh" ];
+        # Use Entrypoint so we can append arguments.
+        Entrypoint = [ "${pkgs.service-mesh}/bin/service-mesh" ];
         Env = [ "PATH=/bin" ]; # This is only here for policy generation.
       };
     };

--- a/service-mesh/main.go
+++ b/service-mesh/main.go
@@ -66,6 +66,7 @@ func run() (retErr error) {
 	}
 
 	log.Println("Starting envoy")
-
-	return syscall.Exec(envoyBin, []string{"envoy", "-c", envoyConfigFile}, os.Environ())
+	args := []string{"envoy", "-c", envoyConfigFile}
+	args = append(args, os.Args[1:]...)
+	return syscall.Exec(envoyBin, args, os.Environ())
 }


### PR DESCRIPTION
This allows configuring the envoy invoked by the service mesh with additional options like for setting the log level.