### PR TITLE
coordinator: only create workload secret if requested

### DIFF
--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -154,6 +154,26 @@ func TestWorkloadSecrets(t *testing.T) {
 		require.Len(webWorkloadSecretBytes, constants.SecretSeedSize)
 		require.Equal(webWorkloadSecretBytes, emojiWorkloadSecretBytes)
 	})
+
+	t.Run("workload secrets are not created if not configured in the manifest", func(t *testing.T) {
+		require := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(60*time.Second))
+		defer cancel()
+
+		ct.PatchManifest(t, patchWorkloadSecretID("web", ""))
+
+		t.Run("set", ct.Set)
+		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, "web"))
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, "web"))
+
+		webPods, err = ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, "web")
+		require.NoError(err)
+		require.Len(webPods, 2, "pod not found: %s/%s", ct.Namespace, "web")
+
+		stdout, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, webPods[0].Name, []string{"/bin/sh", "-c", "test ! -f /contrast/secrets/workload-secret-seed"})
+		require.NoError(err, "stderr: %q", stderr)
+		require.Empty(stdout)
+	})
 }
 
 // patchWorkloadSecretID returns a PatchManifestFunc which overwrites the expectedWorkloadSecretID with the patchWorkloadSecretID

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -127,9 +127,12 @@ func run() (retErr error) {
 	if err != nil {
 		return fmt.Errorf("writing coordinator-root-ca.pem: %w", err)
 	}
-	err = os.WriteFile("/contrast/secrets/workload-secret-seed", []byte(hex.EncodeToString(resp.WorkloadSecret)), 0o400)
-	if err != nil {
-		return fmt.Errorf("writing workload-secret-seed: %w", err)
+
+	if len(resp.WorkloadSecret) > 0 {
+		err = os.WriteFile("/contrast/secrets/workload-secret-seed", []byte(hex.EncodeToString(resp.WorkloadSecret)), 0o400)
+		if err != nil {
+			return fmt.Errorf("writing workload-secret-seed: %w", err)
+		}
 	}
 
 	log.Info("Initializer done")


### PR DESCRIPTION
Setting `WorkloadSecretID` to an empty string (or removing it from the manifest) results in a secret derived from an empty string. This is unlikely to be the users intent, though, because all workloads with an empty `WorkloadSecretID` now share a low-entropy secret, which might be used accidentally. To be safe, don't generate a secret if the ID is not present.