### PR TITLE
[release/v1.2] cli: make default WorkloadSecretIDs unique per k8s object

### DIFF
--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -8,13 +8,17 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/edgelesssys/contrast/internal/kubeapi"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type k8sObject interface {
 	GetName() string
+	GetNamespace() string
+	GetObjectKind() schema.ObjectKind
 }
 
 func policiesFromKubeResources(yamlPaths []string) ([]deployment, error) {
@@ -38,6 +42,10 @@ func policiesFromKubeResources(yamlPaths []string) ([]deployment, error) {
 			continue
 		}
 		name := meta.GetName()
+		namespace := orDefault(meta.GetNamespace(), "default")
+
+		gvk := meta.GetObjectKind().GroupVersionKind()
+		workloadSecretID := strings.Join([]string{orDefault(gvk.Group, "core"), gvk.Version, gvk.Kind, namespace, name}, "/")
 
 		var annotation, role string
 		switch obj := objAny.(type) {
@@ -71,9 +79,10 @@ func policiesFromKubeResources(yamlPaths []string) ([]deployment, error) {
 			return nil, fmt.Errorf("failed to parse policy %s: %w", name, err)
 		}
 		deployments = append(deployments, deployment{
-			name:   name,
-			policy: policy,
-			role:   role,
+			name:             name,
+			policy:           policy,
+			role:             role,
+			workloadSecretID: workloadSecretID,
 		})
 	}
 
@@ -90,7 +99,7 @@ func manifestPolicyMapFromPolicies(policies []deployment) (map[manifest.HexStrin
 			}
 			continue
 		}
-		entry := manifest.PolicyEntry{SANs: depl.DNSNames(), WorkloadSecretID: depl.name}
+		entry := manifest.PolicyEntry{SANs: depl.DNSNames(), WorkloadSecretID: depl.workloadSecretID}
 		policyHashes[depl.policy.Hash()] = entry
 	}
 	return policyHashes, nil
@@ -132,11 +141,19 @@ func getCoordinatorPolicyHash(policies []deployment, log *slog.Logger) string {
 }
 
 type deployment struct {
-	name   string
-	policy manifest.Policy
-	role   string
+	name             string
+	policy           manifest.Policy
+	role             string
+	workloadSecretID string
 }
 
 func (d deployment) DNSNames() []string {
 	return []string{d.name, "*"}
+}
+
+func orDefault(s, d string) string {
+	if s == "" {
+		return d
+	}
+	return s
 }

--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -13,6 +13,10 @@ import (
 	"github.com/edgelesssys/contrast/internal/manifest"
 )
 
+type k8sObject interface {
+	GetName() string
+}
+
 func policiesFromKubeResources(yamlPaths []string) ([]deployment, error) {
 	var kubeObjs []any
 	for _, path := range yamlPaths {
@@ -29,30 +33,30 @@ func policiesFromKubeResources(yamlPaths []string) ([]deployment, error) {
 
 	var deployments []deployment
 	for _, objAny := range kubeObjs {
-		var name, annotation, role string
+		meta, ok := objAny.(k8sObject)
+		if !ok {
+			continue
+		}
+		name := meta.GetName()
+
+		var annotation, role string
 		switch obj := objAny.(type) {
-		case kubeapi.Pod:
-			name = obj.Name
+		case *kubeapi.Pod:
 			annotation = obj.Annotations[kataPolicyAnnotationKey]
 			role = obj.Annotations[contrastRoleAnnotationKey]
-		case kubeapi.Deployment:
-			name = obj.Name
+		case *kubeapi.Deployment:
 			annotation = obj.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = obj.Spec.Template.Annotations[contrastRoleAnnotationKey]
-		case kubeapi.ReplicaSet:
-			name = obj.Name
+		case *kubeapi.ReplicaSet:
 			annotation = obj.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = obj.Spec.Template.Annotations[contrastRoleAnnotationKey]
-		case kubeapi.StatefulSet:
-			name = obj.Name
+		case *kubeapi.StatefulSet:
 			annotation = obj.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = obj.Spec.Template.Annotations[contrastRoleAnnotationKey]
-		case kubeapi.DaemonSet:
-			name = obj.Name
+		case *kubeapi.DaemonSet:
 			annotation = obj.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = obj.Spec.Template.Annotations[contrastRoleAnnotationKey]
-		case kubeapi.Job:
-			name = obj.Name
+		case *kubeapi.Job:
 			annotation = obj.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = obj.Spec.Template.Annotations[contrastRoleAnnotationKey]
 		}

--- a/cli/cmd/policies_test.go
+++ b/cli/cmd/policies_test.go
@@ -74,9 +74,10 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 			},
 			expectedOutput: []deployment{
 				{
-					name:   "test",
-					policy: manifest.Policy([]byte(`valid-agent-policy`)),
-					role:   "coordinator",
+					name:             "test",
+					policy:           manifest.Policy([]byte(`valid-agent-policy`)),
+					role:             "coordinator",
+					workloadSecretID: "apps/v1/Deployment/default/test",
 				},
 			},
 		},
@@ -101,14 +102,16 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 			},
 			expectedOutput: []deployment{
 				{
-					name:   "test",
-					policy: manifest.Policy([]byte(`valid-agent-policy`)),
-					role:   "coordinator",
+					name:             "test",
+					policy:           manifest.Policy([]byte(`valid-agent-policy`)),
+					role:             "coordinator",
+					workloadSecretID: "apps/v1/Deployment/default/test",
 				},
 				{
-					name:   "another-pod",
-					policy: manifest.Policy([]byte(`valid-agent-policy`)),
-					role:   "worker",
+					name:             "another-pod",
+					policy:           manifest.Policy([]byte(`valid-agent-policy`)),
+					role:             "worker",
+					workloadSecretID: "core/v1/Pod/default/another-pod",
 				},
 			},
 		},

--- a/internal/kubeapi/kubeapi.go
+++ b/internal/kubeapi/kubeapi.go
@@ -51,49 +51,49 @@ func UnmarshalK8SResources(data []byte) ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, pod)
+			result = append(result, &pod)
 		case "Deployment":
 			var deployment appsv1.Deployment
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &deployment)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, deployment)
+			result = append(result, &deployment)
 		case "StatefulSet":
 			var statefulSet appsv1.StatefulSet
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &statefulSet)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, statefulSet)
+			result = append(result, &statefulSet)
 		case "ReplicaSet":
 			var replicaSet appsv1.ReplicaSet
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &replicaSet)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, replicaSet)
+			result = append(result, &replicaSet)
 		case "DaemonSet":
 			var daemonSet appsv1.DaemonSet
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &daemonSet)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, daemonSet)
+			result = append(result, &daemonSet)
 		case "Job":
 			var job batchv1.Job
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &job)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, job)
+			result = append(result, &job)
 		case "CronJob":
 			var cronJob batchv1.CronJob
 			err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &cronJob)
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, cronJob)
+			result = append(result, &cronJob)
 		}
 	}
 	return result, nil

--- a/internal/kubeapi/kubeapi_test.go
+++ b/internal/kubeapi/kubeapi_test.go
@@ -26,7 +26,7 @@ metadata:
 `,
 		},
 		"pod": {
-			wantTypes: []any{Pod{}},
+			wantTypes: []any{&Pod{}},
 			resources: `
 apiVersion: v1
 kind: Pod
@@ -35,7 +35,7 @@ metadata:
 `,
 		},
 		"deployment, ignored service, daemonset": {
-			wantTypes: []any{Deployment{}, DaemonSet{}},
+			wantTypes: []any{&Deployment{}, &DaemonSet{}},
 			resources: `
 apiVersion: apps/v1
 kind: Deployment
@@ -54,7 +54,7 @@ metadata:
 `,
 		},
 		"statefulset, replicaset": {
-			wantTypes: []any{StatefulSet{}, ReplicaSet{}},
+			wantTypes: []any{&StatefulSet{}, &ReplicaSet{}},
 			resources: `
 apiVersion: apps/v1
 kind: StatefulSet
@@ -68,7 +68,7 @@ metadata:
 `,
 		},
 		"job": {
-			wantTypes: []any{Job{}},
+			wantTypes: []any{&Job{}},
 			resources: `
 apiVersion: batch/v1
 kind: Job
@@ -77,7 +77,7 @@ metadata:
 `,
 		},
 		"cronjob": {
-			wantTypes: []any{CronJob{}},
+			wantTypes: []any{&CronJob{}},
 			resources: `
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
Backport of https://github.com/edgelesssys/contrast/pull/1127 to `release/v1.2`.

Original description:

---

Contrast configures the manifest with a default `WorkloadSecretID` per k8s object. The current default is simply the object name, which can be problematic if multiple objects (e.g. different kinds) share a name.

Combining the default workload secret ID from group, version, kind, namespace and name should ensure different k8s objects get different workload secrets.