### PR TITLE
initializer: move cryptsetup image into initializer

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,7 +70,7 @@ jobs:
           echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
       - name: Build and prepare deployments
         run: |
-          just coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer ${{ inputs.platform }}
+          just coordinator initializer port-forwarder openssl service-mesh-proxy node-installer ${{ inputs.platform }}
       - name: E2E Test
         run: |
           nix build .#scripts.get-logs

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -54,7 +54,7 @@ jobs:
           echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
       - name: Build and prepare deployments
         run: |
-          nix shell .#just --command just coordinator initializer port-forwarder openssl cryptsetup service-mesh-proxy node-installer
+          nix shell .#just --command just coordinator initializer port-forwarder openssl service-mesh-proxy node-installer
       # steps taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
       - name: Install `az` with extensions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,6 @@ jobs:
           tardevSnapshotterImg=$(nix run .#containers.push-tardev-snapshotter -- "$container_registry/contrast/tardev-snapshotter")
           nydusSnapshotterImg=$(nix run .#containers.push-nydus-snapshotter -- "$container_registry/contrast/nydus-snapshotter")
           nydusPullImg=$(nix run .#containers.push-nydus-pull -- "$container_registry/contrast/nydus-pull")
-          cryptsetupImg=$(nix run .#containers.push-cryptsetup -- "$container_registry/contrast/cryptsetup")
           echo "coordinatorImg=$coordinatorImg" | tee -a "$GITHUB_ENV"
           echo "nodeInstallerMsftImg=$nodeInstallerMsftImg" | tee -a "$GITHUB_ENV"
           echo "nodeInstallerKataImg=$nodeInstallerKataImg" | tee -a "$GITHUB_ENV"
@@ -261,7 +260,6 @@ jobs:
           echo "tardevSnapshotterImg=$tardevSnapshotterImg" | tee -a "$GITHUB_ENV"
           echo "nydusSnapshotterImg=$nydusSnapshotterImg" | tee -a "$GITHUB_ENV"
           echo "nydusPullImg=$nydusPullImg" | tee -a "$GITHUB_ENV"
-          echo "cryptsetupImg=$cryptsetupImg" | tee -a "$GITHUB_ENV"
       - name: Add tag to Coordinator image
         run: |
           tag() {
@@ -275,7 +273,6 @@ jobs:
           echo "initializerImgTagged=$(tag "$initializerImg")" | tee -a "$GITHUB_ENV"
           echo "serviceMeshImgTagged=$(tag "$serviceMeshImg")" | tee -a "$GITHUB_ENV"
           echo "nydusPullImgTagged=$(tag "$nydusPullImg")" | tee -a "$GITHUB_ENV"
-          echo "cryptsetupImgTagged=$(tag "$cryptsetupImg")" | tee -a "$GITHUB_ENV"
 
           tardevVer=$(nix eval --impure --raw --expr "(builtins.getFlake \"git+file://$(pwd)?shallow=1\").outputs.legacyPackages.x86_64-linux.microsoft.tardev-snapshotter.version")
           front=${tardevSnapshotterImg%@*}
@@ -297,7 +294,6 @@ jobs:
             echo "ghcr.io/edgelesssys/contrast/tardev-snapshotter:latest=$tardevSnapshotterImgTagged"
             echo "ghcr.io/edgelesssys/contrast/nydus-snapshotter:latest=$nydusSnapshotterImgTagged"
             echo "ghcr.io/edgelesssys/contrast/nydus-pull:latest=$nydusPullImgTagged"
-            echo "ghcr.io/edgelesssys/contrast/cryptsetup:latest=$cryptsetupImgTagged"
           } > image-replacements.txt
       - name: Upload image replacements file (for main branch PR)
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -522,7 +522,7 @@ func VolumeStatefulSet() []any {
 						WithInitContainers(
 							Container().
 								WithName("volume-tester-init").
-								WithImage("ghcr.io/edgelesssys/contrast/cryptsetup:latest").
+								WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 								WithCommand("/bin/sh", "-c", CryptsetupInitCommand()).
 								WithVolumeDevices(
 									applycorev1.VolumeDevice().
@@ -563,7 +563,7 @@ func VolumeStatefulSet() []any {
 						WithContainers(
 							Container().
 								WithName("volume-tester").
-								WithImage("ghcr.io/edgelesssys/contrast/cryptsetup:latest").
+								WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 								WithCommand("/bin/sh", "-c", "sleep inf").
 								WithVolumeMounts(
 									VolumeMount().
@@ -617,7 +617,7 @@ func MySQL() []any {
 						WithInitContainers(
 							Container().
 								WithName("luks-setup").
-								WithImage("ghcr.io/edgelesssys/contrast/cryptsetup:latest").
+								WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 								WithCommand("/bin/sh", "-c", CryptsetupInitCommand()).
 								WithVolumeDevices(
 									applycorev1.VolumeDevice().

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # Undeploy, rebuild, deploy.
-default target=default_deploy_target platform=default_platform cli=default_cli: soft-clean coordinator initializer openssl cryptsetup port-forwarder service-mesh-proxy (node-installer platform) (deploy target cli platform) set verify (wait-for-workload target)
+default target=default_deploy_target platform=default_platform cli=default_cli: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy (node-installer platform) (deploy target cli platform) set verify (wait-for-workload target)
 
 # Build and push a container image.
 push target:
@@ -14,9 +14,6 @@ coordinator: (push "coordinator")
 
 # Build the openssl container and push it.
 openssl: (push "openssl")
-
-# Build the cryptsetup container and push it.
-cryptsetup: (push "cryptsetup")
 
 # Build the port-forwarder container and push it.
 port-forwarder: (push "port-forwarder")
@@ -66,7 +63,7 @@ node-installer platform=default_platform:
         ;;
     esac
 
-e2e target=default_deploy_target platform=default_platform: soft-clean coordinator initializer cryptsetup openssl port-forwarder service-mesh-proxy (node-installer platform)
+e2e target=default_deploy_target platform=default_platform: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy (node-installer platform)
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "{{ target }}" == "aks-runtime" ]]; then

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -57,7 +57,16 @@ let
     initializer = dockerTools.buildImage {
       name = "initializer";
       tag = "v${pkgs.contrast.version}";
-      copyToRoot = with dockerTools; [ caCertificates ];
+      copyToRoot =
+        (with pkgs; [
+          busybox
+          cryptsetup
+          e2fsprogs # mkfs.ext4
+          mount
+          util-linux # blkid
+          openssl
+        ])
+        ++ (with dockerTools; [ caCertificates ]);
       config = {
         Cmd = [ "${pkgs.contrast.initializer}/bin/initializer" ];
         Env = [ "PATH=/bin" ]; # This is only here for policy generation.
@@ -71,23 +80,6 @@ let
         busybox
         openssl
         curlMinimal
-      ];
-      config = {
-        Cmd = [ "bash" ];
-        Env = [ "PATH=/bin" ]; # This is only here for policy generation.
-      };
-    };
-
-    cryptsetup = dockerTools.buildImage {
-      name = "cryptsetup";
-      tag = "v${pkgs.contrast.version}";
-      copyToRoot = with pkgs; [
-        busybox
-        cryptsetup
-        e2fsprogs # mkfs.ext4
-        mount
-        util-linux # blkid
-        openssl
       ];
       config = {
         Cmd = [ "bash" ];


### PR DESCRIPTION
Until now, we used a specific cryptsetup image, containing a couple of filesystem and mount tools that facilitate the LUKS encryption. 
This PR is a first step to include the dependencies of the cryptsetup image in the initializer, while still keeping the bash entry point for now to allow setting up the LUKS device by the initializer. Thus all existing references to the specific cryptsetup image are dropped as part of this PR.

As a follow up the mounting/set up of the encrypted volume done by the bash entrypoint will be moved to a subcommand of the initializer binary. 

K3s-QEMU-TDX: https://github.com/edgelesssys/contrast/actions/runs/12748493847
K3s-QEMU-SNP: https://github.com/edgelesssys/contrast/actions/runs/12748490036
AKS-CLH-SNP: https://github.com/edgelesssys/contrast/actions/runs/12748475625