### PR TITLE
Support bare-metal Kata GPU containers

### DIFF
--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -10,6 +10,7 @@ on:
         options:
           - genpolicy
           - getdents
+          - gpu
           - openssl
           - policy
           - regression
@@ -24,6 +25,7 @@ on:
         options:
           - AKS-CLH-SNP
           - K3s-QEMU-SNP
+          - K3s-QEMU-SNP-GPU
           - K3s-QEMU-TDX
       skip-undeploy:
         description: "Skip undeploy"

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -19,7 +19,16 @@ jobs:
           - name: K3s-QEMU-TDX
             runner: TDX
             self-hosted: true
+          - name: K3s-QEMU-SNP-GPU
+            runner: SNP
+            self-hosted: true
         test-name: [servicemesh, openssl, policy, workloadsecret, volumestatefulset]
+        include:
+          - platform:
+              name: K3s-QEMU-SNP-GPU
+              runner: SNP
+              self-hosted: true
+            test-name: [gpu]
       fail-fast: false
     name: "${{ matrix.platform.name }}"
     uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,7 @@ jobs:
           coordinatorImg=$(nix run .#containers.push-coordinator -- "$container_registry/contrast/coordinator")
           nodeInstallerMsftImg=$(nix run .#containers.push-node-installer-microsoft -- "$container_registry/contrast/node-installer-microsoft")
           nodeInstallerKataImg=$(nix run .#containers.push-node-installer-kata -- "$container_registry/contrast/node-installer-kata")
+          nodeInstallerKataGPUImg=$(nix run .#containers.push-node-installer-kata-gpu -- "$container_registry/contrast/node-installer-kata")
           initializerImg=$(nix run .#containers.push-initializer -- "$container_registry/contrast/initializer")
           serviceMeshImg=$(nix run .#containers.push-service-mesh-proxy -- "$container_registry/contrast/service-mesh-proxy")
           tardevSnapshotterImg=$(nix run .#containers.push-tardev-snapshotter -- "$container_registry/contrast/tardev-snapshotter")
@@ -256,6 +257,7 @@ jobs:
           echo "coordinatorImg=$coordinatorImg" | tee -a "$GITHUB_ENV"
           echo "nodeInstallerMsftImg=$nodeInstallerMsftImg" | tee -a "$GITHUB_ENV"
           echo "nodeInstallerKataImg=$nodeInstallerKataImg" | tee -a "$GITHUB_ENV"
+          echo "nodeInstallerKataGPUImg=$nodeInstallerKataGPUImg" | tee -a "$GITHUB_ENV"
           echo "initializerImg=$initializerImg" | tee -a "$GITHUB_ENV"
           echo "serviceMeshImg=$serviceMeshImg" | tee -a "$GITHUB_ENV"
           echo "tardevSnapshotterImg=$tardevSnapshotterImg" | tee -a "$GITHUB_ENV"
@@ -272,6 +274,7 @@ jobs:
           echo "coordinatorImgTagged=$(tag "$coordinatorImg")" | tee -a "$GITHUB_ENV"
           echo "nodeInstallerMsftImgTagged=$(tag "$nodeInstallerMsftImg")" | tee -a "$GITHUB_ENV"
           echo "nodeInstallerKataImgTagged=$(tag "$nodeInstallerKataImg")" | tee -a "$GITHUB_ENV"
+          echo "nodeInstallerKataGPUImgTagged=$(tag "$nodeInstallerKataGPUImg")" | tee -a "$GITHUB_ENV"
           echo "initializerImgTagged=$(tag "$initializerImg")" | tee -a "$GITHUB_ENV"
           echo "serviceMeshImgTagged=$(tag "$serviceMeshImg")" | tee -a "$GITHUB_ENV"
           echo "nydusPullImgTagged=$(tag "$nydusPullImg")" | tee -a "$GITHUB_ENV"
@@ -294,6 +297,7 @@ jobs:
             echo "ghcr.io/edgelesssys/contrast/service-mesh-proxy:latest=$serviceMeshImgTagged"
             echo "ghcr.io/edgelesssys/contrast/node-installer-microsoft:latest=$nodeInstallerMsftImgTagged"
             echo "ghcr.io/edgelesssys/contrast/node-installer-kata:latest=$nodeInstallerKataImgTagged"
+            echo "ghcr.io/edgelesssys/contrast/node-installer-kata-gpu:latest=$nodeInstallerKataGPUImgTagged"
             echo "ghcr.io/edgelesssys/contrast/tardev-snapshotter:latest=$tardevSnapshotterImgTagged"
             echo "ghcr.io/edgelesssys/contrast/nydus-snapshotter:latest=$nydusSnapshotterImgTagged"
             echo "ghcr.io/edgelesssys/contrast/nydus-pull:latest=$nydusPullImgTagged"

--- a/e2e/gpu/gpu_test.go
+++ b/e2e/gpu/gpu_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package gpu
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gpuPodName = "gpu-pod"
+	gpuName    = "NVIDIA H100 PCIe"
+)
+
+// TestGPU runs e2e tests on an GPU-enabled Contrast.
+func TestGPU(t *testing.T) {
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
+	require.NoError(t, err)
+	ct := contrasttest.New(t)
+
+	runtimeHandler, err := manifest.RuntimeHandler(platform)
+	require.NoError(t, err)
+
+	resources := kuberesource.OpenSSL()
+	coordinator := kuberesource.CoordinatorBundle()
+
+	resources = append(resources, coordinator...)
+
+	resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
+
+	resources = kuberesource.AddPortForwarders(resources)
+
+	ct.Init(t, resources)
+	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+
+	require.True(t, t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("contrast verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
+
+	applyGPUPod := func(t *testing.T) {
+		yaml, err := os.ReadFile("./e2e/gpu/testdata/gpu-pod.yaml")
+		require.NoError(t, err)
+
+		yaml = bytes.ReplaceAll(
+			bytes.ReplaceAll(yaml, []byte("@@REPLACE_NAMESPACE@@"), []byte(ct.Namespace)),
+			[]byte("@@REPLACE_RUNTIME@@"), []byte(ct.RuntimeClassName),
+		)
+
+		ct.ApplyFromYAML(t, yaml)
+	}
+
+	require.True(t, t.Run("apply GPU pod", applyGPUPod), "GPU pod needs to deploy successfully for subsequent tests")
+
+	t.Run("check GPU availability", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(5*time.Minute))
+		defer cancel()
+
+		require := require.New(t)
+
+		err := ct.Kubeclient.WaitForPod(ctx, ct.Namespace, gpuPodName)
+		require.NoError(err, "GPU pod %s did not start", gpuPodName)
+
+		argv := []string{"/bin/sh", "-c", "nvidia-smi"}
+		stdout, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, gpuPodName, argv)
+		require.NoError(err, "stderr: %q", stderr)
+
+		require.Contains(stdout, gpuName, "nvidia-smi output should contain %s", gpuName)
+	})
+}
+
+func TestMain(m *testing.M) {
+	contrasttest.RegisterFlags()
+	flag.Parse()
+
+	os.Exit(m.Run())
+}

--- a/e2e/gpu/testdata/gpu-pod.yaml
+++ b/e2e/gpu/testdata/gpu-pod.yaml
@@ -1,0 +1,25 @@
+# TODO(msanft): Move this to internal/kuberesource/sets.go as soon as genpolicy
+# support for GPU pods is added.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  namespace: "@@REPLACE_NAMESPACE@@"
+  annotations:
+    # Allow-all policy
+    # TODO(msanft): Generate a policy dynamically once we support policy generation for GPU pods.
+    io.katacontainers.config.agent.policy: IyBDb3B5cmlnaHQgKGMpIDIwMjMgTWljcm9zb2Z0IENvcnBvcmF0aW9uCiMKIyBTUERYLUxpY2Vuc2UtSWRlbnRpZmllcjogQXBhY2hlLTIuMAojCgpwYWNrYWdlIGFnZW50X3BvbGljeQoKZGVmYXVsdCBBZGRBUlBOZWlnaGJvcnNSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBBZGRTd2FwUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgQ2xvc2VTdGRpblJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IENvcHlGaWxlUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgQ3JlYXRlQ29udGFpbmVyUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgQ3JlYXRlU2FuZGJveFJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IERlc3Ryb3lTYW5kYm94UmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgRXhlY1Byb2Nlc3NSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBHZXRNZXRyaWNzUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgR2V0T09NRXZlbnRSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBHdWVzdERldGFpbHNSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBMaXN0SW50ZXJmYWNlc1JlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IExpc3RSb3V0ZXNSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBNZW1Ib3RwbHVnQnlQcm9iZVJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IE9ubGluZUNQVU1lbVJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFBhdXNlQ29udGFpbmVyUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgUHVsbEltYWdlUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgUmVhZFN0cmVhbVJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFJlbW92ZUNvbnRhaW5lclJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFJlbW92ZVN0YWxlVmlydGlvZnNTaGFyZU1vdW50c1JlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFJlc2VlZFJhbmRvbURldlJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFJlc3VtZUNvbnRhaW5lclJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFNldEd1ZXN0RGF0ZVRpbWVSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBTZXRQb2xpY3lSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBTaWduYWxQcm9jZXNzUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgU3RhcnRDb250YWluZXJSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBTdGFydFRyYWNpbmdSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBTdGF0c0NvbnRhaW5lclJlcXVlc3QgOj0gdHJ1ZQpkZWZhdWx0IFN0b3BUcmFjaW5nUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgVHR5V2luUmVzaXplUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgVXBkYXRlQ29udGFpbmVyUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgVXBkYXRlRXBoZW1lcmFsTW91bnRzUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgVXBkYXRlSW50ZXJmYWNlUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgVXBkYXRlUm91dGVzUmVxdWVzdCA6PSB0cnVlCmRlZmF1bHQgV2FpdFByb2Nlc3NSZXF1ZXN0IDo9IHRydWUKZGVmYXVsdCBXcml0ZVN0cmVhbVJlcXVlc3QgOj0gdHJ1ZQo=
+    io.katacontainers.config.hypervisor.default_memory: "15258"
+    cdi.k8s.io/gpu: "nvidia.com/pgpu=0"
+spec:
+  runtimeClassName: "@@REPLACE_RUNTIME@@"
+  restartPolicy: OnFailure
+  containers:
+    - name: vllm
+      image: ghcr.io/edgelesssys/contrast/ubuntu:24.04
+      env:
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: all
+      resources:
+        limits:
+          "nvidia.com/GH100_H100_PCIE": 1

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -153,6 +153,9 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		snapshotterVolumes = tardevSnapshotterVolumes
 	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
+		if platform == platforms.MetalQEMUSNPGPU {
+			nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata-gpu:latest"
+		}
 		containers = append(containers, nydusSnapshotter, nydusPull)
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes,
 			Volume().
@@ -171,6 +174,9 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 		snapshotterVolumes = nydusSnapshotterVolumes
 	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
+		if platform == platforms.K3sQEMUSNPGPU {
+			nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata-gpu:latest"
+		}
 		containers = append(containers, nydusSnapshotter, nydusPull)
 		nydusSnapshotterVolumes = append(nydusSnapshotterVolumes,
 			Volume().

--- a/justfile
+++ b/justfile
@@ -50,10 +50,15 @@ node-installer platform=default_platform:
             just push "tardev-snapshotter"
             just push "node-installer-microsoft"
         ;;
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"Metal-QEMU-SNP-GPU"|"K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"K3s-QEMU-SNP"|"K3s-QEMU-TDX"|"RKE2-QEMU-TDX")
             just push "nydus-snapshotter"
             just push "nydus-pull"
             just push "node-installer-kata"
+        ;;
+        "Metal-QEMU-SNP-GPU"|"K3s-QEMU-SNP-GPU")
+            just push "nydus-snapshotter"
+            just push "nydus-pull"
+            just push "node-installer-kata-gpu"
         ;;
         "AKS-PEER-SNP")
             nix run -L .#scripts.deploy-caa -- \

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -101,6 +101,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 			config.Hypervisor["qemu"]["cold_plug_vfio"] = "root-port"
 			// GPU images tend to be larger, so give a better default timeout that
 			// allows for pulling those.
+			config.Agent["kata"]["dial_timeout"] = 600
 			config.Runtime["create_container_timeout"] = 600
 		}
 	default:

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -31,4 +31,19 @@ final: prev:
         --set SOURCE_DATE_EPOCH 0
     '';
   });
+
+  # Fixes a dangling symlink in the libnvidia-container package that confuses
+  # the nvidia-container-toolkit.
+  # TODO(msanft): Remove once https://github.com/NixOS/nixpkgs/pull/375291 is merged and
+  # pulled into Contrast.
+  libnvidia-container = prev.libnvidia-container.overrideAttrs (prev: {
+    postFixup = ''
+      # Recreate library symlinks which ldconfig would have created
+      for lib in libnvidia-container libnvidia-container-go; do
+        rm -f "$out/lib/$lib.so"
+        ln -s "$out/lib/$lib.so.${prev.version}" "$out/lib/$lib.so.1"
+        ln -s "$out/lib/$lib.so.1" "$out/lib/$lib.so"
+      done
+    '';
+  });
 }

--- a/packages/by-name/kata/kata-runtime/0019-agent-remove-CDI-support.patch
+++ b/packages/by-name/kata/kata-runtime/0019-agent-remove-CDI-support.patch
@@ -1,0 +1,239 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
+Date: Fri, 3 Jan 2025 13:29:05 +0100
+Subject: [PATCH] agent: remove CDI support
+
+This reverts commits aa2e1a57bdd4b9e0d6c0810c05229d77278066c6
+and 3995fe71f9b7b4304dc9cdfd842d296a633c15c3 while keeping the Cargo
+lockfiles intact to allow for easier rebasing of this patch.
+---
+ src/agent/src/device/mod.rs | 158 ------------------------------------
+ src/agent/src/rpc.rs        |  13 +--
+ 2 files changed, 1 insertion(+), 170 deletions(-)
+
+diff --git a/src/agent/src/device/mod.rs b/src/agent/src/device/mod.rs
+index 400b6f1386e1b4a1a4cda1e3e3da2f66640165c7..53e77d82c88912488ead9052f44e397345f8b8ad 100644
+--- a/src/agent/src/device/mod.rs
++++ b/src/agent/src/device/mod.rs
+@@ -11,9 +11,6 @@ use self::vfio_device_handler::{VfioApDeviceHandler, VfioPciDeviceHandler};
+ use crate::pci;
+ use crate::sandbox::Sandbox;
+ use anyhow::{anyhow, Context, Result};
+-use cdi::annotations::parse_annotations;
+-use cdi::cache::{new_cache, with_auto_refresh, CdiOption};
+-use cdi::spec_dirs::with_spec_dirs;
+ use kata_types::device::DeviceHandlerManager;
+ use nix::sys::stat;
+ use oci::{LinuxDeviceCgroup, Spec};
+@@ -28,8 +25,6 @@ use std::path::PathBuf;
+ use std::str::FromStr;
+ use std::sync::Arc;
+ use tokio::sync::Mutex;
+-use tokio::time;
+-use tokio::time::Duration;
+ use tracing::instrument;
+ 
+ pub mod block_device_handler;
+@@ -243,69 +238,6 @@ pub async fn add_devices(
+     update_spec_devices(logger, spec, dev_updates)
+ }
+ 
+-#[instrument]
+-pub async fn handle_cdi_devices(
+-    logger: &Logger,
+-    spec: &mut Spec,
+-    spec_dir: &str,
+-    cdi_timeout: u64,
+-) -> Result<()> {
+-    if let Some(container_type) = spec
+-        .annotations()
+-        .as_ref()
+-        .and_then(|a| a.get("io.katacontainers.pkg.oci.container_type"))
+-    {
+-        if container_type == "pod_sandbox" {
+-            return Ok(());
+-        }
+-    }
+-
+-    let (_, devices) = parse_annotations(spec.annotations().as_ref().unwrap())?;
+-
+-    if devices.is_empty() {
+-        info!(logger, "no CDI annotations, no devices to inject");
+-        return Ok(());
+-    }
+-    // Explicitly set the cache options to disable auto-refresh and
+-    // to use the single spec dir "/var/run/cdi" for tests it can be overridden
+-    let options: Vec<CdiOption> = vec![with_auto_refresh(false), with_spec_dirs(&[spec_dir])];
+-    let cache: Arc<std::sync::Mutex<cdi::cache::Cache>> = new_cache(options);
+-
+-    for _ in 0..=cdi_timeout {
+-        let inject_result = {
+-            // Lock cache within this scope, std::sync::Mutex has no Send
+-            // and await will not work with time::sleep
+-            let mut cache = cache.lock().unwrap();
+-            match cache.refresh() {
+-                Ok(_) => {}
+-                Err(e) => {
+-                    return Err(anyhow!("error refreshing cache: {:?}", e));
+-                }
+-            }
+-            cache.inject_devices(Some(spec), devices.clone())
+-        };
+-
+-        match inject_result {
+-            Ok(_) => {
+-                info!(
+-                    logger,
+-                    "all devices injected successfully, modified CDI container spec: {:?}", &spec
+-                );
+-                return Ok(());
+-            }
+-            Err(e) => {
+-                info!(logger, "error injecting devices: {:?}", e);
+-                println!("error injecting devices: {:?}", e);
+-            }
+-        }
+-        time::sleep(Duration::from_millis(1000)).await;
+-    }
+-    Err(anyhow!(
+-        "failed to inject devices after CDI timeout of {} seconds",
+-        cdi_timeout
+-    ))
+-}
+-
+ #[instrument]
+ async fn validate_device(
+     logger: &Logger,
+@@ -1178,94 +1110,4 @@ mod tests {
+         assert!(name.is_ok(), "{}", name.unwrap_err());
+         assert_eq!(name.unwrap(), devname);
+     }
+-
+-    #[tokio::test]
+-    async fn test_handle_cdi_devices() {
+-        let logger = slog::Logger::root(slog::Discard, o!());
+-        let mut spec = Spec::default();
+-
+-        let mut annotations = HashMap::new();
+-        // cdi.k8s.io/vendor1_devices: vendor1.com/device=foo
+-        annotations.insert(
+-            "cdi.k8s.io/vfio17".to_string(),
+-            "kata.com/gpu=0".to_string(),
+-        );
+-        spec.set_annotations(Some(annotations));
+-
+-        let temp_dir = tempdir().expect("Failed to create temporary directory");
+-        let cdi_file = temp_dir.path().join("kata.json");
+-
+-        let cdi_version = "0.6.0";
+-        let kind = "kata.com/gpu";
+-        let device_name = "0";
+-        let annotation_whatever = "false";
+-        let annotation_whenever = "true";
+-        let inner_env = "TEST_INNER_ENV=TEST_INNER_ENV_VALUE";
+-        let outer_env = "TEST_OUTER_ENV=TEST_OUTER_ENV_VALUE";
+-        let inner_device = "/dev/zero";
+-        let outer_device = "/dev/null";
+-
+-        let cdi_content = format!(
+-            r#"{{
+-            "cdiVersion": "{cdi_version}",
+-            "kind": "{kind}",
+-            "devices": [
+-                {{
+-                    "name": "{device_name}",
+-                    "annotations": {{
+-                        "whatever": "{annotation_whatever}",
+-                        "whenever": "{annotation_whenever}"
+-                    }},
+-                    "containerEdits": {{
+-                        "env": [
+-                            "{inner_env}"
+-                        ],
+-                        "deviceNodes": [
+-                            {{
+-                                "path": "{inner_device}"
+-                            }}
+-                        ]
+-                    }}
+-                }}
+-            ],
+-            "containerEdits": {{
+-                "env": [
+-                    "{outer_env}"
+-                ],
+-                "deviceNodes": [
+-                    {{
+-                        "path": "{outer_device}"
+-                    }}
+-                ]
+-            }}
+-        }}"#
+-        );
+-
+-        fs::write(&cdi_file, cdi_content).expect("Failed to write CDI file");
+-
+-        let res =
+-            handle_cdi_devices(&logger, &mut spec, temp_dir.path().to_str().unwrap(), 0).await;
+-        println!("modfied spec {:?}", spec);
+-        assert!(res.is_ok(), "{}", res.err().unwrap());
+-
+-        let linux = spec.linux().as_ref().unwrap();
+-        let devices = linux
+-            .resources()
+-            .as_ref()
+-            .unwrap()
+-            .devices()
+-            .as_ref()
+-            .unwrap();
+-        assert_eq!(devices.len(), 2);
+-
+-        let env = spec.process().as_ref().unwrap().env().as_ref().unwrap();
+-
+-        // find string TEST_OUTER_ENV in env
+-        let outer_env = env.iter().find(|e| e.starts_with("TEST_OUTER_ENV"));
+-        assert!(outer_env.is_some(), "TEST_OUTER_ENV not found in env");
+-
+-        // find TEST_INNER_ENV in env
+-        let inner_env = env.iter().find(|e| e.starts_with("TEST_INNER_ENV"));
+-        assert!(inner_env.is_some(), "TEST_INNER_ENV not found in env");
+-    }
+ }
+diff --git a/src/agent/src/rpc.rs b/src/agent/src/rpc.rs
+index 0a1c6d34adfffcbc3aef1b55a77556b8b82e85c0..b3888633744a718586069314a192c9c0fd92459e 100644
+--- a/src/agent/src/rpc.rs
++++ b/src/agent/src/rpc.rs
+@@ -58,7 +58,7 @@ use rustjail::process::ProcessOperations;
+ use crate::cdh;
+ use crate::device::block_device_handler::get_virtio_blk_pci_device_name;
+ use crate::device::network_device_handler::wait_for_net_interface;
+-use crate::device::{add_devices, handle_cdi_devices, update_env_pci};
++use crate::device::{add_devices, update_env_pci};
+ use crate::features::get_build_features;
+ use crate::image::KATA_IMAGE_WORK_DIR;
+ use crate::linux_abi::*;
+@@ -130,8 +130,6 @@ const ERR_NO_SANDBOX_PIDNS: &str = "Sandbox does not have sandbox_pidns";
+ // not available.
+ const IPTABLES_RESTORE_WAIT_SEC: u64 = 5;
+ 
+-const CDI_TIMEOUT_LIMIT: u64 = 100;
+-
+ // Convenience function to obtain the scope logger.
+ fn sl() -> slog::Logger {
+     slog_scope::logger()
+@@ -226,15 +224,6 @@ impl AgentService {
+         // cannot predict everything from the caller.
+         add_devices(&sl(), &req.devices, &mut oci, &self.sandbox).await?;
+ 
+-        // In guest-kernel mode some devices need extra handling. Taking the
+-        // GPU as an example the shim will inject CDI annotations that will
+-        // be used by the kata-agent to do containerEdits according to the
+-        // CDI spec coming from a registry that is created on the fly by UDEV
+-        // or other entities for a specifc device.
+-        // In Kata we only consider the directory "/var/run/cdi", "/etc" may be
+-        // readonly
+-        handle_cdi_devices(&sl(), &mut oci, "/var/run/cdi", CDI_TIMEOUT_LIMIT).await?;
+-
+         cdh_handler(&mut oci).await?;
+ 
+         // Both rootfs and volumes (invoked with --volume for instance) will

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -180,13 +180,9 @@ buildGoModule rec {
   # is used when Kata starts a VM.
   # For example, this command should do the job:
   # `journalctl -t kata -l --no-pager | grep launching | tail -1`
-  passthru = {
-    inherit src;
-
-    cmdline = {
-      default = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
-      debug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
-    };
+  passthru.cmdline = {
+    default = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
+    debug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
   };
 
   meta.mainProgram = "containerd-shim-kata-v2";

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -118,6 +118,12 @@ buildGoModule rec {
       # See: https://github.com/kata-containers/kata-containers/pull/10719
       # TODO(msanft): Remove once upstream PR is released.
       ./0018-runtime-use-actual-booleans-for-QMP-device_add-boole.patch
+
+      # Revert CDI support in kata-agent, which breaks legacy mode GPU facilitation which
+      # we currently use.
+      # TODO(msanft): Get native CDI working, which will allow us to drop this patch / undo the revert.
+      # See https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/5061
+      ./0019-agent-remove-CDI-support.patch
     ];
   };
 
@@ -174,9 +180,13 @@ buildGoModule rec {
   # is used when Kata starts a VM.
   # For example, this command should do the job:
   # `journalctl -t kata -l --no-pager | grep launching | tail -1`
-  passthru.cmdline = {
-    default = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
-    debug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
+  passthru = {
+    inherit src;
+
+    cmdline = {
+      default = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
+      debug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
+    };
   };
 
   meta.mainProgram = "containerd-shim-kata-v2";

--- a/packages/by-name/kata/snp-launch-digest/package.nix
+++ b/packages/by-name/kata/snp-launch-digest/package.nix
@@ -52,5 +52,10 @@ stdenvNoCC.mkDerivation {
       --initrd ${initrd} \
       --append "${cmdline}" \
       --output-format hex > $out/genoa.hex
+
+    # cut newlines
+    for file in $out/*.hex; do
+      truncate -s -1 "$file"
+    done
   '';
 }

--- a/packages/by-name/kata/snp-launch-digest/package.nix
+++ b/packages/by-name/kata/snp-launch-digest/package.nix
@@ -9,25 +9,26 @@
   python3Packages,
 
   debug ? false,
+  os-image ? kata.kata-image,
 }:
 
 let
   ovmf-snp = "${OVMF-SNP}/FV/OVMF.fd";
-  kernel = "${kata.kata-image}/bzImage";
-  initrd = "${kata.kata-image}/initrd";
+  kernel = "${os-image}/bzImage";
+  initrd = "${os-image}/initrd";
 
   # Kata uses a base command line and then appends the command line from the kata config (i.e. also our node-installer config).
   # Thus, we need to perform the same steps when calculating the digest.
   baseCmdline = if debug then kata.kata-runtime.cmdline.debug else kata.kata-runtime.cmdline.default;
   cmdline = lib.strings.concatStringsSep " " [
     baseCmdline
-    kata.kata-image.cmdline
+    os-image.cmdline
   ];
 in
 
 stdenvNoCC.mkDerivation {
   name = "snp-launch-digest${lib.optionalString debug "-debug"}";
-  inherit (kata.kata-image) version;
+  inherit (os-image) version;
 
   dontUnpack = true;
 

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -198,5 +198,8 @@ containers
   push-node-installer-kata =
     pushOCIDir "push-node-installer-kata" pkgs.kata.contrast-node-installer-image
       "v${pkgs.contrast.version}";
+  push-node-installer-kata-gpu =
+    pushOCIDir "push-node-installer-kata-gpu" pkgs.kata.contrast-node-installer-image.gpu
+      "v${pkgs.contrast.version}";
 }
 // (lib.concatMapAttrs (name: container: { "push-${name}" = pushContainer container; }) containers)

--- a/packages/nixos/kata.nix
+++ b/packages/nixos/kata.nix
@@ -78,7 +78,13 @@ in
     };
 
     # Not used directly, but required for kernel-specific driver builds.
-    boot.kernelPackages = pkgs.recurseIntoAttrs (pkgs.linuxPackagesFor pkgs.kata-kernel-uvm);
+    boot.kernelPackages = pkgs.recurseIntoAttrs (
+      pkgs.linuxPackagesFor (
+        pkgs.kata-kernel-uvm.override {
+          withGPU = config.contrast.gpu.enable;
+        }
+      )
+    );
 
     boot.initrd = {
       # Don't require TPM2 support. (additional modules)


### PR DESCRIPTION
This adds support for running bare-metal Kata containers with GPUs on Contrast.
Please refer to the commit messages for reasoning about the individual code changes.

Requires a nixpkgs containing https://github.com/NixOS/nixpkgs/pull/372320.

An E2E test based on this will follow.