### PR TITLE
treewide: pass CGO_ENABLED via env

### DIFF
--- a/packages/by-name/cloud-api-adaptor/package.nix
+++ b/packages/by-name/cloud-api-adaptor/package.nix
@@ -70,7 +70,7 @@ buildGoModule rec {
     "cmd/process-user-data"
   ];
 
-  CGO_ENABLED = if withLibvirt then 1 else 0;
+  env.CGO_ENABLED = if withLibvirt then 1 else 0;
 
   tags = builtinCloudProviders;
 

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -200,7 +200,7 @@ buildGoModule rec {
     install -D ${kata.genpolicy.settings-dev}/genpolicy-settings.json cli/genpolicy/assets/genpolicy-settings-kata.json
   '';
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-X github.com/edgelesssys/contrast/internal/constants.Version=v${version}"
@@ -211,7 +211,7 @@ buildGoModule rec {
   tags = [ "contrast_unstable_api" ];
 
   preCheck = ''
-    export CGO_ENABLED=1
+    export env.CGO_ENABLED=1
   '';
 
   checkPhase = ''

--- a/packages/by-name/microsoft/kata-runtime/package.nix
+++ b/packages/by-name/microsoft/kata-runtime/package.nix
@@ -44,7 +44,7 @@ buildGoModule rec {
     git
   ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [ "-s" ];
 
   checkFlags =

--- a/packages/by-name/nydus-snapshotter/package.nix
+++ b/packages/by-name/nydus-snapshotter/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
     "cmd/nydus-overlayfs"
   ];
 
-  CGO_ENABLED = "0";
+  env.CGO_ENABLED = "0";
 
   ldflags = [
     "-s"

--- a/packages/by-name/service-mesh/package.nix
+++ b/packages/by-name/service-mesh/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-w"

--- a/packages/by-name/tdx-measure/package.nix
+++ b/packages/by-name/tdx-measure/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  CGO_ENABLED = 0;
+  env.CGO_ENABLED = 0;
   ldflags = [
     "-s"
     "-X main.version=v${version}"


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/commit/905dc8d978b38b0439905cb5cd1faf79163e1f14, it is necessary to pass the Go build options, such as `CGO_ENABLED` via the environment. So proactively comply with that and pass them via the environment before the deprecation window ends.