### PR TITLE
microsoft.genpolicy: support volume mounting

### DIFF
--- a/packages/by-name/microsoft/genpolicy/0010-genpolicy-support-mount-propagation-and-ro-mounts.patch
+++ b/packages/by-name/microsoft/genpolicy/0010-genpolicy-support-mount-propagation-and-ro-mounts.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmxnzo <jakob.lammering@ruhr-uni-bochum.de>
+Date: Fri, 10 Jan 2025 14:49:05 +0100
+Subject: [PATCH] genpolicy: support mount propagation and ro-mounts
+
+---
+ src/tools/genpolicy/rules.rego | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
+index 3e03070e3743f9a2ecc29e5d7714a5a0335bd1ed..87caa1d3e6ca689d6f2ddf5ada9a7a50e79b7968 100644
+--- a/src/tools/genpolicy/rules.rego
++++ b/src/tools/genpolicy/rules.rego
+@@ -105,7 +105,7 @@ allow_create_container_input {
+     count(i_linux.GIDMappings) == 0
+     count(i_linux.MountLabel) == 0
+     count(i_linux.Resources.Devices) == 0
+-    count(i_linux.RootfsPropagation) == 0
++    # TODO(burgerdev): is it harmful to always allow RootfsPropagation?
+     count(i_linux.UIDMappings) == 0
+     is_null(i_linux.IntelRdt)
+     is_null(i_linux.Resources.BlockIO)

--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -71,6 +71,12 @@ rustPlatform.buildRustPackage rec {
       # This avoids printing the entire annotation on log level debug, which resulted in errors of the logtranslator.go
       # TODO(jmxnzo): remove when https://github.com/kata-containers/kata-containers/pull/10647 is picked up by microsoft/kata-containers fork
       ./0009-genpolicy-do-not-log-policy-annotation-in-debug.patch
+      # Patches the RootfsPropagation check in allow_create_container_input to allow setting up bidirectional volumes, which need to propagate their changes to a
+      # volume mounted on the root filesystem and possibly shared across multiple containers on the host.
+      # RootfsPropagation describes the mapping to mount propagations: https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
+      # It reflects genpolicy-support-mount-propagation-and-ro-mounts.patch on upstream kata.genpolicy, but drops the patched propagation mode
+      # derivation, because it was already built in to the microsoft fork.
+      ./0010-genpolicy-support-mount-propagation-and-ro-mounts.patch
     ];
   };
 


### PR DESCRIPTION
This PR adds a patch to support volume mounting for the genpolicy binary of the microsoft fork, which is necessary for volumestatefulset and mysql deployments. Updating the release of the microsoft fork in https://github.com/edgelesssys/contrast/commit/a3496ccfaac275f8272fa91fd8b8303081b6bc39 resulted in introducing the required change.