### PR TITLE
[release/v1.2] service-mesh: test readiness with exec probe

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -469,8 +469,8 @@ func ServiceMeshProxy() *applycorev1.ContainerApplyConfiguration {
 			WithInitialDelaySeconds(1).
 			WithPeriodSeconds(5).
 			WithFailureThreshold(5).
-			WithTCPSocket(TCPSocketAction().
-				WithPort(intstr.FromInt(15006))),
+			WithExec(ExecAction().
+				WithCommand("test", "-f", "/ready")),
 		).
 		WithArgs(
 			"-l", "debug",

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -336,6 +336,11 @@ func TCPSocketAction() *applycorev1.TCPSocketActionApplyConfiguration {
 	return applycorev1.TCPSocketAction()
 }
 
+// ExecAction creates a new ExecActionApplyConfiguration.
+func ExecAction() *applycorev1.ExecActionApplyConfiguration {
+	return applycorev1.ExecAction()
+}
+
 // RuntimeClassConfig wraps applypodsv1.RuntimeClassApplyConfiguration for a runtime class.
 type RuntimeClassConfig struct {
 	*applynodev1.RuntimeClassApplyConfiguration

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -108,13 +108,14 @@ let
       name = "service-mesh-proxy";
       tag = "v${pkgs.service-mesh.version}";
       copyToRoot = with pkgs; [
+        busybox
         envoy
         iptables-legacy
       ];
       config = {
         # Use Entrypoint so we can append arguments.
         Entrypoint = [ "${pkgs.service-mesh}/bin/service-mesh" ];
-        Env = [ "PATH=/bin" ]; # This is only here for policy generation.
+        Env = [ "PATH=/bin" ];
       };
     };
 

--- a/service-mesh/main.go
+++ b/service-mesh/main.go
@@ -59,6 +59,11 @@ func run() (retErr error) {
 		return fmt.Errorf("failed to set up iptables rules: %w", err)
 	}
 
+	// Signal readiness for startup probe.
+	if err := os.WriteFile("/ready", nil, 0o644); err != nil {
+		return err
+	}
+
 	// execute the envoy binary
 	envoyBin, err := exec.LookPath("envoy")
 	if err != nil {


### PR DESCRIPTION
Backport of #1142 to `release/v1.2`.

Original description:

---

The startup probe for the mesh proxy is redirected onto the same port, causing Envoy to open connections to itself recursively. Unfortunately, this is not visible in the Envoy logs - I only discovered this condition while working on a custom proxy implementation.

Things that are still unclear:

* There is some race condition that causes the redirection loop to only occur ~50% of the time.
* Switching on debug logging makes this condition much rarer.
* Exempting the TPROXY ports with iptables should make the SO_ORIGINAL_DST lookup fail, but the loop happens nonetheless.
* The issue reproduces with opening and holding a single connection, while opening another, but not with just one connection.

Tests:
* [x] https://github.com/edgelesssys/contrast/actions?query=branch%3Aburgerdev%2Fmesh-probe+event%3Aworkflow_dispatch++