### PR TITLE
kuberesource: serve images from edgelesssys org

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -199,9 +199,10 @@ func Emojivoto(smMode serviceMeshMode) []any {
 	var emojiSvcImage, emojiVotingSvcImage, emojiWebImage, emojiWebVoteBotImage, emojiSvcHost, votingSvcHost string
 	switch smMode {
 	case ServiceMeshDisabled:
-		emojiSvcImage = "ghcr.io/3u13r/emojivoto-emoji-svc:coco-1@sha256:fa80600859cda06079a542632713b2cc67ed836e429753a799a6c313322d1426"
-		emojiVotingSvcImage = "ghcr.io/3u13r/emojivoto-voting-svc:coco-1@sha256:bb7fbea32bf28c6201602b473bf7e0f40290642e3f783dcfa4b8e3c693531cba"
-		emojiWebImage = "ghcr.io/3u13r/emojivoto-web:coco-1@sha256:0fd9bf6f7dcb99bdb076144546b663ba6c3eb457cbb48c1d3fceb591d207289c"
+		// Source: https://github.com/3u13r/emojivoto/tree/8ba877681c297721cde63eb7be95c98c4c1186ee
+		emojiSvcImage = "ghcr.io/edgelesssys/contrast/emojivoto-emoji-svc:coco-1@sha256:fa80600859cda06079a542632713b2cc67ed836e429753a799a6c313322d1426"
+		emojiVotingSvcImage = "ghcr.io/edgelesssys/contrast/emojivoto-voting-svc:coco-1@sha256:bb7fbea32bf28c6201602b473bf7e0f40290642e3f783dcfa4b8e3c693531cba"
+		emojiWebImage = "ghcr.io/edgelesssys/contrast/emojivoto-web:coco-1@sha256:0fd9bf6f7dcb99bdb076144546b663ba6c3eb457cbb48c1d3fceb591d207289c"
 		emojiWebVoteBotImage = emojiWebImage
 		emojiSvcHost = "emoji-svc:8080"
 		votingSvcHost = "voting-svc:8080"
@@ -209,7 +210,8 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		emojiSvcImage = "docker.io/buoyantio/emojivoto-emoji-svc:v11@sha256:957949355653776b65fafc2ee22f737cd21e090d4ace63f3b99f6e16976f0458"
 		emojiVotingSvcImage = "docker.io/buoyantio/emojivoto-voting-svc:v11@sha256:a57ac67af7a5b05988a38b49568eca6a078ef27a71c148c44c9db4efb1dac58b"
 		emojiWebImage = "docker.io/buoyantio/emojivoto-web:v11@sha256:d21f9fdb794f754b076344ce01c4858c499617c952cc6a941ac3cefbf5ccedfd"
-		emojiWebVoteBotImage = "ghcr.io/3u13r/emojivoto-web:coco-1@sha256:0fd9bf6f7dcb99bdb076144546b663ba6c3eb457cbb48c1d3fceb591d207289c"
+		// Source: https://github.com/3u13r/emojivoto/tree/8ba877681c297721cde63eb7be95c98c4c1186ee
+		emojiWebVoteBotImage = "ghcr.io/edgelesssys/contrast/emojivoto-web:coco-1@sha256:0fd9bf6f7dcb99bdb076144546b663ba6c3eb457cbb48c1d3fceb591d207289c"
 		emojiSvcHost = "127.137.0.1:8081"
 		votingSvcHost = "127.137.0.2:8081"
 	default:


### PR DESCRIPTION
This makes it so that the images in the Emojivoto deployment are taken from the edgelesssys org, not an individual developer's one. Images are already migrated and published.