### PR TITLE
e2e: prevent download of streamed log directory

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: e2e_pod_logs-${{ inputs.platform }}-${{ inputs.test-name }}
-          path: workspace/logs/export/logs
+          path: workspace/logs/export-no-stream/logs
       - name: Notify teams channel of failure
         if: failure() && github.event_name == 'schedule' && github.run_attempt == 1
         uses: ./.github/actions/post_to_teams

--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: e2e_pod_logs-AKS-CLH-SNP-aks-runtime
-          path: workspace/logs/export/logs
+          path: workspace/logs/export-no-stream/logs
       - name: Notify teams channel of failure
         if: failure() && github.event_name == 'schedule' && github.run_attempt == 1
         uses: ./.github/actions/post_to_teams

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -460,7 +460,7 @@
         pod="$(kubectl get pods -o name -n "$namespace" | grep log-collector | cut -c 5-)"
         mkdir -p ./workspace/logs
         kubectl wait --for=condition=Ready -n "$namespace" "pod/$pod"
-        kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; tar zcvf /exported-logs.tar.gz /export"
+        kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; cp -r /export /export-no-stream; tar zcvf /exported-logs.tar.gz /export-no-stream; rm -rf /export-no-stream"
         kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz
         tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs
         ;;


### PR DESCRIPTION
This fixes [this error](https://github.com/edgelesssys/contrast/actions/runs/12703367171/job/35411042848#step:12:131). The error occurred because data was streamed into the export directory while it was made ready for download. The fix just copies the `export` directory to `export-no-stream`, which is then downloaded instead. This ensures that streaming is never interrupted and logs are never missed.