### PR TITLE
resourcegen: add unique suffix to nodeinstaller clusterrole binding

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -295,6 +295,9 @@ func PatchNamespaces(resources []any, namespace string) []any {
 		case *applycorev1.ServiceAccountApplyConfiguration:
 			r.Namespace = nsPtr
 		case *applyrbacv1.ClusterRoleBindingApplyConfiguration:
+			if namespace != "" {
+				*r.Name = fmt.Sprintf("%s-%s", *r.Name, *nsPtr)
+			}
 			for i := range len(r.Subjects) {
 				r.Subjects[i].Namespace = nsPtr
 			}

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -245,7 +245,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 				WithVerbs("watch"),
 		)
 
-	clusterRoleBinding := applyrbacv1.ClusterRoleBinding("nodeinstaller-clusterrole-binding").
+	clusterRoleBinding := applyrbacv1.ClusterRoleBinding(fmt.Sprintf("nodeinstaller-%s", runtimeHandler)).
 		WithSubjects(
 			applyrbacv1.Subject().
 				WithKind("ServiceAccount").


### PR DESCRIPTION
When running two Contrast deployments, the `ClusterRoleBinding` of one node installer gets overridden by the other, since they have the same name: `nodeinstaller-clusterrole-binding`. This results in one of the `nydus-pull` containers in the node installer to fail due to missing permissions.

Since `ClusterRoleBinding`s are not namespaced, and `RoleBinding`s limit the container's access to its own namespace, this changes the name of the `ClusterRoleBinding` to `nodeinstaller-<platform-hash>-<namespace>`. By doing this, we achieve two things:
1. Two Contrast deployments with the same runtime hash can be deployed in different namespaces simultaneously.
2. Two Contrast deployments with different runtime hashes can be deployed simultaneously.