### PR TITLE
e2e/release: increase timeout for generate

### DIFF
--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -147,7 +147,7 @@ func TestRelease(t *testing.T) {
 		}
 	}), "unpacking needs to succeed for subsequent tests to run")
 
-	contrast.Run(ctx, t, 2*time.Minute, "generate", "--reference-values", *platformStr, "deployment/")
+	contrast.Run(ctx, t, 4*time.Minute, "generate", "--reference-values", *platformStr, "deployment/")
 	contrast.patchReferenceValues(t, lowerPlatformStr)
 
 	overrideFlags := contrast.coordinatorPolicyHashOverride(t, lowerPlatformStr)


### PR DESCRIPTION
Releases were failing due to the short timeout: https://github.com/edgelesssys/contrast/actions/runs/12784167814/job/35640395847#step:9:38