### PR TITLE
runtime: allow installation of multiple Contrast runtimes side-by-side

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,7 +314,7 @@ jobs:
               'select(.kind == "StatefulSet") | .spec.template.metadata.annotations["io.katacontainers.config.agent.policy"]' |
               base64 -d | sha256sum | cut -d " " -f1 >> workspace/coordinator-policy.hash
             nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt --platform $platform \
-              --namespace kube-system runtime > workspace/runtime-$platform.yml
+              runtime > workspace/runtime-$platform.yml
           done
           nix shell .#contrast --command resourcegen --image-replacements ./image-replacements.txt \
             --add-load-balancers emojivoto-sm-ingress > workspace/emojivoto-demo.yml

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -378,7 +378,12 @@ func (ct *ContrastTest) installRuntime(t *testing.T) {
 
 	require.NoError(ct.Kubeclient.Apply(ctx, unstructuredResources...))
 
-	require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.DaemonSet{}, ct.Namespace, "contrast-node-installer"))
+	for _, r := range unstructuredResources {
+		if r.GetKind() != "DaemonSet" {
+			continue
+		}
+		require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.DaemonSet{}, ct.Namespace, r.GetName()))
+	}
 }
 
 // runAgainstCoordinator forwards the coordinator port and executes the command against it.

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -105,7 +105,13 @@ func TestRelease(t *testing.T) {
 		require.NoError(err)
 
 		require.NoError(k.Apply(ctx, resources...))
-		require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.DaemonSet{}, "kube-system", "contrast-node-installer"))
+
+		for _, r := range resources {
+			if r.GetKind() != "DaemonSet" {
+				continue
+			}
+			require.NoError(k.WaitFor(ctx, kubeclient.Ready, kubeclient.DaemonSet{}, r.GetNamespace(), r.GetName()))
+		}
 	}), "the runtime is required for subsequent tests to run")
 
 	var coordinatorIP string

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -276,10 +276,7 @@ func PatchRuntimeHandlers(resources []any, runtimeHandler string) []any {
 
 // PatchNamespaces replaces namespaces in a set of resources.
 func PatchNamespaces(resources []any, namespace string) []any {
-	var nsPtr *string
-	if namespace != "" {
-		nsPtr = &namespace
-	}
+	nsPtr := &namespace
 	for _, resource := range resources {
 		switch r := resource.(type) {
 		case *applycorev1.PodApplyConfiguration:

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -295,6 +295,9 @@ func PatchNamespaces(resources []any, namespace string) []any {
 		case *applycorev1.ServiceAccountApplyConfiguration:
 			r.Namespace = nsPtr
 		case *applyrbacv1.ClusterRoleBindingApplyConfiguration:
+			if namespace != "" {
+				*r.Name = fmt.Sprintf("%s-%s", *r.Name, *nsPtr)
+			}
 			for i := range len(r.Subjects) {
 				r.Subjects[i].Namespace = nsPtr
 			}

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -18,6 +18,7 @@ func TestPatchNamespaces(t *testing.T) {
 	openssl := OpenSSL()
 	emojivoto := Emojivoto(ServiceMeshIngressEgress)
 	volumeStatefulSet := VolumeStatefulSet()
+	mysql := MySQL()
 
 	for _, tc := range []struct {
 		name string
@@ -39,6 +40,10 @@ func TestPatchNamespaces(t *testing.T) {
 			name: "volume-stateful-set",
 			set:  volumeStatefulSet,
 		},
+		{
+			name: "mysql",
+			set:  mysql,
+		},
 	} {
 		t.Run(tc.name, func(_ *testing.T) {
 			expectedNamespace := "right-namespace"
@@ -48,19 +53,6 @@ func TestPatchNamespaces(t *testing.T) {
 			require.NotEmpty(u)
 			for _, obj := range u {
 				require.Equal(expectedNamespace, obj.GetNamespace())
-			}
-		})
-		t.Run(tc.name+"-empty-namespace", func(_ *testing.T) {
-			set := PatchNamespaces(tc.set, "some-namespace")
-			set = PatchNamespaces(set, "")
-			u, err := ResourcesToUnstructured(set)
-			require.NoError(err)
-			require.NotEmpty(u)
-			for _, obj := range u {
-				meta, ok := obj.Object["metadata"].(map[string]any)
-				require.True(ok)
-				_, ok = meta["namespace"]
-				require.False(ok, "namespace should have been deleted")
 			}
 		})
 	}

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -235,7 +235,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 			),
 		)
 
-	serviceAccount := applycorev1.ServiceAccount("nodeinstaller-serviceaccount", "")
+	serviceAccount := applycorev1.ServiceAccount("nodeinstaller-serviceaccount", namespace)
 
 	clusterRole := applyrbacv1.ClusterRole("nodeinstaller-clusterrole").
 		WithRules(

--- a/internal/kuberesource/parts_test.go
+++ b/internal/kuberesource/parts_test.go
@@ -28,3 +28,52 @@ func TestCoordinator(t *testing.T) {
 	require.NoError(err)
 	t.Log("\n" + string(b))
 }
+
+func TestNoNamespaces(t *testing.T) {
+	coordinator := CoordinatorBundle()
+	openssl := OpenSSL()
+	emojivoto := Emojivoto(ServiceMeshIngressEgress)
+	volumeStatefulSet := VolumeStatefulSet()
+	mysql := MySQL()
+
+	for _, tc := range []struct {
+		name string
+		set  []any
+	}{
+		{
+			name: "coordinator",
+			set:  coordinator,
+		},
+		{
+			name: "openssl",
+			set:  openssl,
+		},
+		{
+			name: "emojivoto",
+			set:  emojivoto,
+		},
+		{
+			name: "volume-stateful-set",
+			set:  volumeStatefulSet,
+		},
+		{
+			name: "mysql",
+			set:  mysql,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			u, err := ResourcesToUnstructured(tc.set)
+			require.NoError(err)
+			require.NotEmpty(u)
+			for _, obj := range u {
+				metaAny, ok := obj.Object["metadata"]
+				require.True(ok)
+				meta, ok := metaAny.(map[string]any)
+				require.True(ok)
+				_, ok = meta["namespace"]
+				require.False(ok)
+			}
+		})
+	}
+}

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -118,9 +118,11 @@ func main() {
 	}
 
 	kuberesource.PatchImages(resources, replacements)
-	kuberesource.PatchNamespaces(resources, *namespace)
-	if *addNamespaceObject && *namespace != "default" && *namespace != "" {
-		resources = append([]any{kuberesource.Namespace(*namespace)}, resources...)
+	if *namespace != "" {
+		kuberesource.PatchNamespaces(resources, *namespace)
+		if *addNamespaceObject && *namespace != "default" {
+			resources = append([]any{kuberesource.Namespace(*namespace)}, resources...)
+		}
 	}
 
 	b, err := kuberesource.EncodeResources(resources...)

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -31,7 +31,7 @@ func CoordinatorBundle() []any {
 
 // Runtime returns a set of resources for registering and installing the runtime.
 func Runtime(platform platforms.Platform) ([]any, error) {
-	ns := ""
+	ns := "kube-system"
 
 	runtimeClass, err := ContrastRuntimeClass(platform)
 	if err != nil {

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -685,7 +685,7 @@ func MySQL() []any {
 						),
 				),
 			).
-			WithVolumeClaimTemplates(applycorev1.PersistentVolumeClaim("state", "").
+			WithVolumeClaimTemplates(PersistentVolumeClaim("state", "").
 				WithSpec(applycorev1.PersistentVolumeClaimSpec().
 					WithVolumeMode(corev1.PersistentVolumeBlock).
 					WithAccessModes(corev1.ReadWriteOnce).

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -313,7 +313,11 @@ type ServiceAccountConfig struct {
 
 // ServiceAccount creates a new ServiceAccountConfig.
 func ServiceAccount(name, namespace string) *ServiceAccountConfig {
-	return &ServiceAccountConfig{applycorev1.ServiceAccount(name, namespace)}
+	s := &ServiceAccountConfig{applycorev1.ServiceAccount(name, namespace)}
+	if namespace == "" && s.ObjectMetaApplyConfiguration != nil {
+		s.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return s
 }
 
 // NamespaceConfig wraps applycorev1.NamespaceApplyConfiguration.
@@ -361,6 +365,20 @@ func Scheduling(nodeSelector map[string]string, tolerations ...*applycorev1.Tole
 	return applynodev1.Scheduling().
 		WithNodeSelector(nodeSelector).
 		WithTolerations(tolerations...)
+}
+
+// PersistentVolumeClaimConfig wraps applycorev1.PersistentVolumeClaimApplyConfiguration.
+type PersistentVolumeClaimConfig struct {
+	*applycorev1.PersistentVolumeClaimApplyConfiguration
+}
+
+// PersistentVolumeClaim constructs a new PersistentVolumeClaimConfig.
+func PersistentVolumeClaim(name, namespace string) *PersistentVolumeClaimConfig {
+	pvc := applycorev1.PersistentVolumeClaim(name, namespace)
+	if namespace == "" && pvc.ObjectMetaApplyConfiguration != nil {
+		pvc.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return &PersistentVolumeClaimConfig{pvc}
 }
 
 func fromPtr[T any](v *T) T {


### PR DESCRIPTION
The Contrast runtime used to have a static name, and only one runtime could be installed into the `kube-system` namespace. We're changing the naming scheme in this PR: resources of the Contrast runtime (the node installer and its RBAC config) are now named like the runtime handler, which allows installing more than one version.

**User-visible consequence**: the runtime `DaemonSet` is not called `contrast-node-installer` anymore, but something like `contrast-cc-aks-clh-snp-c52b1454`.