### PR TITLE
microsoft.kata-image: refactor, fix reproducibility issue

### DIFF
--- a/packages/by-name/microsoft/kata-image/package.nix
+++ b/packages/by-name/microsoft/kata-image/package.nix
@@ -163,6 +163,7 @@ let
             --exclude='./usr/lib/systemd/system/systemd-timesyncd*' \
             --exclude='./usr/lib/systemd/system/systemd-tmpfiles-setup*' \
             --exclude='./usr/lib/systemd/system/systemd-update-utmp*' \
+            --exclude='./nix/store' \
             --exclude='*systemd-bless-boot-generator*' \
             --exclude='*systemd-fstab-generator*' \
             --exclude='*systemd-getty-generator*' \

--- a/packages/by-name/microsoft/kata-image/package.nix
+++ b/packages/by-name/microsoft/kata-image/package.nix
@@ -196,41 +196,26 @@ let
   '';
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "kata-image";
-  inherit (microsoft.genpolicy) src version;
+  inherit (microsoft.genpolicy) version;
+
+  dontUnpack = true;
 
   outputs = [
     "out"
     "verity"
   ];
 
-  env = {
-    AGENT_SOURCE_BIN = "${lib.getExe microsoft.kata-agent}";
-    CONF_GUEST = "yes";
-    RUST_VERSION = "not-needed";
-  };
-
   nativeBuildInputs = [
-    yq-go
-    curl
-    fakeroot
-    bubblewrap
-    util-linux
-    tdnf
     buildimage
+    util-linux
   ];
-
-  sourceRoot = "${src.name}/tools/osbuilder/rootfs-builder";
 
   buildPhase = ''
     runHook preBuild
 
-    cp ${rootfsCombinedTar} /build/rootfs.tar
-    chmod +w /build/rootfs.tar
-
-    # convert tar to a squashfs image with dm-verity hash
-    ${lib.getExe buildimage} /build/rootfs.tar .
+    ${lib.getExe buildimage} ${rootfsCombinedTar} .
 
     runHook postBuild
   '';
@@ -251,4 +236,13 @@ stdenv.mkDerivation rec {
     mv raw.img $out
   '';
   dontPatchELF = true;
+
+  passthru = {
+    inherit
+      rootfsTar
+      closureTar
+      rootfsExtraTree
+      rootfsCombinedTar
+      ;
+  };
 }


### PR DESCRIPTION
This fixes a reproducibility issue in the VM image for AKS, where an non-needed RPM sqlite file would be included in the image.

e2e reproducibility: :green_circle: https://github.com/edgelesssys/contrast/actions/runs/12884449490