### PR TITLE
docs: disable SSH access to AKS nodes

### DIFF
--- a/docs/docs/getting-started/cluster-setup.md
+++ b/docs/docs/getting-started/cluster-setup.md
@@ -33,6 +33,14 @@ az feature register \
     --name "KataCcIsolationPreview"
 ```
 
+Also enable the feature flag to disable SSH access to the AKS node (recommended, not required):
+
+```bash
+az feature register \
+  --namespace "Microsoft.ContainerService" \
+  --name "DisableSSHPreview"
+```
+
 The registration can take a few minutes. The status of the operation can be checked with the following
 command, which should show the registration state as `Registered`:
 
@@ -40,6 +48,10 @@ command, which should show the registration state as `Registered`:
 az feature show \
     --namespace "Microsoft.ContainerService" \
     --name "KataCcIsolationPreview" \
+    --output table
+az feature show \
+    --namespace "Microsoft.ContainerService" \
+    --name "DisableSSHPreview" \
     --output table
 ```
 
@@ -99,7 +111,7 @@ az aks create \
   --node-vm-size Standard_DC4as_cc_v5 \
   --workload-runtime KataCcIsolation \
   --node-count 1 \
-  --generate-ssh-keys
+  --ssh-access disabled
 ```
 
 Finally, update your kubeconfig with the credentials to access the cluster:

--- a/packages/create-coco-aks.sh
+++ b/packages/create-coco-aks.sh
@@ -53,7 +53,7 @@ az aks create \
   --node-vm-size Standard_DC4as_cc_v5 \
   --workload-runtime KataCcIsolation \
   --node-count 1 \
-  --generate-ssh-keys
+  --ssh-access disabled
 
 az aks get-credentials \
   --resource-group "${name}" \


### PR DESCRIPTION
Azure's az cli recommends to do so:

```
The new node pool will enable SSH access, recommended to use '--ssh-access disabled' option to disable SSH access for the node pool to make it more secure.
```

 Therefore we integrate this step in our setup guide. SSH access to the node does not undermine Confidential Computing security in any way.