### PR TITLE
docs: add docs on GPU support

### DIFF
--- a/docs/docs/basics/features.md
+++ b/docs/docs/basics/features.md
@@ -13,3 +13,5 @@ From an operational perspective, Contrast provides the following key features:
 * **Remote attestation**: Contrast generates a concise attestation statement that verifies the identity, authenticity, and integrity of your deployment both internally and to external parties. This architecture ensures that updates or scaling of the application don't compromise the attestation’s validity.
 
 * **Service mesh**: Contrast securely manages a Public Key Infrastructure (PKI) for your deployments, issues workload-specific certificates, and establishes transparent mutual TLS (mTLS) connections across pods. This is done by harnessing the [envoy proxy](https://www.envoyproxy.io/) to ensure secure communications within your Kubernetes cluster.
+
+* **GPU support**: Contrast supports GPU integration, enabling the execution of AI workloads.  

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -41,3 +41,15 @@ Kata Containers supports [overriding certain configuration values via Kubernetes
 
 It needs to be noted that setting these values is unsupported, and doing so may lead to unexpected
 behaviour, as Contrast isn't tested against all possible configuration combinations.
+
+## GPU attestation
+
+While Contrast supports integration with confidential computing-enabled GPUs, such as NVIDIA's H100 series, attesting the integrity of the GPU device currently must be handled at the workload layer.
+This means the workload needs to verify that the GPU is indeed an NVIDIA H100 running in confidential computing mode.
+
+To simplify this process, the NVIDIA CC-Manager, which is
+[deployed alongside the NVIDIA GPU operator](./getting-started/bare-metal.md#preparing-a-cluster-for-gpu-usage), enables the use of confidential computing GPUs (CC GPUs) within the workload. With the CC-Manager in place, the workload is responsible only for attesting the GPU's integrity.
+
+One way to perform this attestation is by using
+[nvTrust](https://github.com/NVIDIA/nvtrust), NVIDIA's reference implementation for GPU attestation.
+nvTrust provides tools and utilities to perform attestation within the workload.

--- a/tools/vale/styles/config/vocabularies/edgeless/accept.txt
+++ b/tools/vale/styles/config/vocabularies/edgeless/accept.txt
@@ -81,9 +81,11 @@ namespace
 Nginx
 nixpkgs
 noogle
+nvTrust
 Nydus
 overlayfs
 paravisor
+passthrough
 PCR
 plaintext
 podman


### PR DESCRIPTION
This adds documentation on setting up a bare-metal Contrast cluster for use with GPUs, how to deploy the GPU-enabled runtime class, and how to modify pod specs to use GPU devices.