### PR TITLE
kuberesource: use only PVC wrapper

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -411,7 +411,7 @@ func Coordinator(namespace string) *CoordinatorConfig {
 					),
 				),
 			).
-			WithVolumeClaimTemplates(applycorev1.PersistentVolumeClaim("state-device", namespace).
+			WithVolumeClaimTemplates(PersistentVolumeClaim("state-device", namespace).
 				WithSpec(applycorev1.PersistentVolumeClaimSpec().
 					WithVolumeMode(corev1.PersistentVolumeBlock).
 					WithAccessModes(corev1.ReadWriteOnce).

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -584,7 +584,7 @@ func VolumeStatefulSet() []any {
 						),
 				),
 			).
-			WithVolumeClaimTemplates(applycorev1.PersistentVolumeClaim("state", "").
+			WithVolumeClaimTemplates(PersistentVolumeClaim("state", "").
 				WithSpec(applycorev1.PersistentVolumeClaimSpec().
 					WithVolumeMode(corev1.PersistentVolumeBlock).
 					WithAccessModes(corev1.ReadWriteOnce).


### PR DESCRIPTION
Using the wrapper removes the empty namespace from the volume claim templates in our stateful sets. This is only an aesthetic fix, the explicit empty namespace also does the right thing.