### PR TITLE
deps: remove go-sev-guest replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 // The upstream package has some stepping issues with Genoa:
 // https://github.com/google/go-sev-guest/issues/115
 // https://github.com/google/go-sev-guest/issues/103
-replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20240719074306-114f78ece7a7
+replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250123132625-84dd662ed905
 
 require (
 	filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgelesssys/go-sev-guest v0.0.0-20240719074306-114f78ece7a7 h1:rT17BAHLt7qHt4u8i1dfNl9YB5GZudZ84HA11lTGUOY=
-github.com/edgelesssys/go-sev-guest v0.0.0-20240719074306-114f78ece7a7/go.mod h1:8+UOtSaqVIZjJJ9DDmgRko3J/kNc6jI5KLHxoeao7cA=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250123132625-84dd662ed905 h1:2GWCffQhOVtr/ePrDQf/qKc+2iMnMp84i4suzdNfchc=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250123132625-84dd662ed905/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -183,7 +183,7 @@ buildGoModule rec {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-fgSO+NMhLSxvQM6itw2Wsgr8B+r1Hbuuf9SpbEwajOg=";
+  vendorHash = "sha256-Jn1ymg9pNMOeUgswfyONO2RYIKDR5KUkSiTd7QAsUBU=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
We replaced the version with our fork which was 6 months old. ~The issues mentioned have been resolved.~ While the GitHub issues have been resolved, the issue itself still persists. Therefore I've updated the fork.