### PR TITLE
cli: inject contrast-secrets mount into initcontainers

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -539,9 +539,6 @@ func VolumeStatefulSet() []any {
 										WithName("share").
 										WithMountPath("/state").
 										WithMountPropagation(corev1.MountPropagationBidirectional),
-									VolumeMount().
-										WithName("contrast-secrets").
-										WithMountPath("/contrast"),
 								).
 								WithSecurityContext(
 									applycorev1.SecurityContext().
@@ -634,9 +631,6 @@ func MySQL() []any {
 										WithName("share").
 										WithMountPath("/state").
 										WithMountPropagation(corev1.MountPropagationBidirectional),
-									VolumeMount().
-										WithName("contrast-secrets").
-										WithMountPath("/contrast"),
 								).
 								WithSecurityContext(
 									applycorev1.SecurityContext().


### PR DESCRIPTION
The Contrast CLI injects a `volumeMount` for Contrast secrets (TLS certificates and workload secrets) into application containers. This was used to be done for regular containers only, not for initcontainers. 

However, many use cases for initcontainers involve the Contrast secrets - our own demos are a good example. Therefore, we add support for injecting the mount into initcontainers.

* [x] [volumestatefulset test](https://github.com/edgelesssys/contrast/actions/runs/12933560196)