### PR TITLE
e2e/runtime-reproducibility: fix teams notifications

### DIFF
--- a/.github/workflows/e2e_runtime-reproducibility.yml
+++ b/.github/workflows/e2e_runtime-reproducibility.yml
@@ -58,7 +58,7 @@ jobs:
           name: ${{ matrix.build-target }}-${{ matrix.os }}-checksums
           path: ${{ matrix.build-target }}-${{ matrix.os }}-*_checksum.txt
       - name: Notify teams channel of failure
-        if: failure() && github.ref == 'main' && github.run_attempt == 1
+        if: failure() && github.event_name == 'schedule' && github.run_attempt == 1
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
@@ -99,7 +99,7 @@ jobs:
               exit(1)
           print("All checksums were equal")
       - name: Notify teams channel of failure
-        if: failure() && github.ref == 'main' && github.run_attempt == 1
+        if: failure() && github.event_name == 'schedule' && github.run_attempt == 1
         uses: ./.github/actions/post_to_teams
         with:
           webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}


### PR DESCRIPTION
This should have used `github.ref_name == 'main'` instead of `github.ref`, which is `refs/heads/main` on main.
But even better, we can check for the `event_name` to be `schedule`, so we can also filter out `workflow_dispatch` events on main.