### PR TITLE
kuberesource: some improvements around the port-forwarder resource

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -5,6 +5,7 @@ package kuberesource
 
 import (
 	"fmt"
+	"log"
 	"slices"
 	"strconv"
 	"strings"
@@ -176,7 +177,11 @@ func AddPortForwarders(resources []any) []any {
 	for _, resource := range resources {
 		switch obj := resource.(type) {
 		case *applycorev1.ServiceApplyConfiguration:
-			out = append(out, PortForwarderForService(obj))
+			forwarder, err := PortForwarderForService(obj)
+			if err != nil {
+				log.Printf("WARNING: no port forwarder added for service %q: %v", *obj.Name, err)
+			}
+			out = append(out, forwarder)
 		}
 		out = append(out, resource)
 	}

--- a/internal/kuberesource/parts_test.go
+++ b/internal/kuberesource/parts_test.go
@@ -13,8 +13,8 @@ func TestNewPortForwarder(t *testing.T) {
 	require := require.New(t)
 
 	config := PortForwarder("coordinator", "default").
-		WithListenPort(1313).
-		WithForwardTarget("coordinator", 1313)
+		WithListenPorts([]int32{1313, 7777}).
+		WithForwardTarget("coordinator")
 
 	b, err := EncodeResources(config)
 	require.NoError(err)

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -92,7 +92,11 @@ type PodConfig struct {
 
 // Pod creates a new PodConfig.
 func Pod(name, namespace string) *PodConfig {
-	return &PodConfig{applycorev1.Pod(name, namespace)}
+	p := applycorev1.Pod(name, namespace)
+	if namespace == "" && p.ObjectMetaApplyConfiguration != nil {
+		p.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return &PodConfig{p}
 }
 
 // LabelSelectorConfig wraps applymetav1.LabelSelectorApplyConfiguration.


### PR DESCRIPTION
* Remove the unused port-forwarder for a single port.
* Patch out the namespace if empty. This is mostly to align with the other namespaced wrappers.
* Restrict to TCP ports when forwarding k8s services. The current socat script can't deal with UDP.
* Handle SIGTERM by forwarding to the background children. This speeds up pod termination because we don't need to wait for the SIGKILL anymore.