### PR TITLE
kata: enable blocking logs access

### DIFF
--- a/docs/docs/architecture/security-considerations.md
+++ b/docs/docs/architecture/security-considerations.md
@@ -57,10 +57,28 @@ Ideally, a volume is mounted as a raw block device and authenticated encryption 
 
 ### Logs
 
-By default, container logs are visible to the host.
-Sensitive information shouldn't be logged.
+By default, container logs are visible to the host to enable normal Kubernetes operations, for example debugging using `kubectl logs`.
+The application needs to ensure that sensitive information isn't logged.
 
-As of right now, hiding logs isn't natively supported.
-If `ReadStreamRequest` is denied in the policy, the Kata Agent stops reading the logs.
-This causes the pipes used for standard out and standard error to fill up and potentially deadlock the container.
-If absolutely required, standard out and standard error should be manually redirected to `/dev/null` inside the container.
+If logs access isn't required, it can be denied with a manual change to the policy settings.
+After the initial run of `contrast generate`, there will be a `settings.json` file in the working directory.
+Modify the default for `ReadStreamRequest` like shown in the diff below and run `contrast generate` again.
+
+<!-- TODO(burgerdev): this should reference a man page for advanced config -->
+
+```diff
+diff --git a/settings.json b/settings-no-logs.json
+index fd998a4..6760000 100644
+--- a/settings.json
++++ b/settings-no-logs.json
+@@ -330,7 +330,7 @@
+             "regex": []
+         },
+         "CloseStdinRequest": false,
+-        "ReadStreamRequest": true,
++        "ReadStreamRequest": false,
+         "UpdateEphemeralMountsRequest": false,
+         "WriteStreamRequest": false
+     }
+
+```

--- a/packages/by-name/kata/kata-runtime/0021-agent-clear-log-pipes-if-denied-by-policy.patch
+++ b/packages/by-name/kata/kata-runtime/0021-agent-clear-log-pipes-if-denied-by-policy.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Fri, 20 Dec 2024 08:42:38 +0100
+Subject: [PATCH] agent: clear log pipes if denied by policy
+
+Container logs are forwarded to the agent through a unix pipe. These
+pipes have limited capacity and block the writer when full. If reading
+logs is blocked by policy, a common setup for confidential containers,
+the pipes fill up and eventually block the container.
+
+This commit changes the implementation of ReadStream such that it
+returns empty log messages instead of a policy failure (in case reading
+log messages is forbidden by policy). As long as the runtime does not
+encounter a failure, it keeps pulling logs periodically. In turn, this
+triggers the agent to flush the pipes.
+
+Fixes: #10680
+---
+ src/agent/src/rpc.rs | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/src/agent/src/rpc.rs b/src/agent/src/rpc.rs
+index b3888633744a718586069314a192c9c0fd92459e..4714084d7912f18b3a4a788559ad91fc3723b30a 100644
+--- a/src/agent/src/rpc.rs
++++ b/src/agent/src/rpc.rs
+@@ -637,11 +637,11 @@ impl AgentService {
+ 
+     async fn do_read_stream(
+         &self,
+-        req: protocols::agent::ReadStreamRequest,
++        req: &protocols::agent::ReadStreamRequest,
+         stdout: bool,
+     ) -> Result<protocols::agent::ReadStreamResponse> {
+-        let cid = req.container_id;
+-        let eid = req.exec_id;
++        let cid = &req.container_id;
++        let eid = &req.exec_id;
+ 
+         let term_exit_notifier;
+         let reader = {
+@@ -857,8 +857,12 @@ impl agent_ttrpc::AgentService for AgentService {
+         _ctx: &TtrpcContext,
+         req: protocols::agent::ReadStreamRequest,
+     ) -> ttrpc::Result<ReadStreamResponse> {
+-        is_allowed(&req).await?;
+-        self.do_read_stream(req, true).await.map_ttrpc_err(same)
++        let mut response = self.do_read_stream(&req, true).await.map_ttrpc_err(same)?;
++        if !is_allowed(&req).await.is_ok() {
++            // Policy does not allow reading logs, so we redact the log messages.
++            response.clear_data();
++        }
++        Ok(response)
+     }
+ 
+     async fn read_stderr(
+@@ -866,8 +870,12 @@ impl agent_ttrpc::AgentService for AgentService {
+         _ctx: &TtrpcContext,
+         req: protocols::agent::ReadStreamRequest,
+     ) -> ttrpc::Result<ReadStreamResponse> {
+-        is_allowed(&req).await?;
+-        self.do_read_stream(req, false).await.map_ttrpc_err(same)
++        let mut response = self.do_read_stream(&req, false).await.map_ttrpc_err(same)?;
++        if !is_allowed(&req).await.is_ok() {
++            // Policy does not allow reading logs, so we redact the log messages.
++            response.clear_data();
++        }
++        Ok(response)
+     }
+ 
+     async fn close_stdin(

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -131,6 +131,13 @@ buildGoModule rec {
       # like `cdi.k8s.io/vfioXY`, where `XY` corresponds to a dynamic ID.
       # Upstream issue: https://github.com/kata-containers/kata-containers/issues/10745
       ./0020-genpolicy-support-dynamic-annotations.patch
+
+      # This allows denying ReadStream requests without blocking the container on its
+      # stdout/stderr, by redacting the streams instead of blocking them.
+      # Upstream:
+      # * https://github.com/kata-containers/kata-containers/issues/10680
+      # * https://github.com/kata-containers/kata-containers/pull/10818
+      ./0021-agent-clear-log-pipes-if-denied-by-policy.patch
     ];
   };
 

--- a/packages/by-name/microsoft/kata-runtime/0001-agent-clear-log-pipes-if-denied-by-policy.patch
+++ b/packages/by-name/microsoft/kata-runtime/0001-agent-clear-log-pipes-if-denied-by-policy.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Fri, 20 Dec 2024 08:42:38 +0100
+Subject: [PATCH] agent: clear log pipes if denied by policy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Container logs are forwarded to the agent through a unix pipe. These
+pipes have limited capacity and block the writer when full. If reading
+logs is blocked by policy, a common setup for confidential containers,
+the pipes fill up and eventually block the container.
+
+This commit changes the implementation of ReadStream such that it
+returns empty log messages instead of a policy failure (in case reading
+log messages is forbidden by policy). As long as the runtime does not
+encounter a failure, it keeps pulling logs periodically. In turn, this
+triggers the agent to flush the pipes.
+
+Fixes: #10680
+
+Co-Authored-By: Aurélien Bombo <abombo@microsoft.com>
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/agent/src/rpc.rs | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/src/agent/src/rpc.rs b/src/agent/src/rpc.rs
+index e19933882488c354623cde205c6933ac5c0b9005..cebb582c646aeb266529f0d4d69dbe86230eb16a 100644
+--- a/src/agent/src/rpc.rs
++++ b/src/agent/src/rpc.rs
+@@ -583,11 +583,11 @@ impl AgentService {
+ 
+     async fn do_read_stream(
+         &self,
+-        req: protocols::agent::ReadStreamRequest,
++        req: &protocols::agent::ReadStreamRequest,
+         stdout: bool,
+     ) -> Result<protocols::agent::ReadStreamResponse> {
+-        let cid = req.container_id;
+-        let eid = req.exec_id;
++        let cid = &req.container_id;
++        let eid = &req.exec_id;
+ 
+         let term_exit_notifier;
+         let reader = {
+@@ -802,8 +802,12 @@ impl agent_ttrpc::AgentService for AgentService {
+         _ctx: &TtrpcContext,
+         req: protocols::agent::ReadStreamRequest,
+     ) -> ttrpc::Result<ReadStreamResponse> {
+-        is_allowed(&req).await?;
+-        self.do_read_stream(req, true).await.map_ttrpc_err(same)
++        let mut response = self.do_read_stream(&req, true).await.map_ttrpc_err(same)?;
++        if !is_allowed(&req).await.is_ok() {
++            // Policy does not allow reading logs, so we redact the log messages.
++            response.clear_data();
++        }
++        Ok(response)
+     }
+ 
+     async fn read_stderr(
+@@ -811,8 +815,12 @@ impl agent_ttrpc::AgentService for AgentService {
+         _ctx: &TtrpcContext,
+         req: protocols::agent::ReadStreamRequest,
+     ) -> ttrpc::Result<ReadStreamResponse> {
+-        is_allowed(&req).await?;
+-        self.do_read_stream(req, false).await.map_ttrpc_err(same)
++        let mut response = self.do_read_stream(&req, false).await.map_ttrpc_err(same)?;
++        if !is_allowed(&req).await.is_ok() {
++            // Policy does not allow reading logs, so we redact the log messages.
++            response.clear_data();
++        }
++        Ok(response)
+     }
+ 
+     async fn close_stdin(

--- a/packages/by-name/microsoft/kata-runtime/package.nix
+++ b/packages/by-name/microsoft/kata-runtime/package.nix
@@ -6,17 +6,29 @@
   fetchFromGitHub,
   yq-go,
   git,
+  applyPatches,
 }:
 
 buildGoModule rec {
   pname = "kata-runtime";
   version = "3.2.0.azl2";
 
-  src = fetchFromGitHub {
-    owner = "microsoft";
-    repo = "kata-containers";
-    rev = version;
-    hash = "sha256-5dLWoVy2+RVq3ssGW7bYYAr3mQdO/ehJphpdJ435pC0=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "microsoft";
+      repo = "kata-containers";
+      rev = version;
+      hash = "sha256-5dLWoVy2+RVq3ssGW7bYYAr3mQdO/ehJphpdJ435pC0=";
+    };
+
+    patches = [
+      # This allows denying ReadStream requests without blocking the container on its
+      # stdout/stderr, by redacting the streams instead of blocking them.
+      # Upstream:
+      # * https://github.com/kata-containers/kata-containers/issues/10680
+      # * https://github.com/kata-containers/kata-containers/pull/10818
+      ./0001-agent-clear-log-pipes-if-denied-by-policy.patch
+    ];
   };
 
   sourceRoot = "${src.name}/src/runtime";


### PR DESCRIPTION
Access to logs can now be blocked by policy with an adjustment to the settings, see https://docs.edgeless.systems/contrast/architecture/security-considerations#logs.

Logs access is still allowed by default.