### PR TITLE
nodeinstaller: align default_memory and overhead to actual usage

### DIFF
--- a/e2e/regression/testdata/apache-httpd-centos.yml
+++ b/e2e/regression/testdata/apache-httpd-centos.yml
@@ -19,4 +19,9 @@ spec:
           ports:
             - containerPort: 8443
             - containerPort: 8080
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 100Mi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/apache-httpd-fedora.yml
+++ b/e2e/regression/testdata/apache-httpd-fedora.yml
@@ -19,4 +19,9 @@ spec:
           ports:
             - containerPort: 8443
             - containerPort: 8080
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 100Mi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/keycloak.yml
+++ b/e2e/regression/testdata/keycloak.yml
@@ -20,4 +20,9 @@ spec:
             - containerPort: 9000
             - containerPort: 8443
             - containerPort: 8080
+          resources:
+            limits:
+              memory: 1500Mi
+            requests:
+              memory: 1500Mi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/mongodb.yml
+++ b/e2e/regression/testdata/mongodb.yml
@@ -23,7 +23,7 @@ spec:
           # The memory limit is chosen to allow guest pull of the image (1.2G).
           resources:
             limits:
-              memory: 1500Mi
+              memory: 3000Mi
             requests:
-              memory: 1500Mi
+              memory: 3000Mi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/mysql-centos.yml
+++ b/e2e/regression/testdata/mysql-centos.yml
@@ -21,4 +21,9 @@ spec:
               value: admin
           ports:
             - containerPort: 3306
+          resources:
+            requests:
+              memory: 1Gi
+            limits:
+              memory: 1Gi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/mysql-fedora.yml
+++ b/e2e/regression/testdata/mysql-fedora.yml
@@ -21,4 +21,9 @@ spec:
               value: admin
           ports:
             - containerPort: 3306
+          resources:
+            requests:
+              memory: 1Gi
+            limits:
+              memory: 1Gi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/nginx.yml
+++ b/e2e/regression/testdata/nginx.yml
@@ -22,6 +22,11 @@ spec:
             - name: html
               mountPath: /usr/share/nginx/html
               readOnly: true
+          resources:
+            requests:
+              memory: 400Mi
+            limits:
+              memory: 400Mi
       volumes:
         - name: html
           configMap:

--- a/e2e/regression/testdata/prometheus.yml
+++ b/e2e/regression/testdata/prometheus.yml
@@ -20,4 +20,9 @@ spec:
             - containerPort: 9090
           securityContext:
             runAsUser: 65534
+          resources:
+            limits:
+              memory: 600Mi
+            requests:
+              memory: 600Mi
       runtimeClassName: contrast-cc

--- a/e2e/regression/testdata/redis.yml
+++ b/e2e/regression/testdata/redis.yml
@@ -18,4 +18,9 @@ spec:
           image: ghcr.io/edgelesssys/redis@sha256:ecb0a964c259a166a1eb62f0eb19621d42bd1cce0bc9bb0c71c828911d4ba93d
           ports:
             - containerPort: 6379
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 100Mi
       runtimeClassName: contrast-cc

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -739,7 +739,6 @@ func GPU() []any {
 			WithTemplate(PodTemplateSpec().
 				WithLabels(map[string]string{"app.kubernetes.io/name": "gpu-tester"}).
 				WithAnnotations(map[string]string{
-					"io.katacontainers.config.hypervisor.default_memory": "15258",
 					"cdi.k8s.io/gpu": "nvidia.com/pgpu=0",
 				}).
 				WithSpec(PodSpec().
@@ -752,6 +751,7 @@ func GPU() []any {
 								WithName("NVIDIA_VISIBLE_DEVICES").WithValue("all"),
 							).
 							WithResources(ResourceRequirements().
+								WithMemoryLimitAndRequest(500). // This accounts for nvidia-smi and the guest pull overhead.
 								WithLimits(corev1.ResourceList{
 									corev1.ResourceName("nvidia.com/GH100_H100_PCIE"): resource.MustParse("1"),
 								}),

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -95,3 +95,19 @@ func FromString(s string) (Platform, error) {
 		return Unknown, fmt.Errorf("unknown platform: %s", s)
 	}
 }
+
+// DefaultMemoryInMegaBytes returns the desired VM overhead for the given platform.
+func DefaultMemoryInMegaBytes(p Platform) int {
+	switch p {
+	case AKSCloudHypervisorSNP:
+		return 256
+	case K3sQEMUSNPGPU, MetalQEMUSNPGPU:
+		// Guest components contribute around 600MiB with GPU enabled.
+		return 1024
+	default:
+		// There are no additional guest components compared to AKS, but since the images are being
+		// pulled in the guest we leave a little bit of extra room to accommodate for our init
+		// containers.
+		return 512
+	}
+}

--- a/nodeinstaller/internal/constants/configuration-clh-snp.toml
+++ b/nodeinstaller/internal/constants/configuration-clh-snp.toml
@@ -14,7 +14,6 @@ valid_hypervisor_paths = ["/opt/edgeless/bin/cloud-hypervisor-snp"]
 kernel_params = ""
 default_vcpus = 1
 default_maxvcpus = 0
-default_memory = 256
 default_maxmemory = 0
 shared_fs = "none"
 virtio_fs_daemon = "/opt/confidential-containers/libexec/virtiofsd"
@@ -31,7 +30,7 @@ dial_timeout = 90
 [runtime]
 internetworking_model="tcfilter"
 disable_guest_seccomp=true
-sandbox_cgroup_only=false
+sandbox_cgroup_only=true
 static_sandbox_resource_mgmt=true
 static_sandbox_default_workload_mem=1792
 sandbox_bind_mounts=[]

--- a/nodeinstaller/internal/constants/configuration-qemu-snp.toml
+++ b/nodeinstaller/internal/constants/configuration-qemu-snp.toml
@@ -19,7 +19,6 @@ cpu_features="pmu=off"
 default_vcpus = 1
 default_maxvcpus = 0
 default_bridges = 1
-default_memory = 2048
 default_maxmemory = 0
 disable_block_device_use = false
 shared_fs = "none"
@@ -51,7 +50,7 @@ dial_timeout = 90
 [runtime]
 internetworking_model="tcfilter"
 disable_guest_seccomp=true
-sandbox_cgroup_only=false
+sandbox_cgroup_only=true
 static_sandbox_resource_mgmt=true
 sandbox_bind_mounts=[]
 vfio_mode="guest-kernel"

--- a/nodeinstaller/internal/constants/configuration-qemu-tdx.toml
+++ b/nodeinstaller/internal/constants/configuration-qemu-tdx.toml
@@ -18,10 +18,6 @@ cpu_features="-vmx-rdseed-exit,pmu=off"
 default_vcpus = 1
 default_maxvcpus = 0
 default_bridges = 1
-# On TDX, when lowering this, the patch:
-# packages/by-name/qemu-tdx-static/0004-hw-x86-load-initrd-to-static-address.patch
-# needs to be updated accordingly.
-default_memory = 2048
 default_maxmemory = 0
 disable_block_device_use = false
 shared_fs = "virtio-9p"
@@ -55,7 +51,7 @@ dial_timeout = 60
 enable_debug = false
 internetworking_model="tcfilter"
 disable_guest_seccomp=true
-sandbox_cgroup_only=false
+sandbox_cgroup_only=true
 static_sandbox_resource_mgmt=true
 sandbox_bind_mounts=[]
 vfio_mode="guest-kernel"

--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -55,6 +55,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		config.Hypervisor["clh"]["path"] = filepath.Join(baseDir, "bin", "cloud-hypervisor-snp")
 		config.Hypervisor["clh"]["igvm"] = filepath.Join(baseDir, "share", "kata-containers-igvm.img")
 		config.Hypervisor["clh"]["image"] = filepath.Join(baseDir, "share", "kata-containers.img")
+		config.Hypervisor["clh"]["default_memory"] = platforms.DefaultMemoryInMegaBytes(platform)
 		config.Hypervisor["clh"]["valid_hypervisor_paths"] = []string{filepath.Join(baseDir, "bin", "cloud-hypervisor-snp")}
 		config.Hypervisor["clh"]["enable_debug"] = debug
 	case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
@@ -64,6 +65,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		config.Hypervisor["qemu"]["path"] = filepath.Join(baseDir, "tdx", "bin", "qemu-system-x86_64")
 		config.Hypervisor["qemu"]["firmware"] = filepath.Join(baseDir, "tdx", "share", "OVMF.fd")
 		config.Hypervisor["qemu"]["image"] = filepath.Join(baseDir, "share", "kata-containers.img")
+		config.Hypervisor["qemu"]["default_memory"] = platforms.DefaultMemoryInMegaBytes(platform)
 		config.Hypervisor["qemu"]["valid_hypervisor_paths"] = []string{filepath.Join(baseDir, "tdx", "bin", "qemu-system-x86_64")}
 		config.Hypervisor["qemu"]["block_device_aio"] = "threads"
 		config.Hypervisor["qemu"]["shared_fs"] = "none"
@@ -83,6 +85,7 @@ func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKer
 		config.Hypervisor["qemu"]["path"] = filepath.Join(baseDir, "snp", "bin", "qemu-system-x86_64")
 		config.Hypervisor["qemu"]["firmware"] = filepath.Join(baseDir, "snp", "share", "OVMF.fd")
 		config.Hypervisor["qemu"]["image"] = filepath.Join(baseDir, "share", "kata-containers.img")
+		config.Hypervisor["qemu"]["default_memory"] = platforms.DefaultMemoryInMegaBytes(platform)
 		config.Hypervisor["qemu"]["block_device_aio"] = "threads"
 		config.Hypervisor["qemu"]["shared_fs"] = "none"
 		config.Hypervisor["qemu"]["valid_hypervisor_paths"] = []string{filepath.Join(baseDir, "snp", "bin", "qemu-system-x86_64")}

--- a/packages/by-name/qemu-tdx-static/0001-avoid-duplicate-definitions.patch
+++ b/packages/by-name/qemu-tdx-static/0001-avoid-duplicate-definitions.patch
@@ -1,7 +1,7 @@
-From cab2d6fee07bf935ae161975f5b6a5b7ce5d1c41 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Fri, 20 Sep 2024 16:01:15 +0200
-Subject: [PATCH 1/3] avoid duplicate definitions
+Subject: [PATCH] avoid duplicate definitions
 
 Another library already defines crc32c and this causes linker errors.
 Rename the function in QEMU to avoid conflicts.
@@ -23,7 +23,7 @@ Rename the function in QEMU to avoid conflicts.
  12 files changed, 17 insertions(+), 17 deletions(-)
 
 diff --git a/block/vhdx.c b/block/vhdx.c
-index 5aa1a135..52723d7c 100644
+index 5aa1a13506268c84f4a9a6cbf2dcdfae6a5d94b5..52723d7cc03af0e0283309a02f620073a4797216 100644
 --- a/block/vhdx.c
 +++ b/block/vhdx.c
 @@ -157,7 +157,7 @@ uint32_t vhdx_update_checksum(uint8_t *buf, size_t size, int crc_offset)
@@ -45,7 +45,7 @@ index 5aa1a135..52723d7c 100644
          memcpy(buf + crc_offset, &crc_orig, sizeof(crc_orig));
      }
 diff --git a/hw/net/net_rx_pkt.c b/hw/net/net_rx_pkt.c
-index 32e5f3f9..1cffe29d 100644
+index 32e5f3f9cf785c3f9daab340ac45a36c1a97d399..1cffe29d80ad5a0dea8f7b3a501878fc8ced5a6b 100644
 --- a/hw/net/net_rx_pkt.c
 +++ b/hw/net/net_rx_pkt.c
 @@ -579,7 +579,7 @@ _net_rx_pkt_validate_sctp_sum(struct NetRxPkt *pkt)
@@ -58,7 +58,7 @@ index 32e5f3f9..1cffe29d 100644
      calculated = iov_crc32c(calculated ^ 0xffffffff, vec + 1, vec_len - 1);
      valid = calculated == le32_to_cpu(original);
 diff --git a/include/qemu/crc32c.h b/include/qemu/crc32c.h
-index 88b4d2b3..52ba066c 100644
+index 88b4d2b3b3304803456f5b23ef42dbf530381ec5..52ba066c2e784b8ea3d88671f3d7944062a3660e 100644
 --- a/include/qemu/crc32c.h
 +++ b/include/qemu/crc32c.h
 @@ -29,7 +29,7 @@
@@ -71,7 +71,7 @@ index 88b4d2b3..52ba066c 100644
  
  #endif
 diff --git a/roms/u-boot/fs/btrfs/crypto/hash.c b/roms/u-boot/fs/btrfs/crypto/hash.c
-index fb51f638..4fb00afa 100644
+index fb51f6386cb16277d063a92d031458945c8ff303..4fb00afa2c9ae4c3ea78722feaca770b10ba2e23 100644
 --- a/roms/u-boot/fs/btrfs/crypto/hash.c
 +++ b/roms/u-boot/fs/btrfs/crypto/hash.c
 @@ -49,7 +49,7 @@ int hash_crc32c(const u8 *buf, size_t length, u8 *out)
@@ -84,7 +84,7 @@ index fb51f638..4fb00afa 100644
  	return crc32c_cal(seed, data, len, btrfs_crc32c_table);
  }
 diff --git a/roms/u-boot/fs/btrfs/crypto/hash.h b/roms/u-boot/fs/btrfs/crypto/hash.h
-index d1ba1fa3..223e1ee8 100644
+index d1ba1fa374e3ed4eab3e315f01003213c26c7b2f..223e1ee8fd48d5bfdc51a18e103f12dc4dcd258c 100644
 --- a/roms/u-boot/fs/btrfs/crypto/hash.h
 +++ b/roms/u-boot/fs/btrfs/crypto/hash.h
 @@ -10,7 +10,7 @@ int hash_crc32c(const u8 *buf, size_t length, u8 *out);
@@ -97,7 +97,7 @@ index d1ba1fa3..223e1ee8 100644
  /* Blake2B is not yet supported due to lack of library */
  
 diff --git a/roms/u-boot/fs/btrfs/ctree.h b/roms/u-boot/fs/btrfs/ctree.h
-index 219c410b..5a7e30a1 100644
+index 219c410b189fbbdcdf744137ebfe7046f419770d..5a7e30a1eef85fa220d6d4fff726acfb53d50e23 100644
 --- a/roms/u-boot/fs/btrfs/ctree.h
 +++ b/roms/u-boot/fs/btrfs/ctree.h
 @@ -1186,7 +1186,7 @@ static inline int __btrfs_fs_compat_ro(struct btrfs_fs_info *fs_info, u64 flag)
@@ -110,7 +110,7 @@ index 219c410b..5a7e30a1 100644
  
  /*
 diff --git a/target/arm/helper.c b/target/arm/helper.c
-index df1646de..39d79849 100644
+index df1646de3ae8b6d46604fe069a1fddb3b3b85112..39d7984906d9b3da2a8870b7dd02ce878470939f 100644
 --- a/target/arm/helper.c
 +++ b/target/arm/helper.c
 @@ -11932,14 +11932,14 @@ uint32_t HELPER(crc32)(uint32_t acc, uint32_t val, uint32_t bytes)
@@ -132,7 +132,7 @@ index df1646de..39d79849 100644
  
  /*
 diff --git a/target/arm/helper.h b/target/arm/helper.h
-index 2b027333..25bb12f6 100644
+index 2b0273330531afcd6472f2cd3b4d546002c80488..25bb12f60044e819c9d02d570e0da9bce7ddec30 100644
 --- a/target/arm/helper.h
 +++ b/target/arm/helper.h
 @@ -591,7 +591,7 @@ DEF_HELPER_FLAGS_4(crypto_sm4ekey, TCG_CALL_NO_RWG, void, ptr, ptr, ptr, i32)
@@ -145,7 +145,7 @@ index 2b027333..25bb12f6 100644
  DEF_HELPER_FLAGS_5(gvec_qrdmlah_s16, TCG_CALL_NO_RWG,
                     void, ptr, ptr, ptr, ptr, i32)
 diff --git a/target/arm/tcg/helper-a64.c b/target/arm/tcg/helper-a64.c
-index 8ad84623..b319ad45 100644
+index 8ad84623d37d93a3d56c3f42e770be342b705ff0..b319ad45c21d9db844bd395d32f0d9cca87b7550 100644
 --- a/target/arm/tcg/helper-a64.c
 +++ b/target/arm/tcg/helper-a64.c
 @@ -501,8 +501,8 @@ uint64_t HELPER(crc32c_64)(uint64_t acc, uint64_t val, uint32_t bytes)
@@ -160,7 +160,7 @@ index 8ad84623..b319ad45 100644
  
  /*
 diff --git a/target/loongarch/helper.h b/target/loongarch/helper.h
-index b3b64a02..7416aa00 100644
+index b3b64a021536255a3f9decfc10ff61fe8380e2ae..7416aa00f869edcbff256e0f0404da7308e998d2 100644
 --- a/target/loongarch/helper.h
 +++ b/target/loongarch/helper.h
 @@ -13,7 +13,7 @@ DEF_HELPER_FLAGS_3(asrtle_d, TCG_CALL_NO_WG, void, env, tl, tl)
@@ -173,7 +173,7 @@ index b3b64a02..7416aa00 100644
  
  /* Floating-point helper */
 diff --git a/target/loongarch/op_helper.c b/target/loongarch/op_helper.c
-index fe79c62f..41133336 100644
+index fe79c62fa472bf23b48ca8c1c3eb6b926b7434b4..41133336c0f498705b5ac7a202cdb2c1c64959b4 100644
 --- a/target/loongarch/op_helper.c
 +++ b/target/loongarch/op_helper.c
 @@ -77,7 +77,7 @@ target_ulong helper_crc32c(target_ulong val, target_ulong m, uint64_t sz)
@@ -186,7 +186,7 @@ index fe79c62f..41133336 100644
  
  target_ulong helper_cpucfg(CPULoongArchState *env, target_ulong rj)
 diff --git a/util/crc32c.c b/util/crc32c.c
-index ea7f345d..d6b5fab1 100644
+index ea7f345de86073998250f54a5a19aef0a5bf164f..d6b5fab1379641d88f230448e71c24e8396020bb 100644
 --- a/util/crc32c.c
 +++ b/util/crc32c.c
 @@ -105,7 +105,7 @@ static const uint32_t crc32c_table[256] = {
@@ -207,6 +207,3 @@ index ea7f345d..d6b5fab1 100644
          iov++;
      }
      return crc ^ 0xffffffff;
--- 
-2.46.0
-

--- a/packages/by-name/qemu-tdx-static/0002-add-options-for-library-paths.patch
+++ b/packages/by-name/qemu-tdx-static/0002-add-options-for-library-paths.patch
@@ -1,7 +1,7 @@
-From 0a2595335f47457ed21bf16762d3f38473a5a5fa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Fri, 20 Sep 2024 16:01:46 +0200
-Subject: [PATCH 2/3] add options for library paths
+Subject: [PATCH] add options for library paths
 
 For some reason meson fails to find these when building with pkgsStatic
 in Nix.
@@ -11,7 +11,7 @@ in Nix.
  2 files changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 89b42b21..a6cc8535 100644
+index 89b42b217d39f72e0596fbdf7c8947d211111881..a6cc85350223ba33ae0313de2404e728fd6a46a6 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -832,7 +832,8 @@ zlib = dependency('zlib', required: true)
@@ -35,7 +35,7 @@ index 89b42b21..a6cc8535 100644
         #include <libfdt.h>
         #include <libfdt_env.h>
 diff --git a/meson_options.txt b/meson_options.txt
-index c9baeda6..74345605 100644
+index c9baeda6395634c3478a3c2a3a8c8f57fbe0b592..74345605ca625ec0413fe3c1784a35bdd841397a 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -188,6 +188,7 @@ option('linux_aio', type : 'feature', value : 'auto',
@@ -54,6 +54,3 @@ index c9baeda6..74345605 100644
  
  option('selinux', type: 'feature', value: 'auto',
         description: 'SELinux support in qemu-nbd')
--- 
-2.46.0
-

--- a/packages/by-name/qemu-tdx-static/0003-i386-omit-some-unneeded-ACPI-tables.patch
+++ b/packages/by-name/qemu-tdx-static/0003-i386-omit-some-unneeded-ACPI-tables.patch
@@ -1,7 +1,7 @@
-From 56e5c0d828fd1503da5969ad12e681d8b66245f5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tom Dohrmann <erbse.13@gmx.de>
 Date: Mon, 23 Sep 2024 09:26:32 +0200
-Subject: [PATCH 3/3] i386: omit some unneeded ACPI tables
+Subject: [PATCH] i386: omit some unneeded ACPI tables
 
 This makes the generated ACPI code more deterministic and less dependent on the
 guest configuration (e.g. the amount of assigned memory).
@@ -10,7 +10,7 @@ guest configuration (e.g. the amount of assigned memory).
  1 file changed, 6 insertions(+)
 
 diff --git a/hw/i386/acpi-build.c b/hw/i386/acpi-build.c
-index f401cb5c..e70e8f65 100644
+index f401cb5c277c2e064989700b8351ac300c5a9779..e70e8f65a6f759e76be9973abade81bcf3fcb98e 100644
 --- a/hw/i386/acpi-build.c
 +++ b/hw/i386/acpi-build.c
 @@ -1669,6 +1669,8 @@ build_dsdt(GArray *table_data, BIOSLinker *linker,
@@ -47,6 +47,3 @@ index f401cb5c..e70e8f65 100644
      if (acpi_get_mcfg(&mcfg)) {
          acpi_add_table(table_offsets, tables_blob);
          build_mcfg(tables_blob, tables->linker, &mcfg, x86ms->oem_id,
--- 
-2.46.0
-

--- a/packages/by-name/qemu-tdx-static/0004-hw-x86-load-initrd-to-static-address.patch
+++ b/packages/by-name/qemu-tdx-static/0004-hw-x86-load-initrd-to-static-address.patch
@@ -12,76 +12,24 @@ which depend not only on the size of the initrd, but also on the memory space
 of the guest, this is not viable for Contrast's reference-value-based attestation
 approach.
 
-As we control the minimum VM memory size in Contrast, we just load the initrd
-to the address it gets loaded to for Contrast's minimum VM memory (2Gi), regardless
-of if the VM has more memory.
-
-QEMU, by default, does a similar thing.
-Consider the below line (cited from above):
-
-   `initrd_max = x86ms->below_4g_mem_size - acpi_data_size - 1;`
-
-This adds an artifical upper bound of where the initrd can be loaded to, as
-the calculation is based on the VM memory (below_4g_mem_size), but capped at 4Gi.
-This means, the initrd, regardless of guest memory size, will always be loaded
-at address 0x100000000 (4Gi) max (minus ACPI data size).
-
-Essentially, overwriting this to 0x80000000 (2Gi), we create an artificial lower *and*
-upper bound (set to Contrast minimum TDX VM memory size).
-This means that the initrd will *always* be loaded at 0x80000000 (2Gi), minus ACPI
-data size. The difference to QEMU's setting is, that we *fix* the address, rather than
-setting *only* an upper bound.
-
-This way, we get the initrd to *always* be loaded at a static address.
+The actual value of the static address does not matter, since OVMF fills the
+corresponding Linux header field with the correct address after measuring the
+kernel.
 
 Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
 ---
- hw/i386/x86.c | 35 +++++++++++++++++++++++++++++++++++
- 1 file changed, 35 insertions(+)
+ hw/i386/x86.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/hw/i386/x86.c b/hw/i386/x86.c
-index 504575abfa98bc25e498e219a2d58d8d31e5feaa..0763462c16f4106d0aa6a46c2b9c360e36ae3e96 100644
+index 504575abfa98bc25e498e219a2d58d8d31e5feaa..ec109d0d24256b11ea0f5ad2e4ea57d69aebc915 100644
 --- a/hw/i386/x86.c
 +++ b/hw/i386/x86.c
-@@ -953,6 +953,41 @@ void x86_load_linux(X86MachineState *x86ms,
-         initrd_max = x86ms->below_4g_mem_size - acpi_data_size - 1;
+@@ -1042,7 +1042,7 @@ void x86_load_linux(X86MachineState *x86ms,
+         sev_load_ctx.initrd_data = initrd_data;
+         sev_load_ctx.initrd_size = initrd_size;
+
+-        stl_p(header + 0x218, initrd_addr);
++        stl_p(header + 0x218, 0x80000000); // Placeholder, will be overwritten by OVMF.
+         stl_p(header + 0x21c, initrd_size);
      }
- 
-+    /*
-+     * For TDX RTMRs to be predictable regardless of VM memory size, we need to
-+     * load the initrd to a static address, so no dynamic value ends up in the
-+     * mapped kernel image.
-+     *
-+     * Without setting this to a static address, the address the initrd is mapped to
-+     * which depend not only on the size of the initrd, but also on the memory space
-+     * of the guest, this is not viable for Contrast's reference-value-based attestation
-+     * approach.
-+     *
-+     * As we control the minimum VM memory size in Contrast, we just load the initrd
-+     * to the address it gets loaded to for Contrast's minimum VM memory (2Gi), regardless
-+     * of if the VM has more memory.
-+     *
-+     * QEMU, by default, does a similar thing.
-+     * Consider the below line (cited from above):
-+     *
-+     *    initrd_max = x86ms->below_4g_mem_size - acpi_data_size - 1;
-+     *
-+     * This adds an artifical upper bound of where the initrd can be loaded to, as
-+     * the calculation is based on the VM memory (below_4g_mem_size), but capped at 4Gi.
-+     * This means, the initrd, regardless of guest memory size, will always be loaded
-+     * at address 0x100000000 (4Gi) max (minus ACPI data size).
-+     *
-+     * Essentially, overwriting this to 0x80000000 (2Gi), we create an artificial lower *and*
-+     * upper bound (set to Contrast minimum TDX VM memory size).
-+     * This means that the initrd will *always* be loaded at 0x80000000 (2Gi), minus ACPI
-+     * data size. The difference to QEMU's setting is, that we *fix* the address, rather than
-+     * setting *only* an upper bound.
-+     *
-+     * This way, we get the initrd to *always* be loaded at a static address.
-+     */
-+    uint32_t contrast_min_memory = 0x80000000; // 2Gi
-+    initrd_max = contrast_min_memory - acpi_data_size - 1;
-+
-     fw_cfg_add_i32(fw_cfg, FW_CFG_CMDLINE_ADDR, cmdline_addr);
-     fw_cfg_add_i32(fw_cfg, FW_CFG_CMDLINE_SIZE, strlen(kernel_cmdline) + 1);
-     fw_cfg_add_string(fw_cfg, FW_CFG_CMDLINE_DATA, kernel_cmdline);

--- a/packages/by-name/qemu-tdx-static/package.nix
+++ b/packages/by-name/qemu-tdx-static/package.nix
@@ -62,6 +62,17 @@ in
       # fixed hash for attestation.
       ./0003-i386-omit-some-unneeded-ACPI-tables.patch
       # Load the initrd to a static address to make RTMRs predictable.
+      # Both qemu and OVMF patch the linux kernel header with an initrd
+      # address that depends on VM size. The patch by qemu is redundant, but
+      # ends up being measured into the RTMR by OVMF. Therefore, we replace it
+      # with a static value and apply the same value when calculating the
+      # RTMRs.
+      #
+      # References:
+      # - https://github.com/tianocore/edk2/blob/523dbb6d597b63181bba85a337d1f53e511f4822/OvmfPkg/Library/LoadLinuxLib/Linux.c#L414
+      #   is where OVMF overwrites the initrd address.
+      # - https://www.qemu.org/docs/master/specs/fw_cfg.html is how OVMF learns
+      #   about the initrd address.
       ./0004-hw-x86-load-initrd-to-static-address.patch
     ];
   })

--- a/tools/tdx-measure/rtmr/rtmr.go
+++ b/tools/tdx-measure/rtmr/rtmr.go
@@ -316,13 +316,12 @@ func patchKernel(kernelFile, initrdFile []byte) {
 	kernelFile[0x22B] = 0x00
 
 	// https://github.com/qemu/qemu/blob/f48c205fb42be48e2e47b7e1cd9a2802e5ca17b0/hw/i386/x86.c#L1036
-	// Maximum size of the initrd as calculated by QEMU. Normally, this would be dependent on the VM
-	// memory size, but we have a QEMU patch that removes that fixes this to make RTMR1 reproducible.
-	// Our QEMU patch has a commented-out line to print this value upon start, so it's easy to find
-	// when updating QEMU, as the value might change on QEMU updates.
-	initrdMax := 0x7ffd7fff
+	// Qemu patches the initrd address into the kernel header. This is unnecessary because OVMF
+	// will take the initrd address from fw_cfg and patch it again after measuring the kernel. In
+	// order to have predictable kernel measurements, we patch qemu to set this placeholder instead
+	// of a real address.
+	initrdAddr := 0x80000000
 	initrdSize := len(initrdFile)
-	initrdAddr := (initrdMax - initrdSize) & ^4095
 
 	// https://github.com/qemu/qemu/blob/f48c205fb42be48e2e47b7e1cd9a2802e5ca17b0/hw/i386/x86.c#L1044
 	binary.LittleEndian.PutUint32(kernelFile[0x218:][:4], uint32(initrdAddr))


### PR DESCRIPTION
This PR corrects the calculation of the `RuntimeClass` overhead.

First, a bit of background on Kubernetes resource accounting. The total memory footprint of a pod is the sum of the individual container requests/limits and the overhead from the PodSpec or the overhead from the RuntimeClass. This total is accounted towards the node memory commitment, so we should aim to get it right in order to avoid overcommitting and idle resources. 

Ignoring the pod memory requests for now, we have three sources that add to the total memory used by a pod:

* Size of the VM, which is the sum of
  * the Kata runtime setting `default_memory`
  * the individual container limits
* VM-related processes on the host (i.e. Kata shim, qemu/CLH)

This implies immediately that the **RuntimeClass overhead is the sum of `default_memory` and the host overhead**. 

Empirically (see below), we observe that not all memory allotted to a VM is actually usable by the containers, because there are daemons running in the VM and the Linux kernel reserves some memory for itself. This guest overhead needs to be accounted for in the `default_memory` setting. It follows that **`default_memory` needs to be (at least) the sum of the memory used by daemons and the memory that is not available to userland**.

Rounding up the numbers and optimizing for <2GiB containers, we arrive at <56MiB for daemons, <200MiB for kernel and <50MiB for host overhead. Thus:

* `default_memory = 256Mi`
* `overhead = 320Mi`

In order to properly account for the resources in k8s, we need to configure Kata to use the pod cgroups. This is accomplished by setting `sandbox_cgroup_only = true`. The concepts are explained in more detail at https://github.com/kata-containers/kata-containers/blob/f9bbe4e4396cde04ce8162aead1d12b4f3e7bc96/docs/design/host-cgroups.md. 

---

### Memory usage and overhead survey 

I launched pods with varying memory limits and recorded the overhead both inside and outside the VM. Most notable findings:

* The footprint of guest components unrelated to the workload (`free -m used`) grows a little bit with the VM, but still fits into 70MiB even for large workloads.
* The portion of the VM unavailable to the workload (`Overhead VM`) scales linearily with VM size.
* The overhead outside the VM (`Overhead host`) is constant and on the order of 50MiB worst case.

#### AKS-CLH-SNP

|default_memory [MiB] |Container limit [MiB]|Theoretical VM mem [MiB]|free -m total [MiB]|free -m used [MiB]|cgroup memory.current [B]|Overhead VM [MiB]|Overhead host [MiB]|
|--------------|---------------|--------------------------|-------------|------------|------------|-----------|-------------|
|256           |50             |306                       |197          |27          |335077376   |109        |14           |
|256           |150            |406                       |295          |26          |432263168   |111        |6            |
|256           |500            |756                       |640          |30          |801509376   |116        |8            |
|256           |1024           |1280                      |1090         |32          |1353519104  |190        |11           |
|256           |2048           |2304                      |1965         |31          |2431700992  |339        |15           |
|256           |4096           |4352                      |3716         |47          |4587950080  |636        |23           |

#### K3s-QEMU-TDX

|default_memory [MiB] |Container limit [MiB]|Theoretical VM mem [MiB]|free -m total [MiB]|free -m used [MiB]|cgroup memory.current [B]|Overhead VM [MiB]|Overhead host [MiB]|
|--------------|---------------|--------------------------|-------------|------------|------------|-----------|-------------|
|256           |50             |306                       |207          |49          |355393536   |99         |33           |
|256           |150            |406                       |305          |49          |466104320   |101        |39           |
|256           |500            |756                       |650          |52          |841797632   |106        |47           |
|256           |1024           |1280                      |1100         |53          |1387155456  |180        |43           |
|256           |2048           |2304                      |1976         |62          |2462515200  |328        |44           |
|256           |4096           |4352                      |3727         |74          |?           |625        |?     |