### PR TITLE
transitengineapi: add http handler enc/dec

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -165,6 +165,18 @@ func (m *Authority) walkTransitions(transitionRef [history.HashSize]byte, consum
 	return nil
 }
 
+// GetState syncs the current state and returns the loaded current state.
+func (m *Authority) GetState() (*State, error) {
+	if err := m.syncState(); err != nil {
+		return nil, fmt.Errorf("syncing state: %w", err)
+	}
+	state := m.state.Load()
+	if state == nil {
+		return nil, errors.New("coordinator is not initialized")
+	}
+	return state, nil
+}
+
 // State is a snapshot of the Coordinator's manifest history.
 type State struct {
 	SeedEngine *seedengine.SeedEngine

--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -47,17 +47,8 @@ func (a *Authority) Credentials(reg *prometheus.Registry, issuer atls.Issuer) (*
 	})
 
 	return &Credentials{
-		issuer: issuer,
-		getState: func() (*State, error) {
-			if err := a.syncState(); err != nil {
-				return nil, fmt.Errorf("syncing state: %w", err)
-			}
-			state := a.state.Load()
-			if state == nil {
-				return nil, errors.New("coordinator is not initialized")
-			}
-			return state, nil
-		},
+		issuer:                     issuer,
+		getState:                   a.GetState,
 		logger:                     a.logger,
 		attestationFailuresCounter: attestationFailuresCounter,
 		kdsGetter:                  kdsGetter,

--- a/coordinator/internal/transitengineapi/crypto.go
+++ b/coordinator/internal/transitengineapi/crypto.go
@@ -1,0 +1,97 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package transitengine
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/edgelesssys/contrast/internal/crypto"
+)
+
+// ciphertextContainer describes a base64-encoded ciphertext prepended with the nonce and specified key version.
+type ciphertextContainer struct {
+	nonce      []byte
+	ciphertext []byte
+	keyVersion uint32
+}
+
+// symmetricEncryptRaw returns a ciphertextContainer, based on the encryption key and associatedData handed in.
+func symmetricEncryptRaw(encKey, plaintext []byte, associatedData []byte) (ciphertextContainer, error) {
+	aesCipher, err := aes.NewCipher(encKey)
+	if err != nil {
+		return ciphertextContainer{}, err
+	}
+	gcm, err := cipher.NewGCM(aesCipher)
+	if err != nil {
+		return ciphertextContainer{}, err
+	}
+	nonce, err := crypto.GenerateRandomBytes(gcm.NonceSize())
+	if err != nil {
+		return ciphertextContainer{}, err
+	}
+	ciphertext := gcm.Seal(nil, nonce, plaintext, associatedData)
+	return ciphertextContainer{
+		nonce:      nonce,
+		ciphertext: ciphertext,
+	}, nil
+}
+
+// symmetricDecryptRaw extracts the nonce and returns the decrypted ciphertext based on encryption keys handed in,
+// if the associatedData is valid.
+func symmetricDecryptRaw(decKey []byte, ciphertextContainer ciphertextContainer, associatedData []byte) ([]byte, error) {
+	aesCipher, err := aes.NewCipher(decKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(aesCipher)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := gcm.Open(nil, ciphertextContainer.nonce, ciphertextContainer.ciphertext, associatedData)
+	if err != nil {
+		return nil, err
+	}
+	return plaintext, nil
+}
+
+// UnmarshalJSON umarshalls a json string to a ciphertextContainer holding the version prefix,
+// decoded base64 nonce and ciphertext.
+func (c *ciphertextContainer) UnmarshalJSON(data []byte) error {
+	var encoded string
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		return err
+	}
+	// Split "vault:vX:base64" format
+	parts := strings.SplitN(encoded, ":", 3)
+	if len(parts) < 3 {
+		return fmt.Errorf("invalid ciphertext format")
+	}
+	version, err := extractVersion(parts[1])
+	if err != nil {
+		return fmt.Errorf("ciphertext version: %w", err)
+	}
+	c.keyVersion = version
+	fullCiphertext, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return fmt.Errorf("decoding ciphertext: %w", err)
+	}
+	c.nonce = fullCiphertext[:aesGCMNonceSize]
+	c.ciphertext = fullCiphertext[aesGCMNonceSize:]
+	return nil
+}
+
+// MarshalJSON marshalls a ciphertextContainer to a json string.
+func (c ciphertextContainer) MarshalJSON() ([]byte, error) {
+	fullCiphertext := append(c.nonce, c.ciphertext...)
+	encodedfullCiphertext := base64.StdEncoding.EncodeToString(fullCiphertext)
+	// Convert to "vault:vX:base64" format
+	versioned := fmt.Sprintf("vault:v%d:%s", c.keyVersion, encodedfullCiphertext)
+	return json.Marshal(versioned)
+}

--- a/coordinator/internal/transitengineapi/crypto_test.go
+++ b/coordinator/internal/transitengineapi/crypto_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package transitengine
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCryptoCyclic(t *testing.T) {
+	testCases := map[string]struct {
+		key            string
+		plaintext      string
+		associatedData string
+	}{
+		"plaintext 1": {
+			key:            "H0ltoqZhwB/h1/HqIPWr5rC9Xt/sGkJ3UDU10vYplGw=",
+			plaintext:      "rWk4fnCShUgfxjMShRHS5Q==",
+			associatedData: "VKpPXX5vwsZUPdFTQOTIdg==",
+		},
+		"plaintext 2": {
+			key:            "RV30FnNmnE2b8hUAL4P89tsqF/346nODNTXdYMrOuA0=",
+			plaintext:      "ZSZ/iGeN22qnQrvkogjvVnZG/3zhCboO/DC8Gl/GAFBRXYMh4112FA==",
+			associatedData: "c0JDPPZH0yrHVrl+x8e9JE0wgxrjCBk9Z2Vpi72+Fvy2wUMVPZ2i/A==",
+		},
+		"plaintext 3": {
+			key:            "vMYJT/IsiWCOX5/8cAcP7eEM7G4ZRwMNQtauHORAXY4=",
+			plaintext:      "X3pjwqhM4wMM/OFTpbZsOECwtZ4TZs0ZCptD/kg=",
+			associatedData: "f6kf/DPKlb4ig6JJ7Ls0a+EupP3QSrmkj/bTkIuaW6tm+7z2Ugd4cg==",
+		},
+		"plaintext 4": {
+			key:            "BlWwHNYdKgELBFXuS1BIkccaRY6DHPRmIHWAr6gje+Q=",
+			plaintext:      "XXjgvMHQ3CASYjqHhq1i5rplfNHS",
+			associatedData: "23HOhX2Pqm7qWwa8X/lSIQKRQ+s=",
+		},
+	}
+
+	t.Run("cyclic crypto test", func(t *testing.T) {
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				var ciphertextContainer ciphertextContainer
+				var recPlaintextBytes []byte
+
+				keyBytes, err := base64.StdEncoding.DecodeString(tc.key)
+				require.NoError(t, err)
+				plaintextBytes, err := base64.StdEncoding.DecodeString(tc.plaintext)
+				require.NoError(t, err)
+				associatedDataBytes, err := base64.StdEncoding.DecodeString(tc.associatedData)
+				require.NoError(t, err)
+				t.Run("encrypt", func(t *testing.T) {
+					require := require.New(t)
+					var err error
+					ciphertextContainer, err = symmetricEncryptRaw(keyBytes, plaintextBytes, associatedDataBytes)
+					require.NoError(err, "encryption")
+				})
+
+				t.Run("decrypt", func(t *testing.T) {
+					require := require.New(t)
+					var err error
+					recPlaintextBytes, err = symmetricDecryptRaw(keyBytes, ciphertextContainer, associatedDataBytes)
+					require.NoError(err, "decryption")
+				})
+				require.Equal(t, plaintextBytes, recPlaintextBytes)
+			})
+		}
+	})
+}

--- a/coordinator/internal/transitengineapi/transitengineapi.go
+++ b/coordinator/internal/transitengineapi/transitengineapi.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// transitengine provides all functionality related to the transit engine API endpoints: decrypt and encrypt.
+// It is organized in a layered approach, keeping http request processing separated from the underlying crypto
+// business logic(crypto.go).
+package transitengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+)
+
+const (
+	// aesGCMNonceSize specifies the default nonce size in bytes used in AES GCM, used during parsing of ciphertextContainer.
+	aesGCMNonceSize = 12
+	// aesGCMKeySize specifies the default key size in bytes to use AES-256 GCM.
+	aesGCMKeySize = 32
+)
+
+type (
+	// encryptionRequest holds the request-specific plaintext and currently supported, optional query parameters: associatedData and keyVersion.
+	encryptionRequest struct {
+		Plaintext      []byte `json:"plaintext"`
+		KeyVersion     uint32 `json:"key_version"`
+		AssociatedData []byte `json:"associated_data,omitempty"`
+	}
+	// decryptionRequest holds the request-specific ciphertextContainer and currently supported, optional query parameters: associatedData.
+	decryptionRequest struct {
+		CiphertextContainer ciphertextContainer `json:"ciphertext"`
+		AssociatedData      []byte              `json:"associated_data,omitempty"`
+	}
+	// encryptionResponse holds the response-specific ciphertextContainer.
+	encryptionResponse struct {
+		Ciphertext ciphertextContainer `json:"ciphertext"`
+	}
+	// decryptionResponse holds the response-specific plaintext.
+	decryptionResponse struct {
+		Plaintext []byte `json:"plaintext"`
+	}
+)
+
+type stateAuthority interface {
+	GetState() (*authority.State, error)
+}
+
+// NewTransitEngineAPI sets up the transit engine API with a provided seedEngineAuthority.
+func NewTransitEngineAPI(authority stateAuthority, _ *slog.Logger) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// 'name' wildcard is kept to reflect existing transit engine API specifications:
+	// https://openbao.org/api-docs/secret/transit/#encrypt-data
+	// name <=> workloadSecretID, which should be used for the key derivation.
+	mux.Handle("/v1/transit/encrypt/{name}", getEncryptHandler(authority))
+	mux.Handle("/v1/transit/decrypt/{name}", getDecryptHandler(authority))
+
+	return mux
+}
+
+func getEncryptHandler(authority stateAuthority) http.HandlerFunc {
+	// TODO(jmxnzo): Implement Vault json error bodies
+	return func(w http.ResponseWriter, r *http.Request) {
+		workloadSecretID := r.PathValue("name")
+		if workloadSecretID == "" {
+			http.Error(w, "Invalid URL format", http.StatusBadRequest)
+			return
+		}
+		var encReq encryptionRequest
+		if err := parseRequest(r, &encReq); err != nil {
+			http.Error(w, fmt.Sprintf("parsing encryption request: %v", err), http.StatusBadRequest)
+			return
+		}
+		key, err := deriveEncryptionKey(authority, fmt.Sprintf("%d_%s", encReq.KeyVersion, workloadSecretID))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("key derivation: %v", err), http.StatusInternalServerError)
+			return
+		}
+		ciphertextContainer, err := symmetricEncryptRaw(key, encReq.Plaintext, encReq.AssociatedData)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("encrypting: %v", err), http.StatusInternalServerError)
+			return
+		}
+		ciphertextContainer.keyVersion = encReq.KeyVersion
+		var encResp encryptionResponse
+		encResp.Ciphertext = ciphertextContainer
+		if err = writeJSONResponse(w, encResp); err != nil {
+			http.Error(w, fmt.Sprintf("writing response: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func getDecryptHandler(authority stateAuthority) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workloadSecretID := r.PathValue("name")
+		if workloadSecretID == "" {
+			http.Error(w, "Invalid URL format", http.StatusBadRequest)
+			return
+		}
+		var decReq decryptionRequest
+		if err := parseRequest(r, &decReq); err != nil {
+			http.Error(w, fmt.Sprintf("parsing decryption request: %v", err), http.StatusBadRequest)
+			return
+		}
+		key, err := deriveEncryptionKey(authority, fmt.Sprintf("%d_%s", decReq.CiphertextContainer.keyVersion, workloadSecretID))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("key derivation: %v", err), http.StatusInternalServerError)
+			return
+		}
+		plaintext, err := symmetricDecryptRaw(key, decReq.CiphertextContainer, decReq.AssociatedData)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("decrypting: %v", err), http.StatusInternalServerError)
+			return
+		}
+		var decResp decryptionResponse
+		decResp.Plaintext = plaintext
+		if err = writeJSONResponse(w, decResp); err != nil {
+			http.Error(w, fmt.Sprintf("writing response: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+// deriveEncryptionKey derives the workload secret used as the encryption key by receiving the seedengine of the current state.
+func deriveEncryptionKey(authority stateAuthority, workloadSecretID string) ([]byte, error) {
+	state, err := authority.GetState()
+	if err != nil {
+		return nil, err
+	}
+	// TODO(jmxnzo): authentication of client certs <-> parsed workloadSecretID.
+	derivedWorkloadSecret, err := state.SeedEngine.DeriveWorkloadSecret(workloadSecretID)
+	if err != nil {
+		return nil, err
+	}
+	if len(derivedWorkloadSecret) < aesGCMKeySize {
+		return nil, fmt.Errorf("derived key too small, expected key length: %d", aesGCMKeySize)
+	}
+	return derivedWorkloadSecret[:aesGCMKeySize], nil
+}
+
+// writeJSONResponse wraps any payload inside a "data" object and sends it as an HTTP response.
+func writeJSONResponse(w http.ResponseWriter, payload any) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	response := map[string]any{
+		"data": payload,
+	}
+	return json.NewEncoder(w).Encode(response)
+}
+
+// parseRequest parses the given HTTP request body into the struct.
+func parseRequest(r *http.Request, into any) error {
+	defer r.Body.Close()
+	if err := validateContentType(r); err != nil {
+		return err
+	}
+	if err := json.NewDecoder(r.Body).Decode(into); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateContentType ensures that if Content-Type is present, it is set to application/json.
+func validateContentType(r *http.Request) error {
+	if contentType := r.Header.Get("Content-Type"); contentType != "" {
+		if !strings.HasPrefix(contentType, "application/json") {
+			return fmt.Errorf("invalid content-type: %s (want application/json)", contentType)
+		}
+	}
+	return nil
+}
+
+// extractVersion is a helper function checking the version string format 'vX' and extracting the corresponding version as uint32.
+func extractVersion(versionStr string) (uint32, error) {
+	re := regexp.MustCompile(`^v(\d+)$`)
+	matches := re.FindStringSubmatch(versionStr)
+
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("invalid format: %s", versionStr)
+	}
+	version, err := strconv.ParseUint(matches[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse version: %w", err)
+	}
+
+	return uint32(version), nil
+}

--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -1,0 +1,184 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package transitengine
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+	"github.com/edgelesssys/contrast/coordinator/internal/seedengine"
+	"github.com/edgelesssys/contrast/internal/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransitAPICyclic(t *testing.T) {
+	type encryptionInput struct {
+		Plaintext      string `json:"plaintext"`
+		AssociatedData string `json:"associated_data,omitempty"`
+		Version        int    `json:"key_version"`
+	}
+	testCases := map[string]struct {
+		name            string
+		encryptionInput encryptionInput
+		expStatus       int
+	}{
+		"positive": {
+			name: "autounseal",
+			encryptionInput: encryptionInput{
+				Plaintext:      "vpIhKQhFuGwLv5B/XLYr960uZQ==",
+				AssociatedData: "Xv0nZLWkSan+vdWrH2LrGP8TU/Qg1+ZX7vldWMbxKTk=",
+				Version:        2,
+			},
+			expStatus: 200,
+		},
+		"special char name": {
+			name: "thi$$hoU_ld+*work",
+			encryptionInput: encryptionInput{
+				Plaintext:      "lT3rQGMlxq680DdSKfIYYcfyCfMnP9ikxaO5b0mGRKRl4qNL3W9xkSW3QmaMwozCRfNMZhhDCbYokn6KEiGotlVInKt66QjBgXR2Nk9hIcez0LYt8W5pxD0lwTxC",
+				AssociatedData: "HribV+LFZspJpAauFf643A1HKbj1VlQWVhAKFDJqdZg=",
+				Version:        2000,
+			},
+			expStatus: 200,
+		},
+		"failed not found empty name": {
+			name: "",
+			encryptionInput: encryptionInput{
+				Plaintext:      "vpIh",
+				AssociatedData: "vpIh",
+			},
+			expStatus: 404,
+		},
+		"failed not found name with forward slash": {
+			name: "wrong/url",
+			encryptionInput: encryptionInput{
+				Plaintext:      "vpIh",
+				AssociatedData: "vpIh",
+			},
+			expStatus: 404,
+		},
+		"failed bad request no base64 plaintext": {
+			name: "autounseal",
+			encryptionInput: encryptionInput{
+				Plaintext:      "thi$$hoU_ld+*notwork",
+				AssociatedData: "vpIh",
+			},
+			expStatus: 400,
+		},
+		"failed bad request no base64 additional data": {
+			name: "autounseal",
+			encryptionInput: encryptionInput{
+				Plaintext:      "HribV+LFZspJpAauFf643A1HKbj1VlQWVhAKFDJqdZg=",
+				AssociatedData: "thi$$hoU_ld+*notwork",
+			},
+			expStatus: 400,
+		},
+		"failed bad request negative key version": {
+			name: "thi$$hoU_ld+*work",
+			encryptionInput: encryptionInput{
+				Plaintext:      "lT3rQGMlxq680DdSKfIYYcfyCfMnP9ikxaO5b0mGRKRl4qNL3W9xkSW3QmaMwozCRfNMZhhDCbYokn6KEiGotlVInKt66QjBgXR2Nk9hIcez0LYt8W5pxD0lwTxC",
+				AssociatedData: "HribV+LFZspJpAauFf643A1HKbj1VlQWVhAKFDJqdZg=",
+				Version:        -2000,
+			},
+			expStatus: 400,
+		},
+	}
+
+	t.Run("encrypt-decrypt handler", func(t *testing.T) {
+		fakeStateAuthority, err := newFakeSeedEngineAuthority()
+		require.NoError(t, err)
+		mux := NewTransitEngineAPI(fakeStateAuthority, slog.Default())
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				var ciphertext, receivedPlaintext string
+				t.Run("encryption request handling", func(t *testing.T) {
+					require := require.New(t)
+					jsonBody, err := json.Marshal(tc.encryptionInput)
+					require.NoError(err)
+
+					req := httptest.NewRequest(http.MethodPut, "/v1/transit/encrypt/"+tc.name, bytes.NewReader(jsonBody))
+					req.Header.Set("Content-Type", "application/json")
+
+					rec := httptest.NewRecorder()
+					mux.ServeHTTP(rec, req)
+					res := rec.Result()
+					require.Equal(tc.expStatus, res.StatusCode)
+					if tc.expStatus != http.StatusOK {
+						return
+					}
+
+					var encRespBody map[string]map[string]string
+					require.NoError(json.NewDecoder(res.Body).Decode(&encRespBody))
+					defer res.Body.Close()
+
+					data, exist := encRespBody["data"]
+					require.True(exist)
+					ciphertext, exist = data["ciphertext"]
+					require.True(exist)
+				})
+
+				t.Run("decryption request handling", func(t *testing.T) {
+					require := require.New(t)
+					decryptReqBody, err := json.Marshal(
+						map[string]string{
+							"ciphertext":      ciphertext,
+							"associated_data": tc.encryptionInput.AssociatedData,
+						})
+					require.NoError(err)
+
+					decryptReq := httptest.NewRequest(http.MethodPut, "/v1/transit/decrypt/"+tc.name, bytes.NewReader(decryptReqBody))
+					decryptReq.Header.Set("Content-Type", "application/json")
+
+					rec := httptest.NewRecorder()
+					mux.ServeHTTP(rec, decryptReq)
+					res := rec.Result()
+					require.Equal(tc.expStatus, res.StatusCode)
+					if tc.expStatus != http.StatusOK {
+						return
+					}
+
+					var decRespBody map[string]map[string]string
+					require.NoError(json.NewDecoder(res.Body).Decode(&decRespBody))
+					defer res.Body.Close()
+
+					data, exist := decRespBody["data"]
+					require.True(exist)
+					receivedPlaintext, exist = data["plaintext"]
+					require.True(exist)
+					require.Equal(tc.encryptionInput.Plaintext, receivedPlaintext, "Unexpected received plaintext after cycling handler functions")
+				})
+			})
+		}
+	})
+}
+
+type fakeStateAuthority struct {
+	state authority.State
+}
+
+func newFakeSeedEngineAuthority() (*fakeStateAuthority, error) {
+	salt := make([]byte, constants.SecretSeedSaltSize)
+	secretSeed := make([]byte, constants.SecretSeedSize)
+	seedEngine, err := seedengine.New(secretSeed, salt)
+	if err != nil {
+		return nil, err
+	}
+	fakeState := &authority.State{
+		SeedEngine: seedEngine,
+	}
+
+	authority := &fakeStateAuthority{
+		state: *fakeState,
+	}
+	return authority, nil
+}
+
+func (f *fakeStateAuthority) GetState() (*authority.State, error) {
+	return &f.state, nil
+}


### PR DESCRIPTION
This PR adds basic http handling functionality for the encrypt and decrypt endpoints of the transit engine API, allowing the auto-unsealing process for user-managed Vaults. The PR introduces the following points:

- add GetState() of authority, to always ensure operating on current manifest
- underlying cryptographic functionality for AES-GCM 256
- http-handler functions for encrypt and decrypt endpoints
- message-level implementation of encryption/decryption request and response
- key derivation based on workloadSecretID specified as URL parameter
- support for associatedData request parameter of Vault

### ToDo's
- authorize transit engine requests to name parameter with client cert policy hash
- implement Vault json error bodies