### PR TITLE
release: commit state on which containers are built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Bump flake version temporarily to release version
+      - name: Bump flake version to release version
         uses: ./.github/actions/bump_version
         with:
           version: ${{ needs.process-inputs.outputs.WITHOUT_V }}
-          commit: false
+          commit: true
       - name: Push containers with release tag
         run: |
           coordinatorImg=$(nix run .#containers.push-coordinator -- "$container_registry/contrast/coordinator")


### PR DESCRIPTION
Previously, we would build both container images and cli on a dirty state: we bumped the flake version to release but didn't commit it, the build the container images, then commit the updated cli assets, then build the cli on the still dirty state, as the flake version bump still wasn't committed. This made reproducing the release very difficult.

![image](https://github.com/user-attachments/assets/4e35b393-f6aa-4304-ba77-888a9d02543d)

With this patch, we are committing the flake version bump to the release, too. This produces a first commit (flake bump to release), on which we build the container images, and a second commit (cli assets) on which we build the cli. 

![image](https://github.com/user-attachments/assets/8b01d33d-3b66-4ce3-aeb8-99f883970298)

Another problem not fixed with this release is that the tag of the release points to the last commit (flake bump to next -pre), but that is difficult to mitigate at this point (we could do it on the release branch transaction, but that should be minimal as there isn't a way to test it). Also there isn't a "correct" commit to point the tag to, as we build release artifacts from the two different commits as mentioned above. 
