### PR TITLE
fix: add '/run' volume to initializer

### DIFF
--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -66,13 +66,13 @@ let
           openssl
         ])
         ++ (with dockerTools; [ caCertificates ]);
-      runAsRoot = ''
-        mkdir -p /run
-      '';
       config = {
         # Use Entrypoint so we can append arguments.
         Entrypoint = [ "${pkgs.contrast.initializer}/bin/initializer" ];
         Env = [ "PATH=/bin" ]; # This is only here for policy generation.
+        Volumes = {
+          "/run" = { };
+        };
       };
     };
 


### PR DESCRIPTION
As part of  the [cryptsetup rework](
https://github.com/edgelesssys/contrast/pull/1153/files#diff-62e112e08a129f6cf9872c0f537ccf21f9b08e22cf3ee16946c0997ea7aca0a4), the initializer image was extended to run the `mkdir -p /run` command, because it is required by cryptsetup. The code change made the initializer boot qemu vm to emulate the architecture after runAsRoot command. This is not intended for the minor needs of having an existing /run directory, therefore the PR reverts the runAsRoot command and just mounts an empty volume at /run.