### PR TITLE
nodeinstaller: ignore absence of containerd config template

### DIFF
--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -275,7 +277,10 @@ func parseExistingContainerdConfig(path string) ([]byte, config.ContainerdConfig
 	// they are overwriting the template file and not the rendered file, we need to return the
 	// template file here.
 	configData, err = os.ReadFile(path)
-	if err != nil {
+	if errors.Is(err, fs.ErrNotExist) {
+		// The template file will be created by us, pretend that it's empty right now.
+		return []byte{}, cfg, nil
+	} else if err != nil {
 		return nil, config.ContainerdConfig{}, fmt.Errorf("reading containerd config template %s: %w", path, err)
 	}
 	return configData, cfg, nil


### PR DESCRIPTION
Commit ff6bfe1 introduced an `os.ReadFile` operation for the containerd config template used by k3s, assuming that the template file would always be present. However, a fresh installation of k3s does not come with a template file:
https://docs.k3s.io/advanced#configuring-containerd.

On a fresh k3s installation, the nodeinstaller will not find the template file, (falsely) assume that there is no config and use an embedded default, which happens to be incompatible with k3s.

Going forward, the nodeinstaller will treat an absent template like an empty template.