### PR TITLE
packages/kata-kernel-uvm: 6.11 -> 6.13

### DIFF
--- a/packages/by-name/kata/kata-kernel-uvm/package.nix
+++ b/packages/by-name/kata/kata-kernel-uvm/package.nix
@@ -83,13 +83,13 @@ let
 in
 
 linuxManualConfig rec {
-  version = "6.11";
+  version = "6.13";
   modDirVersion = "${version}.0" + lib.optionalString withGPU "-nvidia-gpu-confidential";
 
   # See https://github.com/kata-containers/kata-containers/blob/5f11c0f144037d8d8f546c89a0392dcd84fa99e2/versions.yaml#L198-L201
   src = fetchurl {
     url = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${version}.tar.xz";
-    hash = "sha256-VdLGwCXrwngQx0jWYyXdW8YB6NMvhYHZ53ZzUpvayy4=";
+    hash = "sha256-553Mbrhmlca6v7B8KGGRK2NdUHXGzRzQVn0eoVX4DW4=";
   };
 
   kernelPatches = [


### PR DESCRIPTION
This updates the Kata kernel to the latest version.