### PR TITLE
containers: reduce image size of initializer and coordinator

### DIFF
--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -62,8 +62,7 @@ let
           busybox
           cryptsetup
           e2fsprogs # mkfs.ext4
-          util-linux # blkid
-          openssl
+          libuuid # blkid
         ])
         ++ (with dockerTools; [ caCertificates ]);
       config = {

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -43,9 +43,9 @@ let
       tag = "v${pkgs.contrast.version}";
       copyToRoot =
         (with pkgs; [
-          util-linux
-          e2fsprogs
-          coreutils
+          busybox
+          e2fsprogs # mkfs.ext4
+          libuuid # blkid
         ])
         ++ (with dockerTools; [ caCertificates ]);
       config = {


### PR DESCRIPTION
Especially `util-linux` comes with a lot of baggage that we don't  need in the Coordinator image. What we actually depend on are `mount` and `blkid`.

The `blkid` from busybox produces output incompatible to util-linux, and harder to parse. Fortunately, there's a minimal version of util-linux that provides `blkid` and `mount`: `libuuid`.

