### PR TITLE
misc: fix linter errors

### DIFF
--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -26,8 +26,8 @@ const (
 
 // History is the history of the Coordinator.
 type History struct {
-	store      Store
-	hashFun    func() hash.Hash
+	store   Store
+	hashFun func() hash.Hash
 }
 
 // New creates a new History backed by the default filesystem store.

--- a/docs/docs/architecture/secrets.md
+++ b/docs/docs/architecture/secrets.md
@@ -42,7 +42,7 @@ Like the workload certificates, it's written to the `secrets/workload-secret-see
 :::warning
 
 The seed share owner can decrypt data encrypted with secrets derived from the workload secret, because they can themselves derive the workload secret.
-If the data owner fully trusts the seed share owner (when they are the same entity, for example), they can securely use the workload secrets.
+If the data owner fully trusts the seed share owner (when they're the same entity, for example), they can securely use the workload secrets.
 
 :::
 


### PR DESCRIPTION
These were introduced in the private commits for https://github.com/edgelesssys/contrast/security/advisories/GHSA-vqv5-385r-2hf8 due to lack of CI coverage.