### PR TITLE
coordinator: handle signals

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/edgelesssys/contrast/coordinator/history"
@@ -41,7 +43,7 @@ func main() {
 }
 
 func run() (retErr error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
 	logger, err := logger.Default()


### PR DESCRIPTION
The TERM and INT signal are usually masked for PID 1, which means that the Coordinator ignores these signals and the container runtime needs to send a KILL signal to terminate it. This results in 30 wasted seconds between the pod deletion request and the deletion itself, which is most annoying in interactive development workflows. Thus, we handle the signal by cancelling the main context, which in turn results in a graceful listener shutdown.