### PR TITLE
docs: bare-metal runner specs

### DIFF
--- a/dev-docs/e2e/bare-metal-runner.md
+++ b/dev-docs/e2e/bare-metal-runner.md
@@ -1,0 +1,13 @@
+## Bare-metal runner specification
+To run our e2e test in with the real bare-metal runner specification a ConfigMap named `bm-tcb-specs` is added to both e2 clusters: `m50-ganondorf` and `discovery`.
+Having the ConfigMap prevents using committed values in the e2e tests directly, which could otherwise lead to backporting problems.
+
+The `bm-tcb-specs` ConfigMap wraps the [`tcb-specs.json`](/dev-docs/e2e/tcb-specs.json), sharing TDX and SNP bare-metal specifications.
+While the ConfigMap stores both runner specifications the [patchReferenceValues()](https://github.com/edgelesssys/contrast/blob/main/e2e/internal/contrasttest/contrasttest.go#L254-L283) function will only use the platform-specific reference values for overwriting.
+
+### Setting up e2e clusters / Updating `tcb-specs.json`
+We expect the e2e clusters not to be destroyed frequently, thus the ConfigMap is stored persistently for the e2e test. In case of setting up the e2e clusters again or an update to the bare-metal runner specifications is required, the ConfigMap has to be applied with:
+
+``` bash
+kubectl create configmap bm-tcb-specs --from-file=tcb-specs.json -n default
+```

--- a/dev-docs/e2e/tcb-specs.json
+++ b/dev-docs/e2e/tcb-specs.json
@@ -1,0 +1,21 @@
+{
+    "snp": [
+        {
+            "MinimumTCB": {
+                "BootloaderVersion": 7,
+                "TEEVersion": 0,
+                "SNPVersion": 15,
+                "MicrocodeVersion": 72
+            },
+            "ProductName": "Genoa",
+            "TrustedMeasurement": ""
+        }
+    ],
+    "tdx": [
+        {
+            "MinimumTeeTcbSvn": "04010200000000000000000000000000",
+            "MrSeam": "1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04"
+        }
+    ]
+}
+

--- a/tools/vale/styles/config/vocabularies/edgeless/accept.txt
+++ b/tools/vale/styles/config/vocabularies/edgeless/accept.txt
@@ -106,6 +106,7 @@ SBOM
 serializable
 sigstore
 snapshotter
+SNP
 SSD
 subcommand
 Subresource
@@ -116,6 +117,7 @@ sysctl
 systemd
 tardev
 tarfs
+TDX
 Terraform
 Tink
 tmpfs


### PR DESCRIPTION
This PR adds some documentation on the ConfigMap used for the e2e clusters, as introduced in #1115. It describes how the ConfigMap can be created and updated in case of changes to the bare-metal runner specifications.