### PR TITLE
e2e: increase wait time for nodeinstaller

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -386,7 +386,7 @@ func (ct *ContrastTest) installRuntime(t *testing.T) {
 	unstructuredResources, err := kuberesource.ResourcesToUnstructured(resources)
 	require.NoError(err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
 	require.NoError(ct.Kubeclient.Apply(ctx, unstructuredResources...))


### PR DESCRIPTION
We saw an increased delay from scheduling the node installer to completion of the installation when using the GPU runtime. This is due to the larger VM image size, which increases the time it takes to download the container image and copy over the resources. Increasing the wait time should accommodate for this.