### PR TITLE
atls: send VCEK and CRL

### DIFF
--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -39,7 +39,7 @@ type Credentials struct {
 func (a *Authority) Credentials(reg *prometheus.Registry, issuer atls.Issuer) (*Credentials, func()) {
 	month := 30 * 24 * time.Hour
 	ticker := clock.RealClock{}.NewTicker(9 * month)
-	kdsGetter := certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(a.logger, "kds-getter"))
+	kdsGetter := certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(a.logger, "kds-getter-validator"))
 	attestationFailuresCounter := promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Subsystem: "contrast_meshapi",
 		Name:      "attestation_failures_total",

--- a/internal/attestation/snp/issuer/issuer.go
+++ b/internal/attestation/snp/issuer/issuer.go
@@ -13,28 +13,41 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
+	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/reportdata"
+	"github.com/edgelesssys/contrast/internal/constants"
+	"github.com/edgelesssys/contrast/internal/logger"
+	"github.com/edgelesssys/contrast/internal/memstore"
 	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/google/go-sev-guest/abi"
 	snpabi "github.com/google/go-sev-guest/abi"
 	"github.com/google/go-sev-guest/client"
+	"github.com/google/go-sev-guest/kds"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
+	"github.com/google/go-sev-guest/verify"
+	"github.com/google/go-sev-guest/verify/trust"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	"k8s.io/utils/clock"
 )
 
 // Issuer issues attestation statements.
 type Issuer struct {
 	thimGetter *THIMGetter
 	logger     *slog.Logger
+	kdsGetter  *certcache.CachedHTTPSGetter
 }
 
 // New returns a new Issuer.
 func New(log *slog.Logger) *Issuer {
+	month := 30 * 24 * time.Hour
+	ticker := clock.RealClock{}.NewTicker(9 * month)
 	return &Issuer{
 		thimGetter: NewTHIMGetter(http.DefaultClient),
 		logger:     log,
+		kdsGetter:  certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(log, "kds-getter-issuer")),
 	}
 }
 
@@ -69,19 +82,6 @@ func (i *Issuer) Issue(ctx context.Context, ownPublicKey []byte, nonce []byte) (
 	}
 	i.logger.Info("Retrieved report", "reportRaw", hex.EncodeToString(reportRaw))
 
-	// Get cert chain from THIM
-	var certChain *spb.CertificateChain
-	thimRaw, err := i.thimGetter.GetCertification(ctx)
-	if err != nil {
-		i.logger.Info("Could not retrieve THIM certification", "error", err)
-	} else {
-		i.logger.Info("Retrieved THIM certification", "thim", thimRaw)
-		certChain, err = thimRaw.Proto()
-		if err != nil {
-			return nil, fmt.Errorf("issuer: converting THIM cert chain: %w", err)
-		}
-	}
-
 	// Get SNP product info from cpuid
 	product := abi.SevProduct()
 	i.logger.Info("cpuid product info", "name", product.GetName(), "machineStepping", product.GetMachineStepping().Value)
@@ -89,11 +89,51 @@ func (i *Issuer) Issue(ctx context.Context, ownPublicKey []byte, nonce []byte) (
 	product.MachineStepping = &wrapperspb.UInt32Value{Value: 0}
 	i.logger.Info("patched product info", "name", product.GetName(), "machineStepping", product.GetMachineStepping().Value)
 
-	att := &spb.Attestation{
-		Report:           report,
-		CertificateChain: certChain,
-		Product:          product,
+	// Get cert chain from THIM
+	var att *spb.Attestation
+	thimRaw, err := i.thimGetter.GetCertification(ctx)
+	if err != nil {
+		i.logger.Info("Could not retrieve THIM certification", "error", err)
+		// Get cert chain including ARK, ASK and VCEK (part of spb.Attestation).
+		att, err = verify.GetAttestationFromReport(report, &verify.Options{Getter: i.kdsGetter, Product: product})
+		if err != nil {
+			return nil, fmt.Errorf("could not get attestation from report: %w", err)
+		}
+	} else {
+		i.logger.Info("Retrieved THIM certification", "thim", thimRaw)
+		certChain, err := thimRaw.Proto()
+		if err != nil {
+			return nil, fmt.Errorf("issuer: converting THIM cert chain: %w", err)
+		}
+		att = &spb.Attestation{
+			Report:           report,
+			CertificateChain: certChain,
+			Product:          product,
+		}
 	}
+
+	// Get the CRL.
+	var productLine string
+	if fms := att.GetReport().GetCpuid1EaxFms(); fms != 0 {
+		productLine = kds.ProductLineFromFms(fms)
+	}
+	root := trust.AMDRootCertsProduct(productLine) // Create AMDRootCerts for product line.
+	chain := att.GetCertificateChain()             // Get ARK, ASK and VCEK from attestation.
+	// Decode ASK/ARK into root.
+	if err := root.Decode(chain.GetAskCert(), chain.GetArkCert()); err != nil {
+		return nil, err
+	}
+	crl, err := verify.GetCrlAndCheckRoot(root, &verify.Options{Getter: i.kdsGetter})
+	if err != nil {
+		// TODO(3u13r): don't fail here. VLEK/ASVK doesn't offer CRLs
+		return nil, err
+	}
+
+	// Add CRL as CertificateChain.Extras to the attestation, so it can be used by a validator.
+	if att.CertificateChain.Extras == nil {
+		att.CertificateChain.Extras = make(map[string][]byte)
+	}
+	att.CertificateChain.Extras[constants.SNPCertChainExtrasCRLKey] = crl.Raw
 
 	attRaw, err := proto.Marshal(att)
 	if err != nil {

--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -86,7 +86,8 @@ func (v *Validator) Validate(attDocRaw []byte, nonce []byte, peerPublicKey []byt
 
 	// CRL validity and expiration is checked as part of verify.SnpAttestation.
 	if err := addCRLtoVerifyOptions(attestationData, v.verifyOpts); err != nil {
-		v.logger.Info("could not use cached CRL from Coordinator", slog.String("error", err.Error()))
+		// Log error but continue, the client can still request the CRL/VCEK from the KDS.
+		v.logger.Info("could not use cached CRL from Coordinator aTLS handshake", slog.String("error", err.Error()))
 	}
 
 	// Report signature verification.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -15,4 +15,6 @@ const (
 	SecretSeedSize = 64
 	// SecretSeedSaltSize is the size of the secret seed salt generated in the coordinator.
 	SecretSeedSaltSize = 32
+	// SNPCertChainExtrasCRLKey is the UUID of the cert chain extra that contains the CRL.
+	SNPCertChainExtrasCRLKey = "00569ee4-e480-4fba-bbf4-45b629901180"
 )

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -22,6 +22,7 @@ import (
 // ValidatorsFromManifest returns a list of validators corresponding to the reference values in the given manifest.
 // Originally an unexported function in the contrast CLI.
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
+// Validators MUST NOT be used concurrently.
 func ValidatorsFromManifest(kdsDir string, m *manifest.Manifest, log *slog.Logger, coordinatorPolicyChecksum []byte) ([]atls.Validator, error) {
 	kdsCache := fsstore.New(kdsDir, log.WithGroup("kds-cache"))
 	kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"))


### PR DESCRIPTION
With this change, the aTLS issuer will send the VCEK and CRL in the aTLS handshake. This allows the Coordinator to cache VCEK/CRL and send them to the client. The client (CLI) doesn't need to request the KDS anymore, so operations against the Coordinator (set, verify) can also be done if the KDS is unreachable to the client, assuming the Coordinator managed to cache both at an earlier point in time. The client will verify the VCEK and CRL for valid signature by AMD ARK/ASK keys, so a malicious Coordinator sending manipulated VCEK/CRL will be detected.