### PR TITLE
runtime: derive handler from version

### DIFF
--- a/packages/by-name/kata/contrast-node-installer-image/package.nix
+++ b/packages/by-name/kata/contrast-node-installer-image/package.nix
@@ -222,6 +222,15 @@ let
     ];
   };
 
+  version = ociLayerTar {
+    files = [
+      {
+        source = ../../../../version.txt;
+        destination = "/usr/share/misc/contrast/version.txt";
+      }
+    ];
+  };
+
   layers = [
     installer-config
     kata-container-img
@@ -231,6 +240,7 @@ let
     qemu-tdx
     kata-runtime
     nydus
+    version
   ];
 
   manifest = ociImageManifest {

--- a/packages/by-name/microsoft/contrast-node-installer-image/package.nix
+++ b/packages/by-name/microsoft/contrast-node-installer-image/package.nix
@@ -93,11 +93,21 @@ let
     ];
   };
 
+  version = ociLayerTar {
+    files = [
+      {
+        source = ../../../../version.txt;
+        destination = "/usr/share/misc/contrast/version.txt";
+      }
+    ];
+  };
+
   layers = [
     installer-config
     kata-container-img
     cloud-hypervisor
     containerd-shim
+    version
   ];
 
   manifest = ociImageManifest {


### PR DESCRIPTION
Our runtime handler suffix used to be derived from the guest VM image only, missing the following Contrast components that influence runtime behaviour or attestation:

* node installer
* Kata configuration files
* embedded coordinator policy

While this is not a security issue, it may cause problems when installing multiple Contrast versions side by side. For example, 1.4.0 and 1.4.1 have the same runtime handler name.

This PR resolves the issue at least for release versions, by mixing the version into the runtime handler suffix generation input. While we could also make the version itself part of the suffix, the runtime handler name is already long enough to bring the node installer name close to the limits for k8s objects.