### PR TITLE
cli: don't panic on absent pod template metadata

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -355,7 +355,7 @@ func injectInitializer(resources []any) error {
 	for _, resource := range resources {
 		switch r := resource.(type) {
 		case *applyappsv1.StatefulSetApplyConfiguration:
-			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.Annotations != nil &&
+			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.ObjectMetaApplyConfiguration != nil && r.Spec.Template.Annotations != nil &&
 				r.Spec.Template.Annotations[contrastRoleAnnotationKey] == "coordinator" {
 				continue
 			}
@@ -371,7 +371,7 @@ func injectInitializer(resources []any) error {
 func injectServiceMesh(resources []any) error {
 	for _, resource := range resources {
 		r, ok := resource.(*applyappsv1.StatefulSetApplyConfiguration)
-		if ok && r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.Annotations != nil &&
+		if ok && r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.ObjectMetaApplyConfiguration != nil && r.Spec.Template.Annotations != nil &&
 			r.Spec.Template.Annotations[contrastRoleAnnotationKey] == "coordinator" {
 			continue
 		}

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -1,0 +1,30 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+// TestStatefulSetInjections is a regression test for a nil dereference in the inject* functions.
+func TestStatefulSetInjections(t *testing.T) {
+	resources := []any{statefulSet()}
+
+	t.Run("injectInitializer", func(t *testing.T) {
+		require.NoError(t, injectInitializer(resources))
+	})
+
+	t.Run("injectServiceMesh", func(t *testing.T) {
+		require.NoError(t, injectServiceMesh(resources))
+	})
+}
+
+func statefulSet() *applyappsv1.StatefulSetApplyConfiguration {
+	return applyappsv1.StatefulSet("some-name", "some-namespace").
+		WithSpec(applyappsv1.StatefulSetSpec().WithTemplate(applycorev1.PodTemplateSpec()))
+}


### PR DESCRIPTION
This is an amendment to #1230. We now don't panic even if the entire pod template metadata is missing.