### PR TITLE
e2e: use correct testing context in policy test

### DIFF
--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -167,7 +167,7 @@ func TestPolicy(t *testing.T) {
 		// connect to the Coordinator. Thus, retry for some time until an attestation failure happens.
 		require.EventuallyWithT(func(t *assert.CollectT) {
 			newFailures := getFailures(ctx, t, ct)
-			require.Greater(newFailures, initialFailures, "pod not covered by manifest should cause attestation failure")
+			assert.Greater(t, newFailures, initialFailures, "pod not covered by manifest should cause attestation failure")
 		}, 1*time.Minute, time.Second)
 	})
 


### PR DESCRIPTION
This is a follow-up fix for #1227, where I accidentally reused the `require` object in the closure instead of allocating a new one. That caused the test to only execute the `Eventually` block once.