### PR TITLE
e2e: improve workloadsecrettest timeout behavior

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -448,7 +448,7 @@ func (ct *ContrastTest) FactorPlatformTimeout(timeout time.Duration) time.Durati
 		platforms.MetalQEMUSNPGPU:
 		return 2 * timeout
 	default:
-		return timeout
+		panic(fmt.Sprintf("FactorPlatformTimeout not configured for platform %q", ct.Platform))
 	}
 }
 

--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -153,9 +153,14 @@ func TestWorkloadSecrets(t *testing.T) {
 
 		t.Run("set", ct.Set)
 
-		var secrets [][]byte
-		for _, deploy := range []string{"web", "emoji"} {
+		deployments := []string{"web", "emoji"}
+		// Delete both pods first so that we don't serialize the waiting time.
+		for _, deploy := range deployments {
 			require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, deploy))
+		}
+
+		var secrets [][]byte
+		for _, deploy := range deployments {
 			require.NoError(ct.Kubeclient.WaitFor(ctx, kubeclient.Ready, kubeclient.Deployment{}, ct.Namespace, deploy))
 
 			pods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, deploy)

--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -140,8 +140,6 @@ func TestWorkloadSecrets(t *testing.T) {
 	t.Run("workload secrets seeds can be set to be equal for different deployments", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
-		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(60*time.Second))
-		defer cancel()
 
 		ct.PatchManifest(t, func(m manifest.Manifest) manifest.Manifest {
 			for key, policy := range m.Policies {
@@ -152,6 +150,9 @@ func TestWorkloadSecrets(t *testing.T) {
 		})
 
 		t.Run("set", ct.Set)
+
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(60*time.Second))
+		defer cancel()
 
 		deployments := []string{"web", "emoji"}
 		// Delete both pods first so that we don't serialize the waiting time.


### PR DESCRIPTION
We've seen an increased amount of nightly failures for the workload secret test since #1104 introduced a new subtest. This PR aims to improve the situation by:

* using the test's timeout exclusively for the restart operation (the `ct.Set` command has its own timeout)
* restarting the pods in parallel and only waiting serially

While looking at the test, I saw that `FactorPlatformTimeout` has an explicit list of slow platforms. I think we should not silently default to the shorter timeout, because it's easy to forget to update this switch statement when a new platform is introduced.