### PR TITLE
Expand coordinator store interface

### DIFF
--- a/coordinator/history/aferostore.go
+++ b/coordinator/history/aferostore.go
@@ -59,3 +59,10 @@ func (s *AferoStore) CompareAndSwap(key string, oldVal, newVal []byte) error {
 	}
 	return s.fs.WriteFile(key, newVal, 0o644)
 }
+
+// Watch watches for changes to the value of key.
+//
+// Not implemented for AferoStore.
+func (s *AferoStore) Watch(_ string) (<-chan []byte, func(), error) {
+	return nil, func() {}, nil
+}

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -251,4 +251,9 @@ type Store interface {
 	// If the current value is not equal to oldVal, an error must be returned. The comparison must
 	// treat a nil slice the same as an empty slice.
 	CompareAndSwap(key string, oldVal, newVal []byte) error
+
+	// Watch watches for changes to the value of key.
+	//
+	// If the value of key changes, the new value is sent on the channel.
+	Watch(key string) (ch <-chan []byte, cancel func(), err error)
 }

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -13,15 +13,11 @@ import (
 	"fmt"
 	"hash"
 	"os"
-
-	"github.com/spf13/afero"
 )
 
 const (
 	// HashSize is the number of octets in hashes used by this package.
 	HashSize = sha256.Size
-
-	histPath = "/mnt/state/history"
 )
 
 // History is the history of the Coordinator.
@@ -30,13 +26,12 @@ type History struct {
 	hashFun func() hash.Hash
 }
 
-// New creates a new History backed by the default filesystem store.
+// New creates a new History backed by the configured store.
 func New() (*History, error) {
-	osFS := afero.NewOsFs()
-	if err := osFS.MkdirAll(histPath, 0o755); err != nil {
-		return nil, fmt.Errorf("creating history directory: %w", err)
+	store, err := NewStore()
+	if err != nil {
+		return nil, fmt.Errorf("creating history store: %w", err)
 	}
-	store := NewAferoStore(&afero.Afero{Fs: afero.NewBasePathFs(osFS, histPath)})
 	return NewWithStore(store), nil
 }
 

--- a/coordinator/history/store.go
+++ b/coordinator/history/store.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !enterprise
+
+package history
+
+import (
+	"fmt"
+
+	"github.com/spf13/afero"
+)
+
+const (
+	histPath = "/mnt/state/history"
+)
+
+// NewStore creates a new AferoStore backed by the default filesystem store.
+func NewStore() (*AferoStore, error) {
+	osFS := afero.NewOsFs()
+	if err := osFS.MkdirAll(histPath, 0o755); err != nil {
+		return nil, fmt.Errorf("creating history directory: %w", err)
+	}
+	return NewAferoStore(&afero.Afero{Fs: afero.NewBasePathFs(osFS, histPath)}), nil
+}


### PR DESCRIPTION
This adds the `Watch()` function to the `Store` interface of the Coordinator. This function returns a channel which receives updates to the store, and a cancel function which can be used to stop watching.

The `NewStore()` method is separated and brought to a new file, so it can be controlled via a `enterprise` build tag.