### PR TITLE
attestation: get product from attestation instead of report

### DIFF
--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -154,11 +154,7 @@ func addCRLtoVerifyOptions(attestationData *sevsnp.Attestation, verifyOpts *veri
 		return errors.New("could not parse CRL from attestation data")
 	}
 
-	fms := attestationData.GetReport().GetCpuid1EaxFms()
-	if fms == 0 {
-		return errors.New("could not retrieve cpuid info from attestation data")
-	}
-	productLine := kds.ProductLineFromFms(fms)
+	productLine := kds.ProductLine(attestationData.GetProduct())
 
 	for _, tr := range verifyOpts.TrustedRoots[productLine] {
 		tr.CRL = crl


### PR DESCRIPTION
Non v3 Reports don't have the eax bits set in the report. We already have the product in the attestation, just use that one.