### PR TITLE
grpc: retry connecting to coordinator on EOF

### DIFF
--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -36,6 +36,10 @@ func TestServiceIsUnavailable(t *testing.T) {
 			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: context deadline exceeded"`),
 			wantUnavailable: true,
 		},
+		"handshake EOF error": {
+			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: EOF"`),
+			wantUnavailable: true,
+		},
 		"wrapped error": {
 			err:             fmt.Errorf("some wrapping: %w", status.Error(codes.Unavailable, "error")),
 			wantUnavailable: true,


### PR DESCRIPTION
If the gRPC connection is terminated before the TLS handshake takes place, the ultimate cause reported by the gRPC library is EOF. In this situation, we should not abort the request, but retry.