### PR TITLE
[release/v1.5] attestation: get product from attestation instead of report

### DIFF
--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -150,11 +150,7 @@ func addCRLtoVerifyOptions(attestationData *sevsnp.Attestation, verifyOpts *veri
 		return errors.New("could not parse CRL from attestation data")
 	}
 
-	fms := attestationData.GetReport().GetCpuid1EaxFms()
-	if fms == 0 {
-		return errors.New("could not retrieve cpuid info from attestation data")
-	}
-	productLine := kds.ProductLineFromFms(fms)
+	productLine := kds.ProductLine(attestationData.GetProduct())
 
 	for _, tr := range verifyOpts.TrustedRoots[productLine] {
 		tr.CRL = crl


### PR DESCRIPTION
Backport of #1238 to `release/v1.5`.

Original description:

---

Non v3 Reports don't have the eax bits set in the report. We already have the product in the attestation, just use that one.