### PR TITLE
atls: forward context to validators

### DIFF
--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -4,6 +4,7 @@
 package snp
 
 import (
+	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -62,7 +63,7 @@ func (v *Validator) OID() asn1.ObjectIdentifier {
 }
 
 // Validate a SNP based attestation.
-func (v *Validator) Validate(attDocRaw []byte, nonce []byte, peerPublicKey []byte) (err error) {
+func (v *Validator) Validate(_ context.Context, attDocRaw []byte, nonce []byte, peerPublicKey []byte) (err error) {
 	v.logger.Info("Validate called", "name", v.name, "nonce", hex.EncodeToString(nonce))
 	defer func() {
 		if err != nil {
@@ -95,6 +96,7 @@ func (v *Validator) Validate(attDocRaw []byte, nonce []byte, peerPublicKey []byt
 	}
 
 	// Report signature verification.
+	// TODO(burgerdev): equip HTTPSGetter with context.
 	if err := verify.SnpAttestation(attestationData, v.verifyOpts); err != nil {
 		return fmt.Errorf("verifying report: %w", err)
 	}

--- a/internal/attestation/tdx/validator.go
+++ b/internal/attestation/tdx/validator.go
@@ -4,6 +4,7 @@
 package tdx
 
 import (
+	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	_ "embed"
@@ -77,7 +78,7 @@ func (v *Validator) OID() asn1.ObjectIdentifier {
 }
 
 // Validate a TDX attestation.
-func (v *Validator) Validate(attDocRaw []byte, nonce []byte, peerPublicKey []byte) (err error) {
+func (v *Validator) Validate(_ context.Context, attDocRaw []byte, nonce []byte, peerPublicKey []byte) (err error) {
 	// TODO(freax13): Validate the memory integrity mode (logical vs cryptographic) in the provisioning certificate.
 
 	v.logger.Info("Validate called", "name", v.name, "nonce", hex.EncodeToString(nonce))
@@ -109,6 +110,7 @@ func (v *Validator) Validate(attDocRaw []byte, nonce []byte, peerPublicKey []byt
 	verifyOpts.CheckRevocations = true
 	verifyOpts.GetCollateral = true
 	// TODO(freax13): Set .Getter with a caching HTTP getter implementation.
+	// TODO(burgerdev): equip HTTPSGetter with context.
 
 	// Verify the report signature.
 

--- a/internal/grpc/atlscredentials/atlscredentials.go
+++ b/internal/grpc/atlscredentials/atlscredentials.go
@@ -43,7 +43,7 @@ func NewWithKey(issuer atls.Issuer, validators []atls.Validator, attestationFail
 
 // ClientHandshake performs the client handshake.
 func (c *Credentials) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	clientCfg, err := atls.CreateAttestationClientTLSConfig(c.issuer, c.validators, c.privKey)
+	clientCfg, err := atls.CreateAttestationClientTLSConfig(ctx, c.issuer, c.validators, c.privKey)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Validators often need to request resources from the internet, for example CRLs. If these resources are unavailable, validation might time out on the TLS handshake level without much information about the root cause.

This commit allows the atls package to forward the context of the TLS handshake to the individual validators. Missing here and to be added in future commits:

- Creating a context with appropriate timeout in atlscredentials.
- Forwarding the context to the HTTPSGetters for SNP/TDX.