### PR TITLE
enterprise: add config map backed history store

### DIFF
--- a/coordinator/history/aferostore.go
+++ b/coordinator/history/aferostore.go
@@ -51,6 +51,20 @@ func (s *AferoStore) Set(key string, value []byte) error {
 	return s.fs.WriteFile(key, value, 0o644)
 }
 
+// Has returns true if the key exists.
+func (s *AferoStore) Has(key string) (bool, error) {
+	if !keyRe.MatchString(key) {
+		return false, fmt.Errorf("invalid key %q", key)
+	}
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	_, err := s.fs.Stat(key)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 // CompareAndSwap updates the key to newVal if its current value is oldVal.
 func (s *AferoStore) CompareAndSwap(key string, oldVal, newVal []byte) error {
 	if !keyRe.MatchString(key) {

--- a/coordinator/history/aferostore_test.go
+++ b/coordinator/history/aferostore_test.go
@@ -56,6 +56,20 @@ func suite(t *testing.T, storeFactory func(t *testing.T) Store) {
 		require.Equal(val2, z)
 	})
 
+	t.Run("Has", func(t *testing.T) {
+		require := require.New(t)
+		s := storeFactory(t)
+
+		key := "foo/bar"
+		val := []byte("val")
+
+		require.False(s.Has(key))
+
+		require.NoError(s.Set(key, val))
+
+		require.True(s.Has(key))
+	})
+
 	t.Run("CompareAndSwap", func(t *testing.T) {
 		require := require.New(t)
 		s := storeFactory(t)

--- a/coordinator/history/aferostore_test.go
+++ b/coordinator/history/aferostore_test.go
@@ -30,9 +30,12 @@ func suite(t *testing.T, storeFactory func(t *testing.T) Store) {
 		require := require.New(t)
 		s := storeFactory(t)
 
-		key := "/foo/bar"
+		key := "foo/bar"
 		val1 := []byte("val1")
 		val2 := []byte("val2")
+
+		_, err := s.Get("invalid-key")
+		require.ErrorContains(err, "invalid key")
 
 		x, err := s.Get(key)
 		require.ErrorIs(err, os.ErrNotExist)
@@ -43,6 +46,8 @@ func suite(t *testing.T, storeFactory func(t *testing.T) Store) {
 		y, err := s.Get(key)
 		require.NoError(err)
 		require.Equal(val1, y)
+
+		require.ErrorContains(s.Set("invalid-key", nil), "invalid key")
 
 		require.NoError(s.Set(key, val2))
 
@@ -55,7 +60,7 @@ func suite(t *testing.T, storeFactory func(t *testing.T) Store) {
 		require := require.New(t)
 		s := storeFactory(t)
 
-		key := "/foo/bar"
+		key := "foo/bar"
 		val1 := []byte("val1")
 		val2 := []byte("val2")
 
@@ -63,6 +68,7 @@ func suite(t *testing.T, storeFactory func(t *testing.T) Store) {
 		require.ErrorIs(err, os.ErrNotExist)
 		require.Empty(x)
 
+		require.ErrorContains(s.CompareAndSwap("invalid-key", nil, nil), "invalid key")
 		require.Error(s.CompareAndSwap(key, val1, val2))
 
 		require.NoError(s.CompareAndSwap(key, nil, val1))

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"log/slog"
 )
 
 const (
@@ -26,8 +27,8 @@ type History struct {
 }
 
 // New creates a new History backed by the configured store.
-func New() (*History, error) {
-	store, err := NewStore()
+func New(log *slog.Logger) (*History, error) {
+	store, err := NewStore(log.WithGroup("history-store"))
 	if err != nil {
 		return nil, fmt.Errorf("creating history store: %w", err)
 	}

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -231,7 +231,8 @@ func (e HashMismatchError) Error() string {
 // Store defines the Key-Value store interface used by History.
 //
 // In addition to the documented behavior below, History expects all functions to be thread-safe
-// and the Store to be globally consistent.
+// and the Store to be globally consistent. Keys must consist of two alphanumeric identifiers
+// separated by a forward slash.
 type Store interface {
 	// Get the value for key.
 	//

--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"os"
 )
 
 const (
@@ -104,13 +103,7 @@ func (h *History) GetLatest(pubKey *ecdsa.PublicKey) (*LatestTransition, error) 
 // HasLatest returns true if there exist a latest transaction. It does not
 // verify the transaction signature or return the transaction.
 func (h *History) HasLatest() (bool, error) {
-	if _, err := h.store.Get("transitions/latest"); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
+	return h.store.Has("transitions/latest")
 }
 
 // SetLatest signs and sets the latest transition if the current latest is equal to oldT.
@@ -241,6 +234,9 @@ type Store interface {
 
 	// Set the value for key.
 	Set(key string, value []byte) error
+
+	// Has returns true if the key exists.
+	Has(key string) (bool, error)
 
 	// CompareAndSwap sets key to newVal if, and only if, key is currently oldVal.
 	//

--- a/coordinator/history/store.go
+++ b/coordinator/history/store.go
@@ -7,6 +7,7 @@ package history
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/afero"
 )
@@ -16,7 +17,7 @@ const (
 )
 
 // NewStore creates a new AferoStore backed by the default filesystem store.
-func NewStore() (*AferoStore, error) {
+func NewStore(_ *slog.Logger) (*AferoStore, error) {
 	osFS := afero.NewOsFs()
 	if err := osFS.MkdirAll(histPath, 0o755); err != nil {
 		return nil, fmt.Errorf("creating history directory: %w", err)

--- a/coordinator/history/store_enterprise.go
+++ b/coordinator/history/store_enterprise.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build enterprise
+
+package history
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/edgelesssys/contrast/enterprise/coordinator/history"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// NewStore creates a new ConfigMapStore backed by Kubernetes Config Maps.
+func NewStore(log *slog.Logger) (*history.ConfigMapStore, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return nil, err
+	}
+	return history.NewConfigMapStore(clientset, string(namespace), log)
+}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -67,7 +67,7 @@ func run() (retErr error) {
 	promRegistry := prometheus.NewRegistry()
 	serverMetrics := newServerMetrics(promRegistry)
 
-	hist, err := history.New()
+	hist, err := history.New(logger)
 	if err != nil {
 		return fmt.Errorf("creating history: %w", err)
 	}

--- a/enterprise/coordinator/history/configmapstore.go
+++ b/enterprise/coordinator/history/configmapstore.go
@@ -1,0 +1,230 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build enterprise
+
+package history
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// timeout is the timeout for Kubernetes API calls.
+const timeout = 10 * time.Second
+
+var keyRe = regexp.MustCompile(`^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$`)
+
+// ConfigMapStore is a Store implementation backed by Kubernetes Config Maps.
+type ConfigMapStore struct {
+	client    kubernetes.Interface
+	namespace string
+	uid       types.UID
+	logger    *slog.Logger
+}
+
+// NewConfigMapStore creates a new instance backed by Kubernetes Config Maps.
+func NewConfigMapStore(client kubernetes.Interface, namespace string, log *slog.Logger) (*ConfigMapStore, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	self, err := client.CoreV1().Pods(namespace).Get(ctx, os.Getenv("HOSTNAME"), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	ownerRefs := self.GetOwnerReferences()
+	var statefulset metav1.OwnerReference
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.Kind == "StatefulSet" && ownerRef.Name == "coordinator" {
+			statefulset = ownerRef
+			break
+		}
+	}
+	if statefulset.UID == "" {
+		return nil, fmt.Errorf("coordinator statefulset not found")
+	}
+	return &ConfigMapStore{
+		client:    client,
+		namespace: self.Namespace,
+		uid:       statefulset.UID,
+		logger:    log,
+	}, nil
+}
+
+// Get the value for key.
+func (s *ConfigMapStore) Get(key string) ([]byte, error) {
+	cmName, err := objectName(key)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cm, err := s.client.CoreV1().ConfigMaps(s.namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cm.BinaryData[filepath.Base(key)], nil
+}
+
+// Has returns true if the key exists.
+func (s *ConfigMapStore) Has(key string) (bool, error) {
+	cmName, err := objectName(key)
+	if err != nil {
+		return false, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	_, err = s.client.CoreV1().ConfigMaps(s.namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// Set the value for key.
+func (s *ConfigMapStore) Set(key string, value []byte) error {
+	cmName, err := objectName(key)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cm, err := s.client.CoreV1().ConfigMaps(s.namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		cm = s.newEntry(cmName, key, value)
+		_, err := s.client.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{})
+		return err
+	}
+	cm.BinaryData[filepath.Base(key)] = value
+	_, err = s.client.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+// CompareAndSwap updates the key to newVal if its current value is oldVal.
+func (s *ConfigMapStore) CompareAndSwap(key string, oldVal, newVal []byte) error {
+	cmName, err := objectName(key)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cm, err := s.client.CoreV1().ConfigMaps(s.namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil && !(errors.IsNotFound(err) && len(oldVal) == 0) {
+		return err
+	}
+	// Treat non-existing config map as empty to allow initial set.
+	if errors.IsNotFound(err) {
+		cm = s.newEntry(cmName, key, newVal)
+		_, err := s.client.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{})
+		return err
+	}
+	current, ok := cm.BinaryData[filepath.Base(key)]
+	if !ok {
+		return fmt.Errorf("key %q not found", key)
+	}
+	if !bytes.Equal(current, oldVal) {
+		return fmt.Errorf("object %q has changed since last read", key)
+	}
+	cm.BinaryData[filepath.Base(key)] = newVal
+	_, err = s.client.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+// Watch watches for changes to the value of key.
+func (s *ConfigMapStore) Watch(key string) (<-chan []byte, func(), error) {
+	cmName, err := objectName(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	watcher, err := s.client.CoreV1().ConfigMaps(s.namespace).Watch(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set(map[string]string{"app.kubernetes.io/managed-by": "contrast.edgeless.systems"}).AsSelector().String(),
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", cmName).String(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan []byte)
+
+	go func() {
+		defer watcher.Stop()
+		defer close(result)
+
+		s.logger.Debug("watch started", "key", key)
+		for {
+			select {
+			case <-ctx.Done():
+				s.logger.Debug("watch canceled", "key", key)
+				return
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					s.logger.Debug("watch channel closed", "key", key)
+					return
+				}
+				switch event.Type {
+				case watch.Error:
+					s.logger.Error("watch error", "key", key, "error", event.Object)
+					return
+				case watch.Added, watch.Modified:
+					cm, ok := event.Object.(*corev1.ConfigMap)
+					if !ok {
+						s.logger.Error("unexpected object type", "key", key, "object", event.Object)
+						continue
+					}
+					result <- cm.BinaryData[filepath.Base(key)]
+				}
+			}
+		}
+	}()
+
+	return result, cancel, nil
+}
+
+func (s *ConfigMapStore) newEntry(cmName, key string, value []byte) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: s.namespace,
+			Labels:    map[string]string{"app.kubernetes.io/managed-by": "contrast.edgeless.systems"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "coordinator",
+					UID:        s.uid,
+				},
+			},
+		},
+		BinaryData: map[string][]byte{filepath.Base(key): value},
+	}
+}
+
+func objectName(key string) (string, error) {
+	if !keyRe.MatchString(key) {
+		return "", fmt.Errorf("invalid key %q", key)
+	}
+	return fmt.Sprintf("contrast-store-%s", strings.ReplaceAll(key, "/", "-")), nil
+}

--- a/enterprise/coordinator/history/configmapstore_test.go
+++ b/enterprise/coordinator/history/configmapstore_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build enterprise
+
+package history
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func coordinatorPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "coordinator-0",
+			Namespace: "test",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind: "StatefulSet",
+					Name: "coordinator",
+					UID:  "00000000-0000-0000-0000-000000000000",
+				},
+			},
+		},
+	}
+}
+
+func TestGetSet(t *testing.T) {
+	require := require.New(t)
+
+	t.Setenv("HOSTNAME", "coordinator-0")
+	s, err := NewConfigMapStore(fake.NewSimpleClientset(coordinatorPod()), "test", slog.Default())
+	require.NoError(err)
+
+	key := "foo/bar"
+	val1 := []byte("val1")
+	val2 := []byte("val2")
+
+	_, err = s.Get("invalid-key")
+	require.ErrorContains(err, "invalid key")
+
+	x, err := s.Get(key)
+	require.True(errors.IsNotFound(err))
+	require.Empty(x)
+
+	require.NoError(s.Set(key, val1))
+
+	y, err := s.Get(key)
+	require.NoError(err)
+	require.Equal(val1, y)
+
+	require.ErrorContains(s.Set("invalid-key", nil), "invalid key")
+
+	require.NoError(s.Set(key, val2))
+
+	z, err := s.Get(key)
+	require.NoError(err)
+	require.Equal(val2, z)
+}
+
+func TestHas(t *testing.T) {
+	require := require.New(t)
+
+	t.Setenv("HOSTNAME", "coordinator-0")
+	s, err := NewConfigMapStore(fake.NewSimpleClientset(coordinatorPod()), "test", slog.Default())
+	require.NoError(err)
+
+	key := "foo/bar"
+	val := []byte("val")
+
+	require.False(s.Has(key))
+
+	require.NoError(s.Set(key, val))
+
+	require.True(s.Has(key))
+}
+
+func TestCompareAndSwap(t *testing.T) {
+	require := require.New(t)
+
+	t.Setenv("HOSTNAME", "coordinator-0")
+	s, err := NewConfigMapStore(fake.NewSimpleClientset(coordinatorPod()), "test", slog.Default())
+	require.NoError(err)
+
+	key := "foo/bar"
+	val1 := []byte("val1")
+	val2 := []byte("val2")
+
+	x, err := s.Get(key)
+	require.True(errors.IsNotFound(err))
+	require.Empty(x)
+
+	require.ErrorContains(s.CompareAndSwap("invalid-key", nil, nil), "invalid key")
+	require.Error(s.CompareAndSwap(key, val1, val2))
+
+	require.NoError(s.CompareAndSwap(key, nil, val1))
+
+	y, err := s.Get(key)
+	require.NoError(err)
+	require.Equal(val1, y)
+
+	require.Error(s.CompareAndSwap(key, nil, val1))
+
+	require.NoError(s.CompareAndSwap(key, val1, val2))
+
+	z, err := s.Get(key)
+	require.NoError(err)
+	require.Equal(val2, z)
+}
+
+func TestWatch(t *testing.T) {
+	require := require.New(t)
+
+	t.Setenv("HOSTNAME", "coordinator-0")
+	s, err := NewConfigMapStore(fake.NewSimpleClientset(coordinatorPod()), "test", slog.Default())
+	require.NoError(err)
+
+	key := "foo/bar"
+	val1 := []byte("val1")
+	val2 := []byte("val2")
+
+	_, _, err = s.Watch("invalid-key")
+	require.ErrorContains(err, "invalid key")
+
+	ch, cancel, err := s.Watch(key)
+	require.NoError(err)
+	defer cancel()
+
+	require.NoError(s.Set(key, val1))
+	require.Equal(val1, <-ch)
+	require.NoError(s.Set(key, val2))
+	require.Equal(val2, <-ch)
+}
+
+func TestObjectName(t *testing.T) {
+	testCases := map[string]struct {
+		key     string
+		name    string
+		wantErr bool
+	}{
+		"default": {
+			key:     "foo/bar",
+			name:    "contrast-store-foo-bar",
+			wantErr: false,
+		},
+		"invalid format": {
+			key:     "foo/bar/baz",
+			wantErr: true,
+		},
+		"invalid chars": {
+			key:     "***/***",
+			wantErr: true,
+		},
+		"empty key": {
+			key:     "",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			name, err := objectName(tc.key)
+			if tc.wantErr {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+				require.Equal(tc.name, name)
+			}
+		})
+	}
+}

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -384,6 +384,13 @@ func PatchNamespaces(resources []any, namespace string) []any {
 			r.Namespace = nsPtr
 		case *applycorev1.ServiceAccountApplyConfiguration:
 			r.Namespace = nsPtr
+		case *applyrbacv1.RoleApplyConfiguration:
+			r.Namespace = nsPtr
+		case *applyrbacv1.RoleBindingApplyConfiguration:
+			r.Namespace = nsPtr
+			for i := range len(r.Subjects) {
+				r.Subjects[i].Namespace = nsPtr
+			}
 		case *applyrbacv1.ClusterRoleBindingApplyConfiguration:
 			if namespace != "" {
 				*r.Name = fmt.Sprintf("%s-%s", *r.Name, *nsPtr)

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -17,16 +17,17 @@ import (
 
 // CoordinatorBundle returns the Coordinator and a matching Service.
 func CoordinatorBundle() []any {
-	coordinatorSfSets := Coordinator("").StatefulSetApplyConfiguration
-	coordinatorService := ServiceForStatefulSet(coordinatorSfSets).
+	coordinator := Coordinator("")
+	coordinatorService := ServiceForStatefulSet(coordinator.StatefulSetApplyConfiguration).
 		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"})
 
-	resources := []any{
-		coordinatorSfSets,
+	return []any{
+		coordinator.StatefulSetApplyConfiguration,
+		coordinator.ServiceAccountApplyConfiguration,
+		coordinator.RoleApplyConfiguration,
+		coordinator.RoleBindingApplyConfiguration,
 		coordinatorService,
 	}
-
-	return resources
 }
 
 // Runtime returns a set of resources for registering and installing the runtime.

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -11,6 +11,7 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	applynodev1 "k8s.io/client-go/applyconfigurations/node/v1"
+	applyrbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 )
 
 // DeploymentConfig wraps applyappsv1.DeploymentApplyConfiguration.
@@ -322,6 +323,34 @@ func ServiceAccount(name, namespace string) *ServiceAccountConfig {
 		s.ObjectMetaApplyConfiguration.Namespace = nil
 	}
 	return s
+}
+
+// RoleConfig wraps applyrbacv1.RoleApplyConfiguration.
+type RoleConfig struct {
+	*applyrbacv1.RoleApplyConfiguration
+}
+
+// Role creates a new RoleConfig.
+func Role(name, namespace string) *RoleConfig {
+	r := &RoleConfig{applyrbacv1.Role(name, namespace)}
+	if namespace == "" && r.ObjectMetaApplyConfiguration != nil {
+		r.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return r
+}
+
+// RoleBindingConfig wraps applyrbacv1.RoleBindingApplyConfiguration.
+type RoleBindingConfig struct {
+	*applyrbacv1.RoleBindingApplyConfiguration
+}
+
+// RoleBinding creates a new RoleBindingConfig.
+func RoleBinding(name, namespace string) *RoleBindingConfig {
+	r := &RoleBindingConfig{applyrbacv1.RoleBinding(name, namespace)}
+	if namespace == "" && r.ObjectMetaApplyConfiguration != nil {
+		r.ObjectMetaApplyConfiguration.Namespace = nil
+	}
+	return r
 }
 
 // NamespaceConfig wraps applycorev1.NamespaceApplyConfiguration.

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -254,6 +254,7 @@ buildGoModule rec {
   checkPhase = ''
     runHook preCheck
     go test -tags=contrast_unstable_api -race ./...
+    go test -tags=contrast_unstable_api,enterprise -race ./...
     runHook postCheck
   '';
 

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -167,6 +167,7 @@
       while IFS= read -r dir; do
         echo "Running golangci-lint on $dir" >&2
         golangci-lint run "$dir/..." || exitcode=$?
+        golangci-lint run --build-tags enterprise "$dir/..." || exitcode=$?
       done < <(go list -f '{{.Dir}}' -m)
 
       echo "Verifying golangci-lint config" >&2


### PR DESCRIPTION
This implements the Store interface using Kubernetes Config Maps in preparation for the distributed Coordinator. For now, this can be tested by manually setting the `enterprise` build tag during the build process.