### PR TITLE
atls: add handshake timeout to aTLS servers and clients

### DIFF
--- a/coordinator/internal/authority/userapi.go
+++ b/coordinator/internal/authority/userapi.go
@@ -301,7 +301,7 @@ func getPeerPublicKey(ctx context.Context) ([]byte, error) {
 	}
 	tlsInfo, ok := peer.AuthInfo.(credentials.TLSInfo)
 	if !ok {
-		return nil, errors.New("peer auth info is not of type TLSInfo")
+		return nil, fmt.Errorf("peer auth info is not of type TLSInfo: got %T", peer.AuthInfo)
 	}
 	if len(tlsInfo.State.PeerCertificates) == 0 || tlsInfo.State.PeerCertificates[0] == nil {
 		return nil, errors.New("no peer certificates found")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -3,7 +3,11 @@
 
 package constants
 
-import "github.com/google/go-sev-guest/abi"
+import (
+	"time"
+
+	"github.com/google/go-sev-guest/abi"
+)
 
 // Version value is injected at build time.
 var (
@@ -26,3 +30,14 @@ var SNPPolicy = abi.SnpPolicy{
 	SMT:   true,
 	Debug: false,
 }
+
+const (
+	// ATLSClientTimeout is the maximal amount of time spent by Coordinator clients for issuing
+	// and validation of attestation docs.
+	ATLSClientTimeout = 30 * time.Second
+
+	// ATLSServerTimeout is the maximal amount of time that the Coordinator can spend for issuing
+	// attestation docs. It's deliberately smaller than ATLSClientTimeout to allow proper error
+	// propagation.
+	ATLSServerTimeout = ATLSClientTimeout - 5*time.Second
+)

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -8,9 +8,9 @@ import (
 	"context"
 	"crypto"
 	"net"
-	"time"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
@@ -57,7 +57,7 @@ func (d *Dialer) Dial(_ context.Context, target string) (*grpc.ClientConn, error
 		grpc.WithConnectParams(grpc.ConnectParams{
 			// We need a high initial timeout, because otherwise the client will get stuck in a reconnect loop
 			// where the timeout is too low to get a full handshake done.
-			MinConnectTimeout: 30 * time.Second,
+			MinConnectTimeout: constants.ATLSClientTimeout,
 		}),
 	)
 }


### PR DESCRIPTION
This is factored out from #1244. We want to explicitly configure timeouts on the server side that are smaller than on the client side, otherwise the client will only ever see a connection timeout, which can mean a lot of things. If the server times out, the client will now receive a TLS error 80, which can then be diagnosed with the documentation from #1245. 

Contrary to the documentation, I found that `MinConnectionTimeout` is rather a `ConnectionTimeout` that will be applied to the TCP+TLS connection. 