### PR TITLE
ci: require "snp-gpu" tag for SNP-GPU platform

### DIFF
--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -20,13 +20,13 @@ jobs:
             runner: TDX
             self-hosted: true
           - name: K3s-QEMU-SNP-GPU
-            runner: SNP
+            runner: SNP-GPU
             self-hosted: true
         test-name: [servicemesh, openssl, policy, workloadsecret, volumestatefulset]
         include:
           - platform:
               name: K3s-QEMU-SNP-GPU
-              runner: SNP
+              runner: SNP-GPU
               self-hosted: true
             test-name: gpu
       fail-fast: false


### PR DESCRIPTION
After the addition of hetzner-ax162-snp, we have a SNP runner which doesn't have a GPU. Therefore introduce a new tag (discovery is already tagged with "snp-gpu") and use it as requirement for the runner.