### PR TITLE
docs: point directly to Longhorn installation docs

### DIFF
--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -31,7 +31,7 @@ Increase the `user.max_inotify_instances` sysctl limit by adding `user.max_inoti
 ## K3s setup
 
 1. Follow the [K3s setup instructions](https://docs.k3s.io/) to create a cluster.
-2. Install a block storage provider such as [Longhorn](https://docs.k3s.io/storage#setting-up-longhorn) and mark it as the default storage class.
+2. Install a block storage provider such as [Longhorn](https://longhorn.io/docs/1.8.0/deploy/install/install-with-kubectl/) and mark it as the default storage class.
 
 ## Preparing a cluster for GPU usage
 


### PR DESCRIPTION
The instructions on the k3s page still point to Longhorn 1.6.0, which is a year old at this point.