### PR TITLE
coordinator: add issuer to meshapi

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -80,7 +80,10 @@ func run() (retErr error) {
 
 	userapi.RegisterUserAPIServer(grpcServer, meshAuth)
 	serverMetrics.InitializeMetrics(grpcServer)
-	meshAPI := newMeshAPIServer(meshAuth, promRegistry, serverMetrics, logger)
+	meshAPI, err := newMeshAPIServer(meshAuth, promRegistry, serverMetrics, logger)
+	if err != nil {
+		return fmt.Errorf("creating mesh API server: %w", err)
+	}
 	metricsServer := &http.Server{}
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
This adds an issuer to the mesh API. The only current use of the mesh API is the Initializer, which doesn't validate the Coordinator's provided attestation document. This will be used for peer recovery in distributed Coordinator.