### PR TITLE
e2e: increase timeout for scaling deployment in workloadsecrettest

### DIFF
--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -70,7 +70,7 @@ func TestWorkloadSecrets(t *testing.T) {
 	require.True(t, t.Run("scale web deployment to 2 pods", func(t *testing.T) {
 		require := require.New(t)
 
-		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(30*time.Second))
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(time.Minute))
 		defer cancel()
 
 		require.NoError(ct.Kubeclient.ScaleDeployment(ctx, ct.Namespace, "web", 2))


### PR DESCRIPTION
This test has been failing frequently on bare metal because the pod takes longer than a minute to start up, which is probably due to slow guest pulls. Increasing the bare timeout to a minute results in a 2 minute timeout after scaling.