### PR TITLE
[release/v1.5] nodeinstaller: support containerd config v3

### DIFF
--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -41,8 +41,25 @@ var (
 	RuntimeNamePlaceholder = "@@runtimeName@@"
 )
 
-// CRIFQDN is the fully qualified domain name of the CRI service.
-const CRIFQDN = "io.containerd.grpc.v1.cri"
+// CRIFQDN is the fully qualified domain name of the CRI service, which depends on the containerd config version.
+func CRIFQDN(v int) string {
+	switch v {
+	case 3:
+		return "io.containerd.cri.v1.runtime"
+	default:
+		return "io.containerd.grpc.v1.cri"
+	}
+}
+
+// ImagesFQDN is the fully qualified domain name of the images plugin, which was factored out of the CRI plugin in containerd v2.
+func ImagesFQDN(v int) string {
+	switch v {
+	case 3:
+		return "io.containerd.cri.v1.images"
+	default:
+		return "io.containerd.grpc.v1.cri"
+	}
+}
 
 // KataRuntimeConfig returns the Kata runtime configuration.
 func KataRuntimeConfig(baseDir string, platform platforms.Platform, qemuExtraKernelParams string, debug bool) (*config.KataRuntimeConfig, error) {

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -222,7 +222,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 		socketName = fmt.Sprintf("/run/containerd/containerd-nydus-grpc-%s.sock", runtimeHandler)
 
 		// Configure the containerd plugin
-		containerdPlugin := ensureMapPath(&existing.Plugins, constants.CRIFQDN, "containerd")
+		containerdPlugin := ensureMapPath(&existing.Plugins, constants.ImagesFQDN(existing.Version), "containerd")
 		containerdPlugin["discard_unpacked_layers"] = false
 		containerdPlugin["disable_snapshot_annotations"] = false
 	}
@@ -234,7 +234,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	}
 
 	// Add contrast-cc runtime
-	runtimes := ensureMapPath(&existing.Plugins, constants.CRIFQDN, "containerd", "runtimes")
+	runtimes := ensureMapPath(&existing.Plugins, constants.CRIFQDN(existing.Version), "containerd", "runtimes")
 	containerdRuntimeConfig, err := constants.ContainerdRuntimeConfigFragment(basePath, snapshotterName, platform)
 	if err != nil {
 		return fmt.Errorf("generating containerd runtime config: %w", err)


### PR DESCRIPTION
Backport of #1276 to `release/v1.5`.

Original description:

---

Some config keys moved between versions 2 and 3, so we need to switch based on the version we find.

Tested on a new Hetzner SNP machine with

```console
# k3s --version
k3s version v1.31.6+k3s1 (6ab750f9)
go version go1.22.12
```

Fixes #1264 