### PR TITLE
manifest: join validation errors and return late

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/google/go-sev-guest/abi"
@@ -41,18 +42,18 @@ type PolicyEntry struct {
 
 // Validate checks the validity of a policy entry given its policy hash.
 func (e PolicyEntry) Validate(policyHash HexString) error {
+	var errs []error
 	if _, err := policyHash.Bytes(); err != nil {
-		return fmt.Errorf("decoding policy hash %q: %w", policyHash, err)
-	}
-	if len(policyHash) != hex.EncodedLen(sha256.Size) {
-		return fmt.Errorf("policy hash %s has invalid length: %d (expected %d)", policyHash, len(policyHash), hex.EncodedLen(sha256.Size))
+		errs = append(errs, fmt.Errorf("decoding policy hash %q: %w", policyHash, err))
+	} else if len(policyHash) != hex.EncodedLen(sha256.Size) {
+		errs = append(errs, fmt.Errorf("invalid policy hash length: %d (expected %d)", len(policyHash), hex.EncodedLen(sha256.Size)))
 	}
 
 	if err := e.Role.Validate(); err != nil {
-		return fmt.Errorf("validating role %s: %w", e.Role, err)
+		errs = append(errs, newValidationError("Role", err))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // HexStrings is a slice of HexString.
@@ -112,22 +113,23 @@ func (r Role) Validate() error {
 
 // Validate checks the validity of all fields in the reference values.
 func (r ReferenceValues) Validate() error {
-	for _, v := range r.SNP {
+	var errs []error
+	for i, v := range r.SNP {
 		if err := v.Validate(); err != nil {
-			return fmt.Errorf("validating SNP reference values: %w", err)
+			errs = append(errs, newValidationError(fmt.Sprintf("snp[%d]", i), err))
 		}
 	}
-	for _, v := range r.TDX {
+	for i, v := range r.TDX {
 		if err := v.Validate(); err != nil {
-			return fmt.Errorf("validating TDX reference values: %w", err)
+			errs = append(errs, newValidationError(fmt.Sprintf("tdx[%d]", i), err))
 		}
 	}
 
 	if len(r.SNP)+len(r.TDX) == 0 {
-		return fmt.Errorf("reference values in manifest cannot be empty. Is the chosen platform supported?")
+		errs = append(errs, fmt.Errorf("reference values in manifest cannot be empty. Is the chosen platform supported?"))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func validateHexString(value HexString, expectedNumBytes int) error {
@@ -140,87 +142,157 @@ func validateHexString(value HexString, expectedNumBytes int) error {
 
 // Validate checks the validity of all fields in the AKS reference values.
 func (r SNPReferenceValues) Validate() error {
+	var minTCBErrs []error
 	if r.MinimumTCB.BootloaderVersion == nil {
-		return fmt.Errorf("field BootloaderVersion in manifest cannot be empty")
-	} else if r.MinimumTCB.TEEVersion == nil {
-		return fmt.Errorf("field TEEVersion in manifest cannot be empty")
-	} else if r.MinimumTCB.SNPVersion == nil {
-		return fmt.Errorf("field SNPVersion in manifest cannot be empty")
-	} else if r.MinimumTCB.MicrocodeVersion == nil {
-		return fmt.Errorf("field MicrocodeVersion in manifest cannot be empty")
+		minTCBErrs = append(minTCBErrs, newValidationError("BootloaderVersion", fmt.Errorf("field cannot be empty")))
 	}
+	if r.MinimumTCB.TEEVersion == nil {
+		minTCBErrs = append(minTCBErrs, newValidationError("TEEVersion", fmt.Errorf("field cannot be empty")))
+	}
+	if r.MinimumTCB.SNPVersion == nil {
+		minTCBErrs = append(minTCBErrs, newValidationError("SNPVersion", fmt.Errorf("field cannot be empty")))
+	}
+	if r.MinimumTCB.MicrocodeVersion == nil {
+		minTCBErrs = append(minTCBErrs, newValidationError("MicrocodeVersion", fmt.Errorf("field cannot be empty")))
+	}
+
+	errs := []error{newValidationError("MinimumTCB", minTCBErrs...)}
 
 	switch r.ProductName {
 	case Milan, Genoa:
 		// These are valid. We don't need to report an error.
 	default:
-		return fmt.Errorf("unknown product name: %s", r.ProductName)
+		errs = append(errs, newValidationError("ProductName", fmt.Errorf("unknown product name: %s", r.ProductName)))
 	}
 
 	if err := validateHexString(r.TrustedMeasurement, abi.MeasurementSize); err != nil {
-		return fmt.Errorf("trusted measurement is invalid: %w", err)
+		errs = append(errs, newValidationError("TrustedMeasurement", err))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // Validate checks the validity of all fields in the bare metal TDX reference values.
 func (r TDXReferenceValues) Validate() error {
+	var errs []error
 	if err := validateHexString(r.MrTd, 48); err != nil {
-		return fmt.Errorf("MrTd is invalid: %w", err)
+		errs = append(errs, newValidationError("MrTd", err))
 	}
 	if r.MinimumQeSvn == nil {
-		return fmt.Errorf("MinimumQeSvn is not set")
+		errs = append(errs, newValidationError("MinimumQeSvn", fmt.Errorf("field cannot be empty")))
 	}
 	if r.MinimumPceSvn == nil {
-		return fmt.Errorf("MinimumPceSvn is not set")
+		errs = append(errs, newValidationError("MinimumPceSvn", fmt.Errorf("field cannot be empty")))
 	}
 	if err := validateHexString(r.MinimumTeeTcbSvn, 16); err != nil {
-		return fmt.Errorf("MinimumTeeTcbSvn is invalid: %w", err)
+		errs = append(errs, newValidationError("MinimumTeeTcbSvn", err))
 	}
 	if err := validateHexString(r.MrSeam, 48); err != nil {
-		return fmt.Errorf("MrSeam is invalid: %w", err)
+		errs = append(errs, newValidationError("MrSeam", err))
 	}
 	if err := validateHexString(r.TdAttributes, 8); err != nil {
-		return fmt.Errorf("TdAttributes is invalid: %w", err)
+		errs = append(errs, newValidationError("TdAttributes", err))
 	}
 	if err := validateHexString(r.Xfam, 8); err != nil {
-		return fmt.Errorf("Xfam is invalid: %w", err)
+		errs = append(errs, newValidationError("Xfam", err))
 	}
 	for i, rtmr := range r.Rtrms {
 		if err := validateHexString(rtmr, 48); err != nil {
-			return fmt.Errorf("Rtmr[%d] is invalid: %w", i, err)
+			errs = append(errs, newValidationError(fmt.Sprintf("Rtrms[%d]", i), err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // Validate checks the validity of all fields in the manifest.
 func (m *Manifest) Validate() error {
+	var errs []error
 	for policyHash, policy := range m.Policies {
 		if err := policy.Validate(policyHash); err != nil {
-			return fmt.Errorf("validating policy %s: %w", policyHash, err)
+			errs = append(errs, newValidationError(fmt.Sprintf("Policies[%q]", policyHash), err))
 		}
 	}
 
 	if err := m.ReferenceValues.Validate(); err != nil {
-		return fmt.Errorf("validating reference values: %w", err)
+		errs = append(errs, newValidationError("ReferenceValues", err))
 	}
 
-	for _, keyDigest := range m.WorkloadOwnerKeyDigests {
+	for i, keyDigest := range m.WorkloadOwnerKeyDigests {
 		if _, err := keyDigest.Bytes(); err != nil {
-			return fmt.Errorf("decoding key digest %s: %w", keyDigest, err)
+			errs = append(errs, newValidationError(fmt.Sprintf("WorkloadOwnerKeyDigests[%d]", i), err))
 		} else if len(keyDigest) != hex.EncodedLen(sha256.Size) {
-			return fmt.Errorf("workload owner key digest %s has invalid length: %d (expected %d)", keyDigest, len(keyDigest), hex.EncodedLen(sha256.Size))
+			errs = append(errs, newValidationError(fmt.Sprintf("WorkloadOwnerKeyDigests[%d]", i), fmt.Errorf("invalid length: %d (expected %d)", len(keyDigest), hex.EncodedLen(sha256.Size))))
 		}
 	}
 
-	for _, key := range m.SeedshareOwnerPubKeys {
+	for i, key := range m.SeedshareOwnerPubKeys {
 		if _, err := ParseSeedShareOwnerKey(key); err != nil {
-			return fmt.Errorf("invalid seed share owner public key %s: %w", key, err)
+			errs = append(errs, newValidationError(fmt.Sprintf("SeedshareOwnerPubKeys[%d]", i), err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
+}
+
+// validationError contains a JSON path and a list of errors.
+// Nested validation errors are printed on newlines with the full path.
+type validationError struct {
+	path string
+	errs []error
+}
+
+func newValidationError(path string, errs ...error) error {
+	e := &validationError{
+		path: path,
+		errs: make([]error, 0, len(errs)),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, flatten(err)...)
+		}
+	}
+	if len(e.errs) == 0 {
+		return nil
+	}
+	return e
+}
+
+func (e *validationError) Error() string {
+	return e.formatError(e.path)
+}
+
+func (e *validationError) Unwrap() []error {
+	return e.errs
+}
+
+func (e *validationError) formatError(path string) string {
+	var sb strings.Builder
+	for i, err := range e.errs {
+		var ve *validationError
+		if errors.As(err, &ve) {
+			sb.WriteString(ve.formatError(path + "." + ve.path))
+		} else {
+			sb.WriteString(path)
+			sb.WriteString(": ")
+			sb.WriteString(err.Error())
+		}
+		if i < len(e.errs)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+func flatten(err error) (errs []error) {
+	if ve, ok := err.(*validationError); ok { //nolint:errorlint // check for exact type
+		return []error{ve}
+	}
+	if wrapped, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, err := range wrapped.Unwrap() {
+			errs = append(errs, flatten(err)...)
+		}
+		return errs
+	}
+	return []error{err}
 }
 
 // TODO(msanft): add generic validation interface for other attestation types.


### PR DESCRIPTION
The manifest validation errors are joined by `errors.Join` to return all failures during validation, not just the first. The error is then printed in a tree-like structure by the new `validationError` error type.