### PR TITLE
coordinator: print run error in main

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -38,6 +38,7 @@ const (
 
 func main() {
 	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: running coordinator: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -136,7 +137,7 @@ func run() (retErr error) {
 
 	eg.Go(func() error {
 		<-ctx.Done()
-		logger.Info("Error detected, shutting down")
+		logger.Error("Error detected, shutting down")
 		grpcServer.GracefulStop()
 		meshAPI.grpc.GracefulStop()
 		//nolint:contextcheck // fresh context for cleanup


### PR DESCRIPTION
Yesterday evening the coordinator crashed in Privatemode's production deployment. However, the only log we are seeing is `Error detected, shutting down`. This is because the errors collected with the errgroup are only returned by the call to `Wait()` and `run`'s error is never printed. This PR should fix that.

Please let me know if you think other places should be touched as well.

In case you want to dig through the OpenSearch logs:
- [this](https://search-e2e-logs-y46renozy42lcojbvrt3qq7csm.eu-central-1.es.amazonaws.com/_dashboards/app/discover/#/doc/308385c0-b09b-11ef-a730-7138182413c7/continuum-k8s-logs-2025.10?id=GjD1gJUBhc9VUFOP1lgJ) is the crashing log statement
- [this](https://search-e2e-logs-y46renozy42lcojbvrt3qq7csm.eu-central-1.es.amazonaws.com/_dashboards/goto/8a0b84baf06abeafeb24448cc388cf6f?security_tenant=global) is a filter that shows you surrounding log messages