### PR TITLE
coordinator: add startup, liveness and readiness probes

### DIFF
--- a/coordinator/internal/probes/probes.go
+++ b/coordinator/internal/probes/probes.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package probes
+
+import (
+	"net/http"
+
+	"github.com/edgelesssys/contrast/coordinator/history"
+	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+)
+
+// StartupHandler is the http handler for `/probes/startup`.
+type StartupHandler struct {
+	UserapiStarted bool
+	MeshapiStarted bool
+}
+
+func (h StartupHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if !h.UserapiStarted || !h.MeshapiStarted {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	// TODO(miampf): Check if peer recovery was attempted once
+	w.WriteHeader(http.StatusOK)
+}
+
+// LivenessHandler is the http handler for `/probes/liveness`.
+type LivenessHandler struct {
+	Hist *history.History
+}
+
+func (h LivenessHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	_, err := h.Hist.HasLatest()
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// ReadinessHandler is the http handler for `/probes/readiness`.
+type ReadinessHandler struct {
+	Authority auth
+}
+
+func (h ReadinessHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	state, err := h.Authority.GetState()
+	if err != nil || state == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+	// TODO(miampf): Check that coordinator isn't in recovery mode
+	w.WriteHeader(http.StatusOK)
+}
+
+type auth interface {
+	GetState() (*authority.State, error)
+}

--- a/coordinator/internal/probes/probes_test.go
+++ b/coordinator/internal/probes/probes_test.go
@@ -1,0 +1,251 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package probes
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgelesssys/contrast/coordinator/history"
+	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartupProbe(t *testing.T) {
+	testCases := map[string]struct {
+		userapiStartedFirst  bool
+		meshapiStartedFirst  bool
+		userapiStartedSecond bool
+		meshapiStartedSecond bool
+		want503First         bool
+		want503Second        bool
+	}{
+		"all immediately online": {
+			userapiStartedFirst:  true,
+			meshapiStartedFirst:  true,
+			userapiStartedSecond: true,
+			meshapiStartedSecond: true,
+			want503First:         false,
+			want503Second:        false,
+		},
+		"userapi never starts": {
+			userapiStartedFirst:  false,
+			meshapiStartedFirst:  true,
+			userapiStartedSecond: false,
+			meshapiStartedSecond: true,
+			want503First:         true,
+			want503Second:        true,
+		},
+		"meshapi never starts": {
+			userapiStartedFirst:  true,
+			meshapiStartedFirst:  false,
+			userapiStartedSecond: true,
+			meshapiStartedSecond: false,
+			want503First:         true,
+			want503Second:        true,
+		},
+		"userapi starts later": {
+			userapiStartedFirst:  false,
+			meshapiStartedFirst:  true,
+			userapiStartedSecond: true,
+			meshapiStartedSecond: true,
+			want503First:         true,
+			want503Second:        false,
+		},
+		"meshapi starts later": {
+			userapiStartedFirst:  true,
+			meshapiStartedFirst:  false,
+			userapiStartedSecond: true,
+			meshapiStartedSecond: true,
+			want503First:         true,
+			want503Second:        false,
+		},
+		"both start later": {
+			userapiStartedFirst:  false,
+			meshapiStartedFirst:  false,
+			userapiStartedSecond: true,
+			meshapiStartedSecond: true,
+			want503First:         true,
+			want503Second:        false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/probes/startup", nil)
+			resp := httptest.NewRecorder()
+
+			mux := http.NewServeMux()
+
+			handler := StartupHandler{MeshapiStarted: tc.meshapiStartedFirst, UserapiStarted: tc.userapiStartedFirst}
+
+			userapiStarted := &handler.UserapiStarted
+			meshapiStarted := &handler.MeshapiStarted
+
+			mux.Handle("/probes/startup", &handler)
+
+			mux.ServeHTTP(resp, req)
+
+			if tc.want503First {
+				assert.Equal(http.StatusServiceUnavailable, resp.Code)
+			} else {
+				assert.Equal(http.StatusOK, resp.Code)
+			}
+
+			resp = httptest.NewRecorder()
+			*userapiStarted = tc.userapiStartedSecond
+			*meshapiStarted = tc.meshapiStartedSecond
+
+			mux.ServeHTTP(resp, req)
+
+			if tc.want503Second {
+				assert.Equal(http.StatusServiceUnavailable, resp.Code)
+			} else {
+				assert.Equal(http.StatusOK, resp.Code)
+			}
+		})
+	}
+}
+
+func TestLivenessProbe(t *testing.T) {
+	testCases := map[string]struct {
+		hasLatest bool
+		err       error
+		want503   bool
+	}{
+		"store accessible but empty": {
+			want503: false,
+		},
+		"store inaccessible": {
+			err:     assert.AnError,
+			want503: true,
+		},
+		"transition exists": {
+			hasLatest: true,
+			want503:   false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/probes/liveness", nil)
+			resp := httptest.NewRecorder()
+
+			mux := http.NewServeMux()
+
+			store := mockStore{
+				hasLatest:      tc.hasLatest,
+				hasLatestError: tc.err,
+			}
+
+			hist := history.NewWithStore(&slog.Logger{}, store)
+
+			handler := LivenessHandler{Hist: hist}
+			mux.Handle("/probes/liveness", handler)
+
+			mux.ServeHTTP(resp, req)
+			if tc.want503 {
+				assert.Equal(http.StatusServiceUnavailable, resp.Code)
+			} else {
+				assert.Equal(http.StatusOK, resp.Code)
+			}
+		})
+	}
+}
+
+func TestReadinessProbe(t *testing.T) {
+	testCases := map[string]struct {
+		hasActiveManifest bool
+		getStateFails     bool
+		want503           bool
+	}{
+		"manifest exists": {
+			hasActiveManifest: true,
+			want503:           false,
+		},
+		"manifest doesn't exist": {
+			hasActiveManifest: false,
+			want503:           true,
+		},
+		"get state fails while manifest exists": {
+			hasActiveManifest: true,
+			getStateFails:     true,
+			want503:           true,
+		},
+		"get state fails while no manifest exists": {
+			hasActiveManifest: false,
+			getStateFails:     true,
+			want503:           true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			req := httptest.NewRequest(http.MethodGet, "/probes/readiness", nil)
+			resp := httptest.NewRecorder()
+
+			auth := mockAuth{hasState: tc.hasActiveManifest, fails: tc.getStateFails}
+
+			mux := http.NewServeMux()
+
+			handler := ReadinessHandler{Authority: auth}
+			mux.Handle("/probes/readiness", handler)
+
+			mux.ServeHTTP(resp, req)
+			if tc.want503 {
+				assert.Equal(http.StatusServiceUnavailable, resp.Code)
+			} else {
+				assert.Equal(http.StatusOK, resp.Code)
+			}
+		})
+	}
+}
+
+type mockAuth struct {
+	hasState bool
+	fails    bool
+}
+
+func (a mockAuth) GetState() (*authority.State, error) {
+	if a.fails {
+		return nil, assert.AnError
+	}
+	if !a.hasState {
+		return nil, nil
+	}
+	return &authority.State{}, nil
+}
+
+type mockStore struct {
+	hasLatest      bool
+	hasLatestError error
+}
+
+func (s mockStore) Get(_ string) ([]byte, error) {
+	return nil, nil
+}
+
+func (s mockStore) Set(_ string, _ []byte) error {
+	return nil
+}
+
+func (s mockStore) Has(_ string) (bool, error) {
+	return s.hasLatest, s.hasLatestError
+}
+
+func (s mockStore) CompareAndSwap(_ string, _, _ []byte) error {
+	return nil
+}
+
+func (s mockStore) Watch(_ string) (_ <-chan []byte, _ func(), _ error) {
+	return nil, nil, nil
+}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"internal/itoa"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -19,6 +19,7 @@ import (
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
 	meshapiserver "github.com/edgelesssys/contrast/coordinator/internal/meshapi"
+	"github.com/edgelesssys/contrast/coordinator/internal/probes"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
@@ -95,14 +96,20 @@ func run() (retErr error) {
 
 	httpServer := &http.Server{}
 
+	startupHandler := probes.StartupHandler{UserapiStarted: false, MeshapiStarted: false}
+	livenessHandler := probes.LivenessHandler{Hist: hist}
+	readinessHandler := probes.ReadinessHandler{Authority: meshAuth}
+
+	userapiStarted := &startupHandler.UserapiStarted
+	meshapiStarted := &startupHandler.MeshapiStarted
+
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
 		_, enableMetrics := os.LookupEnv(metricsEnvVar)
-		// TODO(miampf): add /probe/{startup,liveness,readiness} endpoints
 		mux := http.NewServeMux()
 		if enableMetrics {
-			logger.Info("Starting prometheus /metrics endpoint on port " + itoa.Itoa(probeAndMetricsPort))
+			logger.Info("Starting prometheus /metrics endpoint on port " + strconv.Itoa(probeAndMetricsPort))
 			mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
 				promRegistry, promhttp.HandlerFor(
 					promRegistry,
@@ -110,7 +117,10 @@ func run() (retErr error) {
 				),
 			))
 		}
-		httpServer.Addr = ":" + itoa.Itoa(probeAndMetricsPort)
+		mux.Handle("/probe/startup", &startupHandler)
+		mux.Handle("/probe/liveness", &livenessHandler)
+		mux.Handle("/probe/readiness", &readinessHandler)
+		httpServer.Addr = ":" + strconv.Itoa(probeAndMetricsPort)
 		httpServer.Handler = mux
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("Starting http server", "err", err)
@@ -125,6 +135,7 @@ func run() (retErr error) {
 		if err != nil {
 			return fmt.Errorf("failed to listen: %w", err)
 		}
+		*userapiStarted = true
 		if err := userAPIServer.Serve(lis); err != nil {
 			logger.Error("Serving Coordinator API", "err", err)
 			return fmt.Errorf("serving Coordinator API: %w", err)
@@ -138,6 +149,7 @@ func run() (retErr error) {
 		if err != nil {
 			return fmt.Errorf("failed to listen: %w", err)
 		}
+		*meshapiStarted = true
 		if err := meshAPIServer.Serve(lis); err != nil {
 			logger.Error("Serving Coordinator API", "err", err)
 			return fmt.Errorf("serving Coordinator API: %w", err)

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"internal/itoa"
 	"net"
 	"net/http"
 	"os"
@@ -35,7 +36,8 @@ import (
 )
 
 const (
-	metricsPortEnvVar = "CONTRAST_METRICS_PORT"
+	metricsEnvVar       = "CONTRAST_METRICS"
+	probeAndMetricsPort = 9102
 )
 
 func main() {
@@ -65,7 +67,6 @@ func run() (retErr error) {
 		return fmt.Errorf("setting up mount: %w", err)
 	}
 
-	metricsPort := os.Getenv(metricsPortEnvVar)
 	promRegistry := prometheus.NewRegistry()
 	serverMetrics := newServerMetrics(promRegistry)
 
@@ -92,30 +93,28 @@ func run() (retErr error) {
 	meshapi.RegisterMeshAPIServer(meshAPIServer, meshapiserver.New(logger))
 	serverMetrics.InitializeMetrics(meshAPIServer)
 
-	metricsServer := &http.Server{}
+	httpServer := &http.Server{}
 
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		if metricsPort == "" {
-			return nil
-		}
-		if metricsPort == userapi.Port || metricsPort == meshapi.Port {
-			return fmt.Errorf("invalid port for metrics endpoint: %s", metricsPort)
-		}
-		logger.Info("Starting prometheus /metrics endpoint on port " + metricsPort)
+		_, enableMetrics := os.LookupEnv(metricsEnvVar)
+		// TODO(miampf): add /probe/{startup,liveness,readiness} endpoints
 		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
-			promRegistry, promhttp.HandlerFor(
-				promRegistry,
-				promhttp.HandlerOpts{Registry: promRegistry},
-			),
-		))
-		metricsServer.Addr = ":" + metricsPort
-		metricsServer.Handler = mux
-		if err := metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Error("Serving Prometheus /metrics endpoint", "err", err)
-			return fmt.Errorf("serving Prometheus endpoint: %w", err)
+		if enableMetrics {
+			logger.Info("Starting prometheus /metrics endpoint on port " + itoa.Itoa(probeAndMetricsPort))
+			mux.Handle("/metrics", promhttp.InstrumentMetricHandler(
+				promRegistry, promhttp.HandlerFor(
+					promRegistry,
+					promhttp.HandlerOpts{Registry: promRegistry},
+				),
+			))
+		}
+		httpServer.Addr = ":" + itoa.Itoa(probeAndMetricsPort)
+		httpServer.Handler = mux
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("Starting http server", "err", err)
+			return fmt.Errorf("starting http server: %w", err)
 		}
 		return nil
 	})
@@ -164,7 +163,7 @@ func run() (retErr error) {
 		gracefulStopGRPC(ctx, wg, userAPIServer) //nolint:contextcheck
 		gracefulStopGRPC(ctx, wg, meshAPIServer) //nolint:contextcheck
 		wg.Wait()
-		return metricsServer.Shutdown(ctx) //nolint:contextcheck
+		return httpServer.Shutdown(ctx) //nolint:contextcheck
 	})
 
 	return eg.Wait()

--- a/docs/docs/architecture/observability.md
+++ b/docs/docs/architecture/observability.md
@@ -8,10 +8,9 @@ called labels.
 
 ## Exposed metrics
 
-The metrics can be accessed at the Coordinator pod at the port specified in the
-`CONTRAST_METRICS_PORT` environment variable under the `/metrics` endpoint. By
-default, this environment variable isn't specified, hence no metrics will be
-exposed.
+The metrics can be accessed at the Coordinator pod on port 9102 using the `/metrics` endpoint.
+By default, metrics are disabled. You can enable them by setting the `CONTRAST_METRICS`
+environment variable.
 
 The Coordinator exports gRPC metrics under the prefix `contrast_grpc_server_`.
 These metrics are labeled with the gRPC service name and method name.

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -150,7 +150,7 @@ func (ct *ContrastTest) Init(t *testing.T, resources []any) {
 	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
 	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
 	resources = kuberesource.PatchServiceMeshAdminInterface(resources, 9901)
-	resources = kuberesource.PatchCoordinatorMetrics(resources, 9102)
+	resources = kuberesource.PatchCoordinatorMetrics(resources)
 	resources = kuberesource.AddLogging(resources, "debug", "*")
 	unstructuredResources, err := kuberesource.ResourcesToUnstructured(resources)
 	require.NoError(err)

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -421,19 +421,19 @@ func PatchServiceMeshAdminInterface(resources []any, port int32) []any {
 	return out
 }
 
-// PatchCoordinatorMetrics enables Coordinator metrics on the specified port.
-func PatchCoordinatorMetrics(resources []any, port int32) []any {
+// PatchCoordinatorMetrics enables Coordinator metrics on port 9102.
+func PatchCoordinatorMetrics(resources []any) []any {
 	for _, resource := range resources {
 		switch r := resource.(type) {
 		case *applyappsv1.StatefulSetApplyConfiguration:
 			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.Spec != nil &&
 				len(r.Spec.Template.Spec.Containers) > 0 &&
 				r.Spec.Template.Annotations[contrastRoleAnnotationKey] == "coordinator" {
-				r.Spec.Template.Spec.Containers[0].WithEnv(NewEnvVar("CONTRAST_METRICS_PORT", fmt.Sprint(port)))
+				r.Spec.Template.Spec.Containers[0].WithEnv(NewEnvVar("CONTRAST_METRICS", "1"))
 				r.Spec.Template.Spec.Containers[0].WithPorts(
 					ContainerPort().
 						WithName("prometheus").
-						WithContainerPort(port),
+						WithContainerPort(9102),
 				)
 			}
 		}


### PR DESCRIPTION
This PR adds the probes specified in [RFC 10](https://github.com/edgelesssys/contrast/blob/main/rfc/010-distributed-coordinator.md).

It also removes the `CONTRAST_METRICS_PORT` environment variable. Instead, contrast prometheus metrics are activated by setting the `CONTRAST_METRICS` variable and are always served on port 9102. An http server on this port will now always be started to serve the probes, `CONTRAST_METRICS` only adds the prometheus service to this server.