### PR TITLE
e2e/regression: add test for envFromRef from ConfigMap in separate file

### DIFF
--- a/e2e/regression/testdata/env-from-cm/only_config_map.yml
+++ b/e2e/regression/testdata/env-from-cm/only_config_map.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  key: YmFyCg==
+kind: ConfigMap
+metadata:
+  name: configmap-sample

--- a/e2e/regression/testdata/env-from-cm/pod_with_config_map_ref.yml
+++ b/e2e/regression/testdata/env-from-cm/pod_with_config_map_ref.yml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: "@@REPLACE_NAMESPACE@@"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nginx
+    spec:
+      runtimeClassName: contrast-cc
+      containers:
+        - name: busybox
+          restartPolicy: Never
+          image: "quay.io/prometheus/busybox:latest"
+          stdin: true
+          env:
+            - name: ENV_FROM_CONFIGMAP
+              valueFrom:
+                configMapKeyRef:
+                  key: key
+                  name: configmap-sample
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.serviceAccountName
+            - name: PROXY_CONFIG
+              value: "{}\n"
+            - name: ISTIO_META_POD_PORTS
+              value: "[\n]"
+            - name: ISTIO_META_APP_CONTAINERS
+              value: serviceaclient
+            - name: ISTIO_META_CLUSTER_ID
+              value: Kubernetes
+            - name: ISTIO_META_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - while true; do echo $(POD_NAME); sleep 10; done

--- a/e2e/regression/testdata/keycloak.yml
+++ b/e2e/regression/testdata/keycloak.yml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: keycloak
           image: quay.io/keycloak/keycloak@sha256:b55f55ff60e905db4809ac133c6b963b87963ec1b49aae6d218fdd53646cb09e
+          args: ["start-dev"]
           ports:
             - containerPort: 9000
             - containerPort: 8443


### PR DESCRIPTION
Note that the regression test is expected to fail until https://github.com/edgelesssys/contrast/pull/1288 is merged and this PR is rebased onto main.

<details>

```
=== RUN   TestRegression/env-from-cm
=== RUN   TestRegression/env-from-cm/generate
    contrasttest.go:191: 
        	Error Trace:	github.com/edgelesssys/contrast/e2e/internal/contrasttest/contrasttest.go:191
        	Error:      	Received unexpected error:
        	            	generate policies: failed to generate policy for /home/runner/work/_temp/nix-shell.wz8GO9/TestRegression3402123645/001/pod_with_config_map_ref.yml: running genpolicy: exit status 101
        	Test:       	TestRegression/env-from-cm/generate
        	Messages:   	could not generate manifest: time=2025-03-12T02:53:13.869Z level=INFO msg="Ignoring non-CoCo runtime" className=contrast-cc path=/home/runner/work/_temp/nix-shell.wz8GO9/TestRegression3402123645/001/only_config_map.yml
        	            	time=2025-03-12T02:53:13.870Z level=DEBUG msg="Updating resources in yaml file" path=/home/runner/work/_temp/nix-shell.wz8GO9/TestRegression3402123645/001/pod_with_config_map_ref.yml
        	            	time=2025-03-12T02:53:13.877Z level=DEBUG msg="Updating resources in yaml file" path=/home/runner/work/_temp/nix-shell.wz8GO9/TestRegression3402123645/001/resources.yml
        	            	time=2025-03-12T02:53:13.903Z level=DEBUG msg="============================================" position=genpolicy::registry
        	            	time=2025-03-12T02:53:13.903Z level=DEBUG msg="Pulling manifest and config for \"quay.io/prometheus/busybox:latest\"" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.238Z level=DEBUG msg="Using cache file" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.238Z level=DEBUG msg="dm-verity root hash: " position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.238Z level=DEBUG msg="Pulling layer \"sha256:9fa9226be034e47923c0457d916aa68474cdfb23af8d4525e9baeebc4760977a\"" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.619Z level=DEBUG msg="Decompressing layer" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.625Z level=DEBUG msg="Adding tarfs index to layer" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.627Z level=DEBUG msg="Calculating dm-verity root hash" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.629Z level=DEBUG msg="dm-verity root hash: 2e52d86498030b4b99318650826d3f121bdfac5fe7bbbea9d18c546d48003aa0" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.631Z level=DEBUG msg="Using cache file" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.631Z level=DEBUG msg="dm-verity root hash: " position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.631Z level=DEBUG msg="Pulling layer \"sha256:1617e25568b2231fdd0d5caff63b06f6f7738d8d961f031c80e47d35aaec9733\"" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.857Z level=DEBUG msg="Decompressing layer" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.862Z level=DEBUG msg="Adding tarfs index to layer" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.871Z level=DEBUG msg="Calculating dm-verity root hash" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.874Z level=DEBUG msg="dm-verity root hash: 75ed5e78d30374b9557d32c17ae6d2e1b4afdc5efd128812e6c99a0f60708dba" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.875Z level=DEBUG msg="============================================" position=genpolicy::registry
        	            	time=2025-03-12T02:53:15.875Z level=DEBUG msg="Pulling manifest and config for \"mcr.microsoft.com/oss/kubernetes/pause:3.6\"" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.060Z level=DEBUG msg="Using cache file" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.060Z level=DEBUG msg="dm-verity root hash: 817250f1a3e336da76f5bd3fa784e1b26d959b9c131876815ba2604048b70c18" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.060Z level=DEBUG msg="============================================" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.060Z level=DEBUG msg="Pulling manifest and config for \"ghcr.io/edgelesssys/contrast/initializer@sha256:66d0d6e864c6400639f15f08f2deffdffb31f0b1151c9071f53571d1b5e3017f\"" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.624Z level=DEBUG msg="Using cache file" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.624Z level=DEBUG msg="dm-verity root hash: 37e2c0bffc0ef73d7e1df04aefe33da57117a79c7d5f10553cf36be6ff202569" position=genpolicy::registry
        	            	time=2025-03-12T02:53:16.631Z level=ERROR msg="thread 'main' panicked at src/pod.rs:789:9:"
        	            	time=2025-03-12T02:53:16.631Z level=ERROR msg="Couldn't get the value of env var: ENV_FROM_CONFIGMAP"
        	            	time=2025-03-12T02:53:16.631Z level=ERROR msg="stack backtrace:"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   0: rust_begin_unwind"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   1: core::panicking::panic_fmt"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   2: genpolicy::pod::Container::get_env_variables"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   3: genpolicy::policy::AgentPolicy::get_container_policy"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   4: genpolicy::policy::AgentPolicy::generate_policy"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   5: <genpolicy::deployment::Deployment as genpolicy::yaml::K8sResource>::generate_policy"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   6: genpolicy::policy::AgentPolicy::export_policy"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   7: tokio::runtime::context::runtime::enter_runtime"
        	            	time=2025-03-12T02:53:16.634Z level=ERROR msg="   8: genpolicy::main"
        	            	time=2025-03-12T02:53:16.635Z level=ERROR msg="note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace."
        	            	Error: generate policies: failed to generate policy for /home/runner/work/_temp/nix-shell.wz8GO9/TestRegression3402123645/001/pod_with_config_map_ref.yml: running genpolicy: exit status 101
```

</details>