### PR TITLE
generate: allow generating with a one ConfigMap as envFromRef dependency

### DIFF
--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -93,7 +93,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading workload owner key: %w", err)
 	}
 
-	paths, err := findGenerateTargets(args, log)
+	paths, _, err := findGenerateTargets(args, log)
 	if err != nil {
 		return fmt.Errorf("finding yaml files: %w", err)
 	}

--- a/cli/genpolicy/genpolicy_test.go
+++ b/cli/genpolicy/genpolicy_test.go
@@ -69,7 +69,7 @@ func TestRunner(t *testing.T) {
 	r, err := New(expectedRulesPath, expectedSettingsPath, cachePath, genpolicyBin)
 	require.NoError(err)
 
-	require.NoError(r.Run(ctx, expectedYAMLPath, logger))
+	require.NoError(r.Run(ctx, expectedYAMLPath, nil, logger))
 
 	rulesPath, err := os.ReadFile(rulesPathFile)
 	require.NoError(err)


### PR DESCRIPTION
This is the maximum implementation that we can implement with the intersection of the features of the microsoft genpolicy and the upstream genpolicy.

The full envFromRef feature for secrets and multiple dependency files will be implemented in https://github.com/edgelesssys/contrast/pull/1273.

This PR will be tested with the following regression test: https://github.com/edgelesssys/contrast/pull/1287