### PR TITLE
coordinator: move meshapi into its own package

### DIFF
--- a/coordinator/internal/meshapi/meshapi.go
+++ b/coordinator/internal/meshapi/meshapi.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Edgeless Systems GmbH
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package main
+package meshapi
 
 import (
 	"context"
@@ -17,14 +17,16 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type meshAPIServer struct {
+// Server implements the meshapi service.
+type Server struct {
 	logger *slog.Logger
 
 	meshapi.UnimplementedMeshAPIServer
 }
 
-func newMeshAPIServer(log *slog.Logger) *meshAPIServer {
-	return &meshAPIServer{
+// New returns a meshapi server using a sub-logger of log.
+func New(log *slog.Logger) *Server {
+	return &Server{
 		logger: log.WithGroup("meshapi"),
 	}
 }
@@ -34,7 +36,7 @@ func newMeshAPIServer(log *slog.Logger) *meshAPIServer {
 // When this handler is called, the transport credentials already ensured that
 // the peer is authorized according to the manifest, so it can start issuing
 // right away.
-func (i *meshAPIServer) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertRequest) (*meshapi.NewMeshCertResponse, error) {
+func (i *Server) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertRequest) (*meshapi.NewMeshCertResponse, error) {
 	i.logger.Info("NewMeshCert called")
 
 	p, ok := peer.FromContext(ctx)

--- a/coordinator/internal/meshapi/meshapi_test.go
+++ b/coordinator/internal/meshapi/meshapi_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package meshapi
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"testing"
+
+	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+	"github.com/edgelesssys/contrast/coordinator/internal/seedengine"
+	"github.com/edgelesssys/contrast/internal/ca"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/testkeys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+func TestNewMeshCert(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	m := &manifest.Manifest{}
+	policyHash := sha256.Sum256(nil)
+	policyHashHex := manifest.NewHexString(policyHash[:])
+	m.Policies = map[manifest.HexString]manifest.PolicyEntry{
+		policyHashHex: {
+			SANs:             []string{"test"},
+			WorkloadSecretID: "test",
+		},
+	}
+	key := testkeys.New[ecdsa.PrivateKey](t, testkeys.ECDSAP384Keys[0])
+	meshKey := testkeys.New[ecdsa.PrivateKey](t, testkeys.ECDSAP384Keys[1])
+	rootKey := testkeys.New[ecdsa.PrivateKey](t, testkeys.ECDSAP384Keys[2])
+
+	seed := [32]byte{}
+	salt := [32]byte{}
+	se, err := seedengine.New(seed[:], salt[:])
+	require.NoError(err)
+	ca, err := ca.New(rootKey, meshKey)
+	require.NoError(err)
+
+	info := authority.AuthInfo{
+		TLSInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{{PublicKey: key.Public(), PublicKeyAlgorithm: x509.ECDSA}},
+			},
+		},
+		Report: &fakeReport{
+			hostData: policyHash[:],
+		},
+		State: &authority.State{
+			Manifest:   m,
+			SeedEngine: se,
+			CA:         ca,
+		},
+	}
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: info,
+	})
+
+	meshapi := New(slog.Default())
+
+	resp, err := meshapi.NewMeshCert(ctx, nil)
+	require.NoError(err)
+
+	require.NotEmpty(resp.WorkloadSecret)
+
+	certChain := certFromPEM(t, resp.CertChain)
+	require.Len(certChain, 2)
+	cert, intermediateCert := certChain[0], certChain[1]
+	assert.False(cert.IsCA)
+	assert.True(intermediateCert.IsCA)
+	assert.Equal(cert.AuthorityKeyId, intermediateCert.SubjectKeyId)
+
+	meshCerts := certFromPEM(t, resp.MeshCACert)
+	require.Len(meshCerts, 1)
+	assert.True(meshCerts[0].IsCA)
+	assert.Equal(cert.AuthorityKeyId, meshCerts[0].SubjectKeyId)
+	assert.Empty(meshCerts[0].AuthorityKeyId)
+
+	rootCerts := certFromPEM(t, resp.RootCACert)
+	require.Len(rootCerts, 1)
+	assert.True(rootCerts[0].IsCA)
+	assert.Empty(rootCerts[0].AuthorityKeyId)
+	assert.Equal(intermediateCert.AuthorityKeyId, rootCerts[0].SubjectKeyId)
+}
+
+type fakeReport struct {
+	extensions []pkix.Extension
+	hostData   []byte
+}
+
+func (r *fakeReport) ClaimsToCertExtension() ([]pkix.Extension, error) {
+	return r.extensions, nil
+}
+
+func (r *fakeReport) HostData() []byte {
+	return r.hostData
+}
+
+func certFromPEM(t *testing.T, pemBytes []byte) []*x509.Certificate {
+	t.Helper()
+	var certs []*x509.Certificate
+	for len(pemBytes) > 0 {
+		derCert, rest := pem.Decode(pemBytes)
+		cert, err := x509.ParseCertificate(derCert.Bytes)
+		require.NoError(t, err)
+		certs = append(certs, cert)
+		pemBytes = rest
+	}
+	return certs
+}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+	meshapiserver "github.com/edgelesssys/contrast/coordinator/internal/meshapi"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
@@ -88,7 +89,7 @@ func run() (retErr error) {
 	meshAPIcredentials, cancel := meshAuth.Credentials(promRegistry, issuer)
 	defer cancel()
 	meshAPIServer := newGRPCServer(meshAPIcredentials, serverMetrics)
-	meshapi.RegisterMeshAPIServer(meshAPIServer, newMeshAPIServer(logger))
+	meshapi.RegisterMeshAPIServer(meshAPIServer, meshapiserver.New(logger))
 	serverMetrics.InitializeMetrics(meshAPIServer)
 
 	metricsServer := &http.Server{}


### PR DESCRIPTION
This is an alternative approach to #1272. Both in its current form as well as with the additions from RFC 010, the meshapi only depends on the state of the coordinator as per creation of the channel. We can thus decouple the authority struct and the meshapi server, the remaining interface being the state passed via context.

Before moving the service implementation into its own package, I consolidated the gRPC server creation, which was mostly duplicated code and used to expose the meshapi server to structs it should not concern itself with.

~I will port the test from #1272 in a separate PR.~