### PR TITLE
transitengineapi: tls authentication/authorization + example Vault deployment

### DIFF
--- a/coordinator/internal/transitengineapi/transitengineapi.go
+++ b/coordinator/internal/transitengineapi/transitengineapi.go
@@ -79,6 +79,9 @@ func NewTransitEngineAPI(authority stateAuthority, port int, logger *slog.Logger
 					ClientCAs:  meshCAPool,
 					ClientAuth: tls.RequireAndVerifyClientCert,
 					MinVersion: tls.VersionTLS12,
+					GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+						return nil, nil
+					},
 				}, nil
 			},
 		},

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
+	transitengine "github.com/edgelesssys/contrast/coordinator/internal/transitengineapi"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
@@ -131,6 +132,17 @@ func run() (retErr error) {
 		if err := meshAPI.Serve(net.JoinHostPort("0.0.0.0", meshapi.Port)); err != nil {
 			logger.Error("Serving mesh API", "err", err)
 			return fmt.Errorf("serving mesh API: %w", err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		transitAPI := transitengine.NewTransitEngineAPI(meshAuth, 8200, logger)
+		logger.Info("Transit Engine API initialized")
+		logger.Info("Serving transit engine API", "err", err)
+		if err := transitAPI.ListenAndServeTLS("", ""); err != nil {
+			logger.Error("Failed serving transit engine API", "err", err)
+			return fmt.Errorf("Serving transit engine API: %w", err)
 		}
 		return nil
 	})

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -137,7 +137,11 @@ func run() (retErr error) {
 	})
 
 	eg.Go(func() error {
-		transitAPI := transitengine.NewTransitEngineAPI(meshAuth, 8200, logger)
+		transitAPI, err := transitengine.NewTransitEngineAPI(meshAuth, 8200, logger)
+		if err != nil {
+			logger.Error("Initialize transit engine API", "err", err)
+			return fmt.Errorf("Initialize transit engine API: %w", err)
+		}
 		logger.Info("Transit Engine API initialized")
 		logger.Info("Serving transit engine API", "err", err)
 		if err := transitAPI.ListenAndServeTLS("", ""); err != nil {

--- a/coordinator/meshapi.go
+++ b/coordinator/meshapi.go
@@ -22,6 +22,9 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+
+	"github.com/edgelesssys/contrast/internal/attestation/extension"
+	"github.com/edgelesssys/contrast/internal/oid"
 )
 
 type meshAPIServer struct {
@@ -117,6 +120,14 @@ func (i *meshAPIServer) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertR
 	extensions, err := report.ClaimsToCertExtension()
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct extensions: %w", err)
+	}
+	if entry.WorkloadSecretID != "" {
+		workloadSecretExtension, err := extension.ConvertExtension(extension.NewBytesExtension(oid.WorkloadSecretOID,
+			[]byte(entry.WorkloadSecretID)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to construct workload secret extension: %w", err)
+		}
+		extensions = append(extensions, workloadSecretExtension)
 	}
 	cert, err := state.CA.NewAttestedMeshCert(dnsNames, extensions, peerPubKey)
 	if err != nil {

--- a/internal/attestation/extension/extension.go
+++ b/internal/attestation/extension/extension.go
@@ -85,3 +85,8 @@ func ConvertExtensions(extensions []Extension) ([]pkix.Extension, error) {
 	}
 	return exts, nil
 }
+
+// ConvertExtension converts a single extension into a pkix extension.
+func ConvertExtension(extension Extension) (pkix.Extension, error) {
+	return extension.toExtension()
+}

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -380,6 +380,9 @@ func Coordinator(namespace string) *CoordinatorConfig {
 								ContainerPort().
 									WithName("meshapi").
 									WithContainerPort(7777),
+								ContainerPort().
+									WithName("transitapi").
+									WithContainerPort(8200),
 							).
 							WithReadinessProbe(Probe().
 								WithInitialDelaySeconds(1).

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -58,6 +58,8 @@ func main() {
 			subResources = kuberesource.PatchRuntimeHandlers(kuberesource.VolumeStatefulSet(), "contrast-cc")
 		case "mysql":
 			subResources = kuberesource.PatchRuntimeHandlers(kuberesource.MySQL(), "contrast-cc")
+		case "vault":
+			subResources = kuberesource.PatchRuntimeHandlers(kuberesource.Vault(*namespace), "contrast-cc")
 		default:
 			log.Fatalf("Error: unknown set: %s\n", set)
 		}

--- a/internal/oid/oid.go
+++ b/internal/oid/oid.go
@@ -12,3 +12,8 @@ var RawSNPReport = asn1.ObjectIdentifier{1, 3, 9901, 2, 1}
 // RawTDXReport is the root OID for the raw TDX report extensions
 // used by the aTLS issuer and validator.
 var RawTDXReport = asn1.ObjectIdentifier{1, 3, 9901, 2, 2}
+
+// WorkloadSecretOID is the root OID for the workloadSecretID report
+// extension, added to the mesh certificates to allow verification
+// and authorization based on the workloadSecretID.
+var WorkloadSecretOID = asn1.ObjectIdentifier{1, 3, 9901, 2, 3}

--- a/justfile
+++ b/justfile
@@ -306,6 +306,9 @@ wait-for-workload target=default_deploy_target:
             nix run .#scripts.kubectl-wait-ready -- $ns mysql-backend
             nix run .#scripts.kubectl-wait-ready -- $ns mysql-client
         ;;
+        "vault")
+            nix run .#scripts.kubectl-wait-ready -- $ns vault
+        ;;
         "custom")
             :
         ;;


### PR DESCRIPTION
This PR introduces mTLS to the transit engine API to secure connections based on Contrast mesh certs. Further it adds an example OpenBao Vault deployment, which utilizes our built-in transit engine API of the coordinator to unseal a user-managed Vault secured by the mTLS connection.

- The client has to authenticate with a valid mesh cert of the current state.
- MeshAPI: A certificate extension holding the workloadSecretID of the requesting client, which is looked up from the manifest while issuing, is added to every meshCert now. Thus we have no need for an additional manifest look-up.
- The client is only authorized to the transit key set of the workloadSecretID in the received meshCert extension. As prior we handle the `<name>` parameter of existing Vault implementations as our workloadSecretID. 
- On initialization the transit engine API derives a private ecdsa key. For each incoming TLS connection of the transit engine API, the coordinator issues itself a fresh mesh cert for this private key of the transit engine API, which is therefore valid for the current state. 