### PR TITLE
authority: add getters for State fields

### DIFF
--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -44,7 +44,7 @@ func TestSNPValidateOpts(t *testing.T) {
 	_, err := a.SetManifest(context.Background(), req)
 	require.NoError(err)
 
-	gens, err := a.state.Load().Manifest.SNPValidateOpts(nil)
+	gens, err := a.state.Load().Manifest().SNPValidateOpts(nil)
 	require.NoError(err)
 	require.NotNil(gens)
 }

--- a/coordinator/internal/authority/credentials.go
+++ b/coordinator/internal/authority/credentials.go
@@ -74,7 +74,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 
 	var validators []atls.Validator
 
-	opts, err := state.Manifest.SNPValidateOpts(c.kdsGetter)
+	opts, err := state.Manifest().SNPValidateOpts(c.kdsGetter)
 	if err != nil {
 		log.Error("Could not generate SNP validation options", "error", err)
 		return nil, nil, fmt.Errorf("generating SNP validation options: %w", err)
@@ -88,7 +88,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		validators = append(validators, validator)
 	}
 
-	tdxOpts, err := state.Manifest.TDXValidateOpts()
+	tdxOpts, err := state.Manifest().TDXValidateOpts()
 	if err != nil {
 		log.Error("Could not generate TDX validation options", "error", err)
 		return nil, nil, fmt.Errorf("generating TDX validation options: %w", err)

--- a/coordinator/internal/meshapi/meshapi_test.go
+++ b/coordinator/internal/meshapi/meshapi_test.go
@@ -58,11 +58,7 @@ func TestNewMeshCert(t *testing.T) {
 		Report: &fakeReport{
 			hostData: policyHash[:],
 		},
-		State: &authority.State{
-			Manifest:   m,
-			SeedEngine: se,
-			CA:         ca,
-		},
+		State: authority.NewState(se, m, ca),
 	}
 	ctx := peer.NewContext(context.Background(), &peer.Peer{
 		AuthInfo: info,

--- a/coordinator/internal/transitengineapi/transitengineapi.go
+++ b/coordinator/internal/transitengineapi/transitengineapi.go
@@ -135,7 +135,7 @@ func deriveEncryptionKey(authority stateAuthority, workloadSecretID string) ([]b
 		return nil, err
 	}
 	// TODO(jmxnzo): authentication of client certs <-> parsed workloadSecretID.
-	derivedWorkloadSecret, err := state.SeedEngine.DeriveWorkloadSecret(workloadSecretID)
+	derivedWorkloadSecret, err := state.SeedEngine().DeriveWorkloadSecret(workloadSecretID)
 	if err != nil {
 		return nil, err
 	}

--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -169,9 +169,7 @@ func newFakeSeedEngineAuthority() (*fakeStateAuthority, error) {
 	if err != nil {
 		return nil, err
 	}
-	fakeState := &authority.State{
-		SeedEngine: seedEngine,
-	}
+	fakeState := authority.NewState(seedEngine, nil, nil)
 
 	authority := &fakeStateAuthority{
 		state: *fakeState,


### PR DESCRIPTION
Since we're using the `State` struct in other packages now, we should make sure that it is not accidentally modified by those packages. This commit is a first step in this direction, replacing direct field access with getters.

It's still possible to modify the manifest, though - I'm going to fix this in a future commit.