### PR TITLE
authority: allow testing without embedded reference values

### DIFF
--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/internal/manifest"
-	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/internal/userapi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -66,8 +65,7 @@ func newManifest(t *testing.T) (*manifest.Manifest, []byte, [][]byte) {
 	policyHash := sha256.Sum256(policy)
 	policyHashHex := manifest.NewHexString(policyHash[:])
 
-	mnfst, err := manifest.Default(platforms.AKSCloudHypervisorSNP)
-	require.NoError(t, err)
+	mnfst := &manifest.Manifest{}
 	mnfst.Policies = map[manifest.HexString]manifest.PolicyEntry{
 		policyHashHex: {
 			SANs:             []string{"test"},
@@ -75,6 +73,18 @@ func newManifest(t *testing.T) (*manifest.Manifest, []byte, [][]byte) {
 			Role:             manifest.RoleCoordinator,
 		},
 	}
+	svn0 := manifest.SVN(0)
+	measurement := [48]byte{}
+	mnfst.ReferenceValues.SNP = []manifest.SNPReferenceValues{{
+		ProductName: "Milan",
+		MinimumTCB: manifest.SNPTCB{
+			BootloaderVersion: &svn0,
+			TEEVersion:        &svn0,
+			SNPVersion:        &svn0,
+			MicrocodeVersion:  &svn0,
+		},
+		TrustedMeasurement: manifest.NewHexString(measurement[:]),
+	}}
 	mnfst.WorkloadOwnerKeyDigests = []manifest.HexString{keyDigest}
 	mnfstBytes, err := json.Marshal(mnfst)
 	require.NoError(t, err)

--- a/coordinator/internal/authority/userapi_test.go
+++ b/coordinator/internal/authority/userapi_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/internal/manifest"
-	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/internal/testkeys"
 	"github.com/edgelesssys/contrast/internal/userapi"
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,9 +34,7 @@ import (
 
 func TestManifestSet(t *testing.T) {
 	newBaseManifest := func() *manifest.Manifest {
-		mnf, err := manifest.Default(platforms.AKSCloudHypervisorSNP)
-		require.NoError(t, err)
-		return mnf
+		return &manifest.Manifest{}
 	}
 	newManifestBytes := func(f func(*manifest.Manifest)) []byte {
 		m := newBaseManifest()
@@ -223,8 +220,7 @@ func TestGetManifests(t *testing.T) {
 	require.Equal(codes.FailedPrecondition, status.Code(err))
 	assert.Nil(resp)
 
-	m, err := manifest.Default(platforms.AKSCloudHypervisorSNP)
-	require.NoError(err)
+	m := &manifest.Manifest{}
 	m.Policies = map[manifest.HexString]manifest.PolicyEntry{
 		manifest.HexString("ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"): {SANs: []string{"a1", "a2"}, WorkloadSecretID: "a3"},
 		manifest.HexString("3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d"): {SANs: []string{"b1", "b2"}, WorkloadSecretID: "b3"},
@@ -404,9 +400,7 @@ func TestRecoveryFlow(t *testing.T) {
 // gRPCs of the server.
 func TestUserAPIConcurrent(t *testing.T) {
 	newBaseManifest := func() *manifest.Manifest {
-		mnf, err := manifest.Default(platforms.AKSCloudHypervisorSNP)
-		require.NoError(t, err)
-		return mnf
+		return &manifest.Manifest{}
 	}
 	newManifestBytes := func(f func(*manifest.Manifest)) []byte {
 		m := newBaseManifest()
@@ -497,10 +491,7 @@ func rpcContext(cryptoKey crypto.PrivateKey) context.Context {
 }
 
 func manifestWithWorkloadOwnerKey(key *ecdsa.PrivateKey) (*manifest.Manifest, error) {
-	m, err := manifest.Default(platforms.AKSCloudHypervisorSNP)
-	if err != nil {
-		return nil, err
-	}
+	m := &manifest.Manifest{}
 	if key == nil {
 		return m, nil
 	}


### PR DESCRIPTION
This is a follow-up on https://github.com/edgelesssys/contrast/pull/1291#discussion_r1995646165 - being able to run the tests without nix improves iteration velocity. 