### PR TITLE
history: allow watching for LatestTransition changes

### DIFF
--- a/coordinator/history/history.go
+++ b/coordinator/history/history.go
@@ -24,6 +24,7 @@ const (
 type History struct {
 	store   Store
 	hashFun func() hash.Hash
+	log     *slog.Logger
 }
 
 // New creates a new History backed by the configured store.
@@ -32,14 +33,15 @@ func New(log *slog.Logger) (*History, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating history store: %w", err)
 	}
-	return NewWithStore(store), nil
+	return NewWithStore(log, store), nil
 }
 
 // NewWithStore creates a new History with the given storage backend.
-func NewWithStore(store Store) *History {
+func NewWithStore(log *slog.Logger, store Store) *History {
 	h := &History{
 		store:   store,
 		hashFun: sha256.New,
+		log:     log,
 	}
 	if HashSize != h.hashFun().Size() {
 		panic("mismatch between hashSize and hash function size")

--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -54,7 +54,7 @@ func newAuthority(t *testing.T) (*Authority, *prometheus.Registry) {
 	t.Helper()
 	fs := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
 	store := history.NewAferoStore(&afero.Afero{Fs: fs})
-	hist := history.NewWithStore(store)
+	hist := history.NewWithStore(slog.Default(), store)
 	reg := prometheus.NewRegistry()
 	return New(hist, reg, slog.Default()), reg
 }

--- a/coordinator/internal/authority/userapi_test.go
+++ b/coordinator/internal/authority/userapi_test.go
@@ -414,7 +414,7 @@ func TestUserAPIConcurrent(t *testing.T) {
 
 	fs := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
 	store := history.NewAferoStore(&afero.Afero{Fs: fs})
-	hist := history.NewWithStore(store)
+	hist := history.NewWithStore(slog.Default(), store)
 	coordinator := New(hist, prometheus.NewRegistry(), slog.Default())
 
 	setReq := &userapi.SetManifestRequest{
@@ -465,7 +465,7 @@ func newCoordinator() *Authority {
 func newCoordinatorWithRegistry(reg *prometheus.Registry) *Authority {
 	fs := afero.NewMemMapFs()
 	store := history.NewAferoStore(&afero.Afero{Fs: fs})
-	hist := history.NewWithStore(store)
+	hist := history.NewWithStore(slog.Default(), store)
 	return New(hist, reg, slog.Default())
 }
 


### PR DESCRIPTION
Propagate watcher events from the low-level store to the history, where they can be used by `authority.Authority` to enter recovery mode.