### PR TITLE
meshapi: add recover handler

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -141,11 +141,12 @@ func (m *Authority) fetchState(se *seedengine.SeedEngine) (*State, error) {
 		return nil, fmt.Errorf("walking transitions: %w", err)
 	}
 	nextState := &State{
-		seedEngine: se,
-		latest:     latest,
-		ca:         ca,
-		manifest:   mnfst,
-		generation: generation,
+		seedEngine:    se,
+		latest:        latest,
+		ca:            ca,
+		manifest:      mnfst,
+		manifestBytes: manifestBytes,
+		generation:    generation,
 	}
 	return nextState, nil
 }
@@ -179,9 +180,10 @@ func (m *Authority) GetState() (*State, error) {
 
 // State is a snapshot of the Coordinator's manifest history.
 type State struct {
-	seedEngine *seedengine.SeedEngine
-	manifest   *manifest.Manifest
-	ca         *ca.CA
+	seedEngine    *seedengine.SeedEngine
+	manifest      *manifest.Manifest
+	manifestBytes []byte
+	ca            *ca.CA
 
 	latest     *history.LatestTransition
 	generation int
@@ -191,11 +193,12 @@ type State struct {
 //
 // This function is intended for other packages that work on State objects. It does not produce a
 // State that is valid for this package.
-func NewState(seedEngine *seedengine.SeedEngine, manifest *manifest.Manifest, ca *ca.CA) *State {
+func NewState(seedEngine *seedengine.SeedEngine, manifest *manifest.Manifest, manifestBytes []byte, ca *ca.CA) *State {
 	return &State{
-		seedEngine: seedEngine,
-		manifest:   manifest,
-		ca:         ca,
+		seedEngine:    seedEngine,
+		manifest:      manifest,
+		manifestBytes: manifestBytes,
+		ca:            ca,
 	}
 }
 
@@ -208,6 +211,11 @@ func (s *State) SeedEngine() *seedengine.SeedEngine {
 func (s *State) Manifest() *manifest.Manifest {
 	// TODO(burgerdev): consider deep-copying for safety
 	return s.manifest
+}
+
+// ManifestBytes returns the raw bytes of the manifest for this state.
+func (s *State) ManifestBytes() []byte {
+	return s.manifestBytes
 }
 
 // CA returns the CA for this state.

--- a/coordinator/internal/authority/userapi.go
+++ b/coordinator/internal/authority/userapi.go
@@ -144,11 +144,12 @@ func (a *Authority) SetManifest(ctx context.Context, req *userapi.SetManifestReq
 	}
 
 	nextState := &State{
-		seedEngine: se,
-		latest:     nextLatest,
-		manifest:   m,
-		ca:         ca,
-		generation: oldGeneration + 1,
+		seedEngine:    se,
+		latest:        nextLatest,
+		manifest:      m,
+		manifestBytes: req.GetManifest(),
+		ca:            ca,
+		generation:    oldGeneration + 1,
 	}
 
 	if a.state.CompareAndSwap(oldState, nextState) {

--- a/coordinator/internal/meshapi/meshapi.go
+++ b/coordinator/internal/meshapi/meshapi.go
@@ -5,7 +5,9 @@ package meshapi
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 
@@ -99,4 +101,58 @@ func (i *Server) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertRequest)
 	}
 
 	return resp, nil
+}
+
+// Recover provides key material to authenticated workloads with the Coordinator role.
+func (i *Server) Recover(ctx context.Context, _ *meshapi.RecoverRequest) (*meshapi.RecoverResponse, error) {
+	i.logger.Info("Recover called")
+
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("failed to get peer from context")
+	}
+
+	authInfo, ok := p.AuthInfo.(authority.AuthInfo)
+	if !ok {
+		return nil, fmt.Errorf("unexpected AuthInfo type: %T", p.AuthInfo)
+	}
+	state := authInfo.State
+	report := authInfo.Report
+
+	hostData := manifest.NewHexString(report.HostData())
+	entry, ok := state.Manifest().Policies[hostData]
+	if !ok {
+		return nil, status.Errorf(codes.PermissionDenied, "policy hash %s not found in manifest", hostData)
+	}
+	if entry.Role != manifest.RoleCoordinator {
+		return nil, status.Errorf(codes.PermissionDenied, "role %q not allowed to recover", entry.Role)
+	}
+
+	ca := state.CA()
+	se := state.SeedEngine()
+
+	meshCAPrivKeyPEM, err := encodeKey(ca.GetIntermCAPrivKey())
+	if err != nil {
+		return nil, fmt.Errorf("encoding mesh CA private key: %w", err)
+	}
+
+	resp := &meshapi.RecoverResponse{
+		Seed:           se.Seed(),
+		Salt:           se.Salt(),
+		MeshCAKey:      meshCAPrivKeyPEM,
+		LatestManifest: state.ManifestBytes(),
+	}
+
+	return resp, nil
+}
+
+func encodeKey(key *ecdsa.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling private key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: der,
+	}), nil
 }

--- a/coordinator/internal/seedengine/seedengine.go
+++ b/coordinator/internal/seedengine/seedengine.go
@@ -24,6 +24,7 @@ import (
 type SeedEngine struct {
 	curve   func() elliptic.Curve
 	hashFun func() hash.Hash
+	seed    []byte
 	salt    []byte
 
 	podStateSeed []byte
@@ -38,6 +39,7 @@ func New(secretSeed []byte, salt []byte) (*SeedEngine, error) {
 	se := &SeedEngine{
 		curve:   elliptic.P384,
 		hashFun: sha256.New,
+		seed:    secretSeed,
 		salt:    salt,
 	}
 
@@ -100,6 +102,16 @@ func (s *SeedEngine) RootCAKey() *ecdsa.PrivateKey {
 // TransactionSigningKey returns the transaction signing key which is derived from the secret seed.
 func (s *SeedEngine) TransactionSigningKey() *ecdsa.PrivateKey {
 	return s.transactionSigningKey
+}
+
+// Seed returns the secret seed.
+func (s *SeedEngine) Seed() []byte {
+	return s.seed
+}
+
+// Salt returns the salt.
+func (s *SeedEngine) Salt() []byte {
+	return s.salt
 }
 
 func (s *SeedEngine) hkdfDerive(secret []byte, info string) ([]byte, error) {

--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -169,7 +169,7 @@ func newFakeSeedEngineAuthority() (*fakeStateAuthority, error) {
 	if err != nil {
 		return nil, err
 	}
-	fakeState := authority.NewState(seedEngine, nil, nil)
+	fakeState := authority.NewState(seedEngine, nil, nil, nil)
 
 	authority := &fakeStateAuthority{
 		state: *fakeState,

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -136,6 +136,11 @@ func (c *CA) GetRootCACert() []byte {
 	return c.rootCAPEM
 }
 
+// GetIntermCAPrivKey returns the intermediate private key of the CA.
+func (c *CA) GetIntermCAPrivKey() *ecdsa.PrivateKey {
+	return c.intermPrivKey
+}
+
 // GetIntermCACert returns the intermediate CA certificate in PEM format.
 func (c *CA) GetIntermCACert() []byte {
 	return c.intermCAPEM

--- a/internal/meshapi/meshapi.pb.go
+++ b/internal/meshapi/meshapi.pb.go
@@ -129,6 +129,110 @@ func (x *NewMeshCertResponse) GetWorkloadSecret() []byte {
 	return nil
 }
 
+type RecoverRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RecoverRequest) Reset() {
+	*x = RecoverRequest{}
+	mi := &file_meshapi_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecoverRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecoverRequest) ProtoMessage() {}
+
+func (x *RecoverRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_meshapi_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecoverRequest.ProtoReflect.Descriptor instead.
+func (*RecoverRequest) Descriptor() ([]byte, []int) {
+	return file_meshapi_proto_rawDescGZIP(), []int{2}
+}
+
+type RecoverResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Seed           []byte                 `protobuf:"bytes,1,opt,name=Seed,proto3" json:"Seed,omitempty"`
+	Salt           []byte                 `protobuf:"bytes,2,opt,name=Salt,proto3" json:"Salt,omitempty"`
+	MeshCAKey      []byte                 `protobuf:"bytes,3,opt,name=MeshCAKey,proto3" json:"MeshCAKey,omitempty"`
+	LatestManifest []byte                 `protobuf:"bytes,4,opt,name=LatestManifest,proto3" json:"LatestManifest,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RecoverResponse) Reset() {
+	*x = RecoverResponse{}
+	mi := &file_meshapi_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RecoverResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecoverResponse) ProtoMessage() {}
+
+func (x *RecoverResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_meshapi_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecoverResponse.ProtoReflect.Descriptor instead.
+func (*RecoverResponse) Descriptor() ([]byte, []int) {
+	return file_meshapi_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *RecoverResponse) GetSeed() []byte {
+	if x != nil {
+		return x.Seed
+	}
+	return nil
+}
+
+func (x *RecoverResponse) GetSalt() []byte {
+	if x != nil {
+		return x.Salt
+	}
+	return nil
+}
+
+func (x *RecoverResponse) GetMeshCAKey() []byte {
+	if x != nil {
+		return x.MeshCAKey
+	}
+	return nil
+}
+
+func (x *RecoverResponse) GetLatestManifest() []byte {
+	if x != nil {
+		return x.LatestManifest
+	}
+	return nil
+}
+
 var File_meshapi_proto protoreflect.FileDescriptor
 
 const file_meshapi_proto_rawDesc = "" +
@@ -143,9 +247,16 @@ const file_meshapi_proto_rawDesc = "" +
 	"\n" +
 	"RootCACert\x18\x03 \x01(\fR\n" +
 	"RootCACert\x12&\n" +
-	"\x0eWorkloadSecret\x18\x04 \x01(\fR\x0eWorkloadSecret2S\n" +
+	"\x0eWorkloadSecret\x18\x04 \x01(\fR\x0eWorkloadSecret\"\x10\n" +
+	"\x0eRecoverRequest\"\x7f\n" +
+	"\x0fRecoverResponse\x12\x12\n" +
+	"\x04Seed\x18\x01 \x01(\fR\x04Seed\x12\x12\n" +
+	"\x04Salt\x18\x02 \x01(\fR\x04Salt\x12\x1c\n" +
+	"\tMeshCAKey\x18\x03 \x01(\fR\tMeshCAKey\x12&\n" +
+	"\x0eLatestManifest\x18\x04 \x01(\fR\x0eLatestManifest2\x91\x01\n" +
 	"\aMeshAPI\x12H\n" +
-	"\vNewMeshCert\x12\x1b.meshapi.NewMeshCertRequest\x1a\x1c.meshapi.NewMeshCertResponseB2Z0github.com/edgelesssys/contrast/internal/meshapib\x06proto3"
+	"\vNewMeshCert\x12\x1b.meshapi.NewMeshCertRequest\x1a\x1c.meshapi.NewMeshCertResponse\x12<\n" +
+	"\aRecover\x12\x17.meshapi.RecoverRequest\x1a\x18.meshapi.RecoverResponseB2Z0github.com/edgelesssys/contrast/internal/meshapib\x06proto3"
 
 var (
 	file_meshapi_proto_rawDescOnce sync.Once
@@ -159,16 +270,20 @@ func file_meshapi_proto_rawDescGZIP() []byte {
 	return file_meshapi_proto_rawDescData
 }
 
-var file_meshapi_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_meshapi_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_meshapi_proto_goTypes = []any{
 	(*NewMeshCertRequest)(nil),  // 0: meshapi.NewMeshCertRequest
 	(*NewMeshCertResponse)(nil), // 1: meshapi.NewMeshCertResponse
+	(*RecoverRequest)(nil),      // 2: meshapi.RecoverRequest
+	(*RecoverResponse)(nil),     // 3: meshapi.RecoverResponse
 }
 var file_meshapi_proto_depIdxs = []int32{
 	0, // 0: meshapi.MeshAPI.NewMeshCert:input_type -> meshapi.NewMeshCertRequest
-	1, // 1: meshapi.MeshAPI.NewMeshCert:output_type -> meshapi.NewMeshCertResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	2, // 1: meshapi.MeshAPI.Recover:input_type -> meshapi.RecoverRequest
+	1, // 2: meshapi.MeshAPI.NewMeshCert:output_type -> meshapi.NewMeshCertResponse
+	3, // 3: meshapi.MeshAPI.Recover:output_type -> meshapi.RecoverResponse
+	2, // [2:4] is the sub-list for method output_type
+	0, // [0:2] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -185,7 +300,7 @@ func file_meshapi_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_meshapi_proto_rawDesc), len(file_meshapi_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/meshapi/meshapi.proto
+++ b/internal/meshapi/meshapi.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/edgelesssys/contrast/internal/meshapi";
 
 service MeshAPI {
   rpc NewMeshCert(NewMeshCertRequest) returns (NewMeshCertResponse);
+  rpc Recover(RecoverRequest) returns (RecoverResponse);
 }
 
 message NewMeshCertRequest {
@@ -22,4 +23,13 @@ message NewMeshCertResponse {
   bytes RootCACert = 3;
   // Raw byte slice which can be used to derive more secrets
   bytes WorkloadSecret = 4;
+}
+
+message RecoverRequest {}
+
+message RecoverResponse {
+  bytes Seed = 1;
+  bytes Salt = 2;
+  bytes MeshCAKey = 3;
+  bytes LatestManifest = 4;
 }

--- a/internal/meshapi/meshapi_grpc.pb.go
+++ b/internal/meshapi/meshapi_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	MeshAPI_NewMeshCert_FullMethodName = "/meshapi.MeshAPI/NewMeshCert"
+	MeshAPI_Recover_FullMethodName     = "/meshapi.MeshAPI/Recover"
 )
 
 // MeshAPIClient is the client API for MeshAPI service.
@@ -27,6 +28,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type MeshAPIClient interface {
 	NewMeshCert(ctx context.Context, in *NewMeshCertRequest, opts ...grpc.CallOption) (*NewMeshCertResponse, error)
+	Recover(ctx context.Context, in *RecoverRequest, opts ...grpc.CallOption) (*RecoverResponse, error)
 }
 
 type meshAPIClient struct {
@@ -47,11 +49,22 @@ func (c *meshAPIClient) NewMeshCert(ctx context.Context, in *NewMeshCertRequest,
 	return out, nil
 }
 
+func (c *meshAPIClient) Recover(ctx context.Context, in *RecoverRequest, opts ...grpc.CallOption) (*RecoverResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RecoverResponse)
+	err := c.cc.Invoke(ctx, MeshAPI_Recover_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MeshAPIServer is the server API for MeshAPI service.
 // All implementations must embed UnimplementedMeshAPIServer
 // for forward compatibility.
 type MeshAPIServer interface {
 	NewMeshCert(context.Context, *NewMeshCertRequest) (*NewMeshCertResponse, error)
+	Recover(context.Context, *RecoverRequest) (*RecoverResponse, error)
 	mustEmbedUnimplementedMeshAPIServer()
 }
 
@@ -64,6 +77,9 @@ type UnimplementedMeshAPIServer struct{}
 
 func (UnimplementedMeshAPIServer) NewMeshCert(context.Context, *NewMeshCertRequest) (*NewMeshCertResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NewMeshCert not implemented")
+}
+func (UnimplementedMeshAPIServer) Recover(context.Context, *RecoverRequest) (*RecoverResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Recover not implemented")
 }
 func (UnimplementedMeshAPIServer) mustEmbedUnimplementedMeshAPIServer() {}
 func (UnimplementedMeshAPIServer) testEmbeddedByValue()                 {}
@@ -104,6 +120,24 @@ func _MeshAPI_NewMeshCert_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MeshAPI_Recover_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RecoverRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MeshAPIServer).Recover(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MeshAPI_Recover_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MeshAPIServer).Recover(ctx, req.(*RecoverRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MeshAPI_ServiceDesc is the grpc.ServiceDesc for MeshAPI service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -114,6 +148,10 @@ var MeshAPI_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "NewMeshCert",
 			Handler:    _MeshAPI_NewMeshCert_Handler,
+		},
+		{
+			MethodName: "Recover",
+			Handler:    _MeshAPI_Recover_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
The recover handler verifies the peer Coordinator's policy and role and sends a `RecoverResponse` struct so the calling Coordinator can reconstruct its state.

The initial proto definition of the `RecoverResponse` defined in [RFC 10](https://github.com/edgelesssys/contrast/blob/main/rfc/010-distributed-coordinator.md#peer-recovery) is reduced to:
```proto
message RecoverResponse {
  bytes Seed = 1;
  bytes Salt = 2;
  bytes MeshCAKey = 3;
  bytes LatestManifest = 4;
}
```
The root CA key can already be derived by the seed and salt. The certificates can be generated afterward (this happens automatically when calling the constructor of the `CA` with given root CA and mesh CA keys).