### PR TITLE
e2e: increase timeout for rogue pod test

### DIFF
--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -97,8 +97,8 @@ func TestPolicy(t *testing.T) {
 	t.Run("pod cannot join after it was removed from the manifest", func(t *testing.T) {
 		require := require.New(t)
 
-		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(1*time.Minute))
-		defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), ct.FactorPlatformTimeout(2*time.Minute))
+		t.Cleanup(cancel)
 
 		c := kubeclient.NewForTest(t)
 


### PR DESCRIPTION
We're already spending 20s idle [waiting for readiness checks](https://github.com/edgelesssys/contrast/blob/6d9e46eac8b6eddf4e14f1547bb40f915d757cf3/e2e/internal/kubeclient/deploy.go#L206), so the timeout is probably too aggressive. 