### PR TITLE
e2e: use retry package for kubeclient.WaitFor

### DIFF
--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -201,6 +201,7 @@ func (c *Kubeclient) checkIfReady(ctx context.Context, name string, namespace st
 		if err != nil {
 			return false, err
 		}
+		c.log.Debug("readiness check complete", "kind", resource.kind(), "name", name, "namespace", namespace, "desired", desiredPods, "ready", numPodsReady)
 		if desiredPods <= numPodsReady {
 			// Wait for 5 more seconds just to be *really* sure that
 			// the pods are actually up.


### PR DESCRIPTION
Moving away from the bespoke retry mechanism should allow us to see the actual cause of failed retries, instead of `context deadline exceeded`. See also #1244.