### PR TITLE
attestation: include reason for failed CRL parsing

### DIFF
--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -153,7 +153,7 @@ func addCRLtoVerifyOptions(attestationData *sevsnp.Attestation, verifyOpts *veri
 	}
 	crl, err := x509.ParseRevocationList(crlRaw)
 	if err != nil {
-		return errors.New("could not parse CRL from attestation data")
+		return fmt.Errorf("could not parse CRL from attestation data: %w", err)
 	}
 
 	productLine := kds.ProductLine(attestationData.GetProduct())


### PR DESCRIPTION
I saw the `could not parse CRL` message in the logs while verifying the production Privatemode deployment, but without the cause attached it's hard to tell what's going wrong.