### PR TITLE
docs: load balancer and registry authentication

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -448,10 +448,27 @@ coordinator=$(kubectl get svc coordinator -o=jsonpath='{.status.loadBalancer.ing
 :::info[Port-forwarding of Confidential Containers]
 
 `kubectl port-forward` uses a Container Runtime Interface (CRI) method that isn't supported by the Kata shim.
-If you can't use a public load balancer, you can deploy a [port-forwarder](https://github.com/edgelesssys/contrast/blob/ddc371b/deployments/emojivoto/portforwarder.yml).
-The port-forwarder relays traffic from a CoCo pod and can be accessed via `kubectl port-forward`.
+If you can't use a public load balancer, you can deploy a port-forwarding pod to relay traffic to a Contrast pod:
 
-<!-- TODO(burgerdev): inline port-forwarder definition, it has been removed from main. -->
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: port-forwarder-coordinator
+spec:
+  containers:
+    - name: port-forwarder
+      image: alpine/socat
+      args:
+        - -d
+        - TCP-LISTEN:1313,fork
+        - TCP:coordinator:1313
+      resources:
+        requests:
+          memory: 50Mi
+        limits:
+          memory: 50Mi
+```
 
 Upstream tracking issue: https://github.com/kata-containers/kata-containers/issues/1693.
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -304,7 +304,7 @@ A pod configured to use GPU support may take a few minutes to come up, as the VM
 Run the `generate` command to add the necessary components to your deployment files.
 This will add the Contrast Initializer to every workload with the specified `contrast-cc` runtime class
 and the Contrast Service Mesh to all workloads that have a specified configuration.
-After that, it will generate the execution policies and add them as annotations to your deployment files.
+After that, it will generate the [execution policies](components/policies.md) and add them as annotations to your deployment files.
 A `manifest.json` with the reference values of your deployment will be created.
 
 <Tabs queryString="platform">
@@ -344,6 +344,11 @@ If you don't know the correct values use `ffffffffffffffffffffffffffffffff` and 
 :::
 </TabItem>
 </Tabs>
+
+The `generate` command needs to pull the container images to derive policies.
+Running `generate` for the first time can take a while, especially if the images are large.
+If your container registry requires authentication, you can create the necessary credentials with `docker login` or `podman login`.
+Be aware of the [registry authentication limitation](features-limitations.md#kubernetes-features) on bare metal.
 
 :::warning
 Please be aware that runtime policies currently have some blind spots. For example, they can't guarantee the starting order of containers. See the [current limitations](features-limitations.md#runtime-policies) for more details.

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -12,6 +12,7 @@ This section lists planned features and current limitations of Contrast.
 - **Persistent volumes**: Contrast only supports volumes with [`volumeMode: Block`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode). These block devices are provided by the untrusted environment and should be treated accordingly. We plan to provide transparent encryption on top of block devices in a future release.
 - **Port forwarding**: This feature [isn't yet supported by Kata Containers](https://github.com/kata-containers/kata-containers/issues/1693). You can [deploy a port-forwarder](https://docs.edgeless.systems/contrast/deployment#connect-to-the-contrast-coordinator) as a workaround.
 - **Resource limits**: There is an existing bug on AKS where container memory limits are incorrectly applied. The current workaround involves using only memory requests instead of limits.
+- **Image pull secrets**: registry authentication is only supported on AKS, see [Registry Authentication](howto/registry-authentication.md#bare-metal) for details.
 
 ## Runtime policies
 

--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -39,6 +39,7 @@ Apply this change by running `systemctl restart systemd-sysctl` and verify it us
 
 1. Follow the [K3s setup instructions](https://docs.k3s.io/) to create a cluster.
 2. Install a block storage provider such as [Longhorn](https://longhorn.io/docs/latest/deploy/install/install-with-kubectl/) and mark it as the default storage class.
+3. Ensure that a load balancer controller is installed. For development and testing purposes, the built-in [ServiceLB](https://docs.k3s.io/networking/networking-services#service-load-balancer) should suffice.
 
 ## Preparing a cluster for GPU usage
 

--- a/docs/docs/howto/registry-authentication.md
+++ b/docs/docs/howto/registry-authentication.md
@@ -1,0 +1,48 @@
+# Registry authentication
+
+This guide shows how to set up registry credentials for Contrast.
+
+## Contrast CLI
+
+The Contrast CLI, specifically the `contrast generate` subcommand, needs access to the registry to derive policies for the referenced container images.
+The CLI authenticates to the registry using the [`docker_credential`](https://crates.io/crates/docker_credential) crate.
+This crate searches some default locations for a registry authentication file, so it should find credentials created by `docker login` or `podman login`.
+
+The only authentication method that's currently supported is `Basic` HTTP authentication with user name and password (or personal access token).
+Identity token flows, such as the default mechanism of plain `docker login`, don't work.
+Basic authentication can be forced with `docker login -u $REGISTRYUSER`.
+
+You can override the credentials file used by Contrast by setting the environment variable `DOCKER_CONFIG`. This is useful for creating a credential file from scratch, as shown in the following script:
+
+```sh
+#!/bin/sh
+
+registry="<put registry here>"
+user="<put user id here>"
+password="<put client secret here>"
+
+export DOCKER_CONFIG=$(mktemp)
+
+cat >"${DOCKER_CONFIG}" <<EOF
+{
+        "auths": {
+                "$registry": {
+                        "auth": "$(printf "%s:%s" "$user" "$password" | base64 -w0)"
+                }
+        }
+}
+EOF
+
+contrast generate "$@"
+```
+
+## AKS
+
+On AKS, images are pulled on the worker nodes using credentials available to Kubernetes and containerd.
+Follow the [official instructions](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to set up registry authentication with image pull secrets.
+
+## Bare metal
+
+On bare metal, images are pulled within the confidential guest, which doesn't receive credentials from the host yet.
+You can work around this by mirroring the required images to a private registry that's only exposed to the cluster.
+Such a registry needs to have a valid TLS certificate that's trusted in the web PKI (issued by Let's Encrypt, for example).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -147,6 +147,17 @@ const sidebars = {
       ]
     },
     {
+      type: 'category',
+      label: 'How-To',
+      items: [
+        {
+          type: 'doc',
+          label: 'Registry authentication',
+          id: 'howto/registry-authentication',
+        },
+      ]
+    },
+    {
       type: 'doc',
       label: 'Planned features and limitations',
       id: 'features-limitations',


### PR DESCRIPTION
Add some missing details with respect to load balancers and registry authentication.

I have some more content for the `How-To` section in mind:

* Exposing the Coordinator with Ingress/Gateway-API
* Working with genpolicy settings
* Determine correct reference values
* Manual recovery of persistence