### PR TITLE
grpc: use default dialer implementation that supports HTTP CONNECT

### DIFF
--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 
@@ -86,7 +85,7 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("getting validators: %w", err)
 	}
 
-	dialer := dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{}, seedShareOwnerKey, log)
+	dialer := dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, nil, seedShareOwnerKey, log)
 
 	log.Debug("Dialing coordinator", "endpoint", flags.coordinator)
 	conn, err := dialer.Dial(cmd.Context(), flags.coordinator)

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"os"
 	"path"
 	"slices"
@@ -113,9 +112,9 @@ func runSet(cmd *cobra.Command, args []string) error {
 
 	var dialr *dialer.Dialer
 	if workloadOwnerKey == nil {
-		dialr = dialer.New(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{}, log)
+		dialr = dialer.New(atls.NoIssuer, validators, atls.NoMetrics, nil, log)
 	} else {
-		dialr = dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{}, workloadOwnerKey, log)
+		dialr = dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, nil, workloadOwnerKey, log)
 	}
 
 	conn, err := dialr.Dial(cmd.Context(), flags.coordinator)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0
 
 require (
 	filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87
+	github.com/elazarl/goproxy v1.7.2
 	github.com/google/go-github/v66 v66.0.0
 	github.com/google/go-sev-guest v0.13.0
 	github.com/google/go-tdx-guest v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/edgelesssys/go-sev-guest v0.0.0-20250402104424-deaf0dfccf3c h1:uYJZDRTBrk586WqI+BlgSa3kv23NsHMREIvaCJ+4/OA=
 github.com/edgelesssys/go-sev-guest v0.0.0-20250402104424-deaf0dfccf3c/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
+github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -95,7 +95,7 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 	requestCert := func() (*meshapi.NewMeshCertResponse, error) {
 		// Supply an empty list of validators, as the coordinator does not need to be
 		// validated by the initializer.
-		dial := dialer.NewWithKey(issuer, atls.NoValidators, atls.NoMetrics, &net.Dialer{}, privKey, log)
+		dial := dialer.NewWithKey(issuer, atls.NoValidators, atls.NoMetrics, nil, privKey, log)
 		conn, err := dial.Dial(ctx, net.JoinHostPort(coordinatorHostname, meshapi.Port))
 		if err != nil {
 			return nil, fmt.Errorf("dialing: %w", err)

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -89,6 +89,9 @@ func (d *Dialer) DialNoVerify(_ context.Context, target string) (*grpc.ClientCon
 }
 
 func (d *Dialer) grpcWithDialer() grpc.DialOption {
+	if d.netDialer == nil {
+		return grpc.EmptyDialOption{}
+	}
 	return grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 		return d.netDialer.DialContext(ctx, "tcp", addr)
 	})

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -215,7 +215,7 @@ buildGoModule rec {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-LKVVQ1qWFFvOZjJtPpBcmgLv2g8FZKhrwf5ZbCI+9xg=";
+  vendorHash = "sha256-lRaKOk682PkIQowXeY2oh/q4kWLXeHObUcsM3bDhslg=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
@@ -53,7 +52,7 @@ func (c Client) GetCoordinatorState(ctx context.Context, kdsDir string, manifest
 	if err != nil {
 		return CoordinatorState{}, fmt.Errorf("getting validators: %w", err)
 	}
-	dialer := dialer.New(atls.NoIssuer, validators, atls.NoMetrics, &net.Dialer{}, c.log)
+	dialer := dialer.New(atls.NoIssuer, validators, atls.NoMetrics, nil, c.log)
 
 	c.log.Debug("Dialing coordinator", "endpoint", endpoint)
 


### PR DESCRIPTION
The grpc client wrapper `internal/grpc/dialer` takes a dialer that should be used to establish connections. This allows to inject a fake dialer for testing.
In the application code, we pass a `net.Dialer` instance. This overrides grpc's default dialer implementation, which supports HTTP CONNECT. To enable this feature, pass `nil` in the application code and then don't set a custom dialer for grpc.

I need some hints on how to test this. I thought about cloning one of the e2e tests and run some HTTP proxy in a goroutine.