### PR TITLE
docs: correct sysctl setting recommendation

### DIFF
--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -26,7 +26,14 @@ Follow Canonical's instructions on [setting up Intel TDX on Ubuntu 24.04](https:
 </TabItem>
 </Tabs>
 
-Increase the `user.max_inotify_instances` sysctl limit by adding `user.max_inotify_instances=8192` to `/etc/sysctl.d/99-sysctl.conf` and running `sysctl --system`.
+Containerd uses a significant amount of `inotify` instances, so we recommend to allow at least 8192.
+If necessary, the default can be increased by creating a config override file (for example in `/etc/sysctl.d/98-containerd.conf`) with the following content:
+
+```ini
+fs.inotify.max_user_instances = 8192
+```
+
+Apply this change by running `systemctl restart systemd-sysctl` and verify it using `sysctl fs.inotify.max_user_instances`.
 
 ## K3s setup
 


### PR DESCRIPTION
The instructions pointed to a non-existent sysctl. While replacing it with the actual setting, I used the opportunity to also

* not strictly prescribe the file the setting needs to go into
* suggest that users should check whether their setting is too low, rather than telling them to blindly change the setting
* use systemd commands for applying changes
* tell users how to verify