### PR TITLE
kata: disable genpolicy integration tests

### DIFF
--- a/packages/by-name/kata/genpolicy/package.nix
+++ b/packages/by-name/kata/genpolicy/package.nix
@@ -52,17 +52,8 @@ rustPlatform.buildRustPackage rec {
     make src/version.rs
   '';
 
-  checkFlags = [
-    # these want internet access, disable them
-    "--skip=test_copyfile"
-    "--skip=test_create_container_generate_name"
-    "--skip=test_create_container_network_namespace"
-    "--skip=test_create_container_process"
-    "--skip=test_create_container_sysctls"
-    "--skip=test_create_sandbox"
-    "--skip=test_update_interface"
-    "--skip=test_update_routes"
-  ];
+  # Only run library tests, the integration tests need internet access.
+  cargoTestFlags = [ "--lib" ];
 
   passthru = rec {
     settings-base = stdenvNoCC.mkDerivation {


### PR DESCRIPTION
With this, we should not need to manually disable all tests that are added upstream in the future.