### PR TITLE
nodeinstaller: backup existing containerd config

### DIFF
--- a/docs/docs/components/runtime.md
+++ b/docs/docs/components/runtime.md
@@ -87,5 +87,7 @@ After deploying the installer, it performs the following steps on each node:
 - Install `cloud-hypervisor` or `QEMU` as the virtual machine manager (VMM)
 - Install an IGVM file or separate firmware and kernel files for pod-VMs of this class
 - Install a read only root filesystem disk image for the pod-VMs of this class
+- Backup any existing `containerd` configuration in the format
+`<containerd-path>/<config-name>.<time>.bak`
 - Reconfigure `containerd` by adding a runtime plugin that corresponds to the `handler` field of the Kubernetes `RuntimeClass`
 - Restart `containerd` to make it aware of the new plugin


### PR DESCRIPTION
With this PR, the containerd config will be backed up before the node installer overwrites it to configure the new runtime. For an atomic update, the new config will be written to a temporary file first and then replace the old config.