### PR TITLE
transitengineapi: json error bodies and logging

### DIFF
--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -6,9 +6,11 @@ package transitengine
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/edgelesssys/contrast/coordinator/internal/authority"
@@ -92,7 +94,7 @@ func TestTransitAPICyclic(t *testing.T) {
 	t.Run("encrypt-decrypt handler", func(t *testing.T) {
 		fakeStateAuthority, err := newFakeSeedEngineAuthority()
 		require.NoError(t, err)
-		mux := NewTransitEngineAPI(fakeStateAuthority, slog.Default())
+		mux := newTransitEngineMux(fakeStateAuthority, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
@@ -110,6 +112,7 @@ func TestTransitAPICyclic(t *testing.T) {
 					res := rec.Result()
 					require.Equal(tc.expStatus, res.StatusCode)
 					if tc.expStatus != http.StatusOK {
+						ciphertext = "vault:v" + strconv.Itoa(tc.encryptionInput.Version) + tc.encryptionInput.Plaintext
 						return
 					}
 


### PR DESCRIPTION
This PR adds a json httpError struct to the transit engine API, to allow json error body responses and reuses it for error logging of the handler functions.

Further the test cases were reworked to construct the ciphertext, falling back to the plaintext, in case of an expected error for the encryption. This ensures that the input validation of the decryption endpoints is tested as well and does not fail because of missing ciphertext input. 