### PR TITLE
manifest: validate guest policy

### DIFF
--- a/coordinator/internal/authority/authority_test.go
+++ b/coordinator/internal/authority/authority_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgelesssys/contrast/coordinator/history"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
+	"github.com/google/go-sev-guest/abi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/spf13/afero"
@@ -84,6 +85,9 @@ func newManifest(t *testing.T) (*manifest.Manifest, []byte, [][]byte) {
 			MicrocodeVersion:  &svn0,
 		},
 		TrustedMeasurement: manifest.NewHexString(measurement[:]),
+		GuestPolicy: abi.SnpPolicy{
+			SMT: true,
+		},
 	}}
 	mnfst.WorkloadOwnerKeyDigests = []manifest.HexString{keyDigest}
 	mnfstBytes, err := json.Marshal(mnfst)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/google/go-sev-guest/abi"
 	"github.com/google/go-sev-guest/kds"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,6 +38,9 @@ func TestValidate(t *testing.T) {
 						},
 						ProductName:        "Milan",
 						TrustedMeasurement: HexString("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+						GuestPolicy: abi.SnpPolicy{
+							SMT: true,
+						},
 					},
 				},
 			},
@@ -162,6 +166,13 @@ func TestValidate(t *testing.T) {
 			m: newTestManifestSNP(),
 			mutate: func(m *Manifest) {
 				m.ReferenceValues.SNP[0].ProductName = "unknown"
+			},
+			wantErr: true,
+		},
+		"snp guest policy smt not set": {
+			m: newTestManifestSNP(),
+			mutate: func(m *Manifest) {
+				m.ReferenceValues.SNP[0].GuestPolicy.SMT = false
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
We currently only allow two static policies. This changes will detect modification of the guest policy in the manifest early to give the user a proper error.