### PR TITLE
transitengineapi: mTLS with client authorization by workloadSecret 

### DIFF
--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -94,7 +94,7 @@ func TestTransitAPICyclic(t *testing.T) {
 	t.Run("encrypt-decrypt handler", func(t *testing.T) {
 		fakeStateAuthority, err := newFakeSeedEngineAuthority()
 		require.NoError(t, err)
-		mux := newTransitEngineMux(fakeStateAuthority, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		mux := newMockTransitEngineMux(fakeStateAuthority)
 
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
@@ -182,4 +182,13 @@ func newFakeSeedEngineAuthority() (*fakeStateAuthority, error) {
 
 func (f *fakeStateAuthority) GetState() (*authority.State, error) {
 	return f.state, nil
+}
+
+
+func newMockTransitEngineMux(authority stateAuthority) *http.ServeMux {
+	mux := http.NewServeMux()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mux.Handle("/v1/transit/encrypt/{name}", getEncryptHandler(authority,logger))
+	mux.Handle("/v1/transit/decrypt/{name}", getDecryptHandler(authority,logger))
+	return mux
 }

--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -184,11 +184,10 @@ func (f *fakeStateAuthority) GetState() (*authority.State, error) {
 	return f.state, nil
 }
 
-
 func newMockTransitEngineMux(authority stateAuthority) *http.ServeMux {
 	mux := http.NewServeMux()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	mux.Handle("/v1/transit/encrypt/{name}", getEncryptHandler(authority,logger))
-	mux.Handle("/v1/transit/decrypt/{name}", getDecryptHandler(authority,logger))
+	mux.Handle("/v1/transit/encrypt/{name}", getEncryptHandler(authority, logger))
+	mux.Handle("/v1/transit/decrypt/{name}", getDecryptHandler(authority, logger))
 	return mux
 }


### PR DESCRIPTION
This PR introduces mTLS to the transit engine API to secure connections based on Contrast mesh certs.

- The client is only authorized to the transit key set of the workloadSecretID in the received meshCert extension. As prior we handle the <name> parameter of existing Vault implementations as our workloadSecretID.

- On initialization the transit engine API derives a private ecdsa key. For each incoming TLS connection of the transit engine API, the coordinator issues itself a fresh mesh cert for this private key of the transit engine API, which is therefore valid for the current state.

 The logging mechanism introduced in #1345 and the new authorizationMiddleware is bypassed during testing using a mock transitengine API.  