### PR TITLE
meshapi: add workload secret as extension

### DIFF
--- a/internal/attestation/extension/extension.go
+++ b/internal/attestation/extension/extension.go
@@ -85,3 +85,8 @@ func ConvertExtensions(extensions []Extension) ([]pkix.Extension, error) {
 	}
 	return exts, nil
 }
+
+// ConvertExtension converts a single extension into a pkix extension.
+func ConvertExtension(extension Extension) (pkix.Extension, error) {
+	return extension.toExtension()
+}

--- a/internal/oid/oid.go
+++ b/internal/oid/oid.go
@@ -12,3 +12,8 @@ var RawSNPReport = asn1.ObjectIdentifier{1, 3, 9901, 2, 1}
 // RawTDXReport is the root OID for the raw TDX report extensions
 // used by the aTLS issuer and validator.
 var RawTDXReport = asn1.ObjectIdentifier{1, 3, 9901, 2, 2}
+
+// WorkloadSecretOID is the root OID for the workloadSecretID report
+// extension, added to the mesh certificates to allow verification
+// and authorization based on the workloadSecretID.
+var WorkloadSecretOID = asn1.ObjectIdentifier{1, 3, 9901, 3, 1}


### PR DESCRIPTION
This PR adds an extension to the issued mesh certificates holding the workloadSecretID, if set in the manifest entry. Therefore allowing for faster authorization without any manifest look-ups.