### PR TITLE
ci: periodically update kubernetes resources

### DIFF
--- a/.github/workflows/update_ci_resources.yml
+++ b/.github/workflows/update_ci_resources.yml
@@ -1,0 +1,47 @@
+name: update ci resources
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *' # 1 AM every day
+
+env:
+  container_registry: ghcr.io/edgelesssys
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test_matrix:
+    strategy:
+      matrix:
+        platform:
+          - name: K3s-QEMU-SNP
+            runner: SNP
+          - name: K3s-QEMU-TDX
+            runner: TDX
+          - name: K3s-QEMU-SNP-GPU
+            runner: SNP-GPU
+    name: "${{ matrix.platform.name }}"
+    runs-on: ${{ matrix.platform.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create justfile.env
+        run: |
+          cat <<EOF > justfile.env
+          container_registry=${{ env.container_registry }}
+          EOF
+      - name: Build and push cleanup-bare-metal image
+        run: |
+          just push cleanup-bare-metal
+      - name: Update kubernetes resources
+        run: |
+          kubectl apply -f ./tools/bm-maintenance/deployment_tdx_snp.yml
+          kubectl create configmap bm-tcb-specs --from-file=./dev-docs/e2e/tcb-specs.json -n default --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
This adds a GitHub cronjob which periodically applies all YAML resources for the CI clusters from main. This currently includes the bare-metal cleanup cronjob and the tcb-specs config map.

[Successful run for TDX](https://github.com/edgelesssys/contrast/actions/runs/14335559151)