### PR TITLE
docs: improve language of SNP attestation

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -146,7 +146,7 @@ const sidebars = {
         },
         {
           type: 'doc',
-          label: 'SNP Attestation',
+          label: 'AMD SEV-SNP attestation',
           id: 'architecture/snp',
         },
       ]

--- a/docs/versioned_sidebars/version-1.7-sidebars.json
+++ b/docs/versioned_sidebars/version-1.7-sidebars.json
@@ -132,7 +132,7 @@
         },
         {
           "type": "doc",
-          "label": "SNP Attestation",
+          "label": "AMD SEV-SNP attestation",
           "id": "architecture/snp"
         }
       ]

--- a/tools/vale/styles/config/vocabularies/edgeless/accept.txt
+++ b/tools/vale/styles/config/vocabularies/edgeless/accept.txt
@@ -157,7 +157,7 @@ virsh
 VMs?
 VSCode
 walkthrough
-whitepaper
+whitepapers?
 WireGuard
 Xeon
 xsltproc


### PR DESCRIPTION
I reviewed the docs page. Content LGTM, so I didn't make changes in that respect.

Apart from language improvements, notable changes are:
* Added one or two introductory sentences to some of the sections.
* Removed some fields from the attestation report table. Please let me know if you think these should stay.