### PR TITLE
resourcegen: bump mem requests

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -594,7 +594,7 @@ func MySQL() []any {
 										WithMountPropagation(corev1.MountPropagationHostToContainer),
 								).
 								WithResources(ResourceRequirements().
-									WithMemoryLimitAndRequest(1000),
+									WithMemoryLimitAndRequest(2000),
 								),
 						).
 						WithVolumes(
@@ -649,7 +649,7 @@ done
 								WithEnv(NewEnvVar("MYSQL_ALLOW_EMPTY_PASSWORD", "1")).
 								WithCommand("/bin/sh", "-c", clientCmd).
 								WithResources(ResourceRequirements().
-									WithMemoryLimitAndRequest(1000),
+									WithMemoryLimitAndRequest(2000),
 								),
 						),
 				),

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -580,7 +580,7 @@ func MySQL() []any {
 						WithContainers(
 							Container().
 								WithName("mysql-backend").
-								WithImage("docker.io/library/mysql:latest").
+								WithImage("docker.io/library/mysql:9.1.0@sha256:0255b469f0135a0236d672d60e3154ae2f4538b146744966d96440318cc822c6").
 								WithEnv(NewEnvVar("MYSQL_ALLOW_EMPTY_PASSWORD", "1")).
 								WithPorts(
 									ContainerPort().

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -209,7 +209,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		emojiSvcHost = "emoji-svc:8080"
 		votingSvcHost = "voting-svc:8080"
 		// Our modified images are around 100MiB compressed.
-		memoryLimitMiB = 500
+		memoryLimitMiB = 600
 	case ServiceMeshIngressEgress:
 		emojiSvcImage = "docker.io/buoyantio/emojivoto-emoji-svc:v11@sha256:957949355653776b65fafc2ee22f737cd21e090d4ace63f3b99f6e16976f0458"
 		emojiVotingSvcImage = "docker.io/buoyantio/emojivoto-voting-svc:v11@sha256:a57ac67af7a5b05988a38b49568eca6a078ef27a71c148c44c9db4efb1dac58b"
@@ -219,7 +219,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		emojiSvcHost = "127.137.0.1:8081"
 		votingSvcHost = "127.137.0.2:8081"
 		// Upstream images are at most 75MiB compressed, but we're adding the service mesh image with 50MiB.
-		memoryLimitMiB = 700
+		memoryLimitMiB = 800
 	default:
 		panic(fmt.Sprintf("unknown service mesh mode: %s", smMode))
 	}

--- a/justfile
+++ b/justfile
@@ -293,7 +293,7 @@ wait-for-workload target=default_deploy_target:
             nix run -L .#scripts.kubectl-wait-ready -- $ns openssl-backend
             nix run -L .#scripts.kubectl-wait-ready -- $ns openssl-frontend
         ;;
-        "emojivoto" | "emojivoto-sm-egress" | "emojivoto-sm-ingress")
+        "emojivoto" | "emojivoto-sm-ingress")
             nix run -L .#scripts.kubectl-wait-ready -- $ns emoji-svc
             nix run -L .#scripts.kubectl-wait-ready -- $ns vote-bot
             nix run -L .#scripts.kubectl-wait-ready -- $ns voting-svc


### PR DESCRIPTION
I needed to bump the mem requests for mysql to be able to start it. Since the mysql deployment is not tested nightly, I think this broke when we introduced the various sidecars or adjusted our VM overhead we add.

I also bumped the emojivoto-sm-ingress (does both ingress and egress SM), which succeeded in the nightly, but failed when testing. This is because in the just target we add dmesg sidecar containers. If I remove them, I can deploy emojivoto with the memory numbers from the main branch. 