### PR TITLE
coordinator: expose methods for external recovery

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -219,6 +219,21 @@ func (m *Authority) GetState() (*State, error) {
 	return state, nil
 }
 
+// NeedsRecovery decides whether the Coordinator at hand needs recovery.
+func (m *Authority) NeedsRecovery() bool {
+	state := m.state.Load()
+	if state != nil {
+		return state.stale.Load()
+	}
+	hasLatest, err := m.hist.HasLatest()
+	if err != nil {
+		m.logger.Warn("Could not access history", "error", err)
+		// If we can't access history, a recovery attemtpt is unlikely to help.
+		return false
+	}
+	return hasLatest
+}
+
 // State is a snapshot of the Coordinator's manifest history.
 type State struct {
 	seedEngine    *seedengine.SeedEngine


### PR DESCRIPTION
We're going to add an external recovery mechanism to the enterprise package, which does not have accesss to the internal structs of the authority. Thus, we add two functions that can be called from outside:

* `RecoverWith` allows the enterprise package to perform peer recovery with all the checks from RFC010, while the authority only updates its internal state without checking.
* `NeedsRecovery` allows for early abort of recovery attempts, to be used in the peer recovery loop and the readiness probe.