### PR TITLE
enterprise: make peerdiscovery a struct

### DIFF
--- a/enterprise/coordinator/peerdiscovery/peerdiscovery.go
+++ b/enterprise/coordinator/peerdiscovery/peerdiscovery.go
@@ -16,9 +16,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type Discovery struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+func New(client kubernetes.Interface, namespace string) *Discovery {
+	return &Discovery{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
 // GetPeers returns a list of Coordinator IPs that are ready to be used for peer recovery.
-func GetPeers(ctx context.Context, client kubernetes.Interface, namespace string) ([]string, error) {
-	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+func (d *Discovery) GetPeers(ctx context.Context) ([]string, error) {
+	// TODO(burgerdev): this should be an informer with cache.
+	pods, err := d.client.CoreV1().Pods(d.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set{"app.kubernetes.io/name": "coordinator"}.String(),
 	})
 	if err != nil {

--- a/enterprise/coordinator/peerdiscovery/peerdiscovery_test.go
+++ b/enterprise/coordinator/peerdiscovery/peerdiscovery_test.go
@@ -72,7 +72,7 @@ func TestGetPeers(t *testing.T) {
 			t.Setenv("HOSTNAME", host)
 
 			client := fake.NewSimpleClientset(tc.pods...)
-			peers, err := GetPeers(context.Background(), client, namespace)
+			peers, err := New(client, namespace).GetPeers(context.Background())
 			require.NoError(err)
 			slices.Sort(tc.expected)
 			slices.Sort(peers)


### PR DESCRIPTION
This makes it easier to use `GetPeers`, because I don't need to hold on to the clientset. It also allows for future improvements, like an informer cache.