### PR TITLE
node-installer: fix timestamp precision in unit restart detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0
 
 require (
 	filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/elazarl/goproxy v1.7.2
 	github.com/google/go-github/v66 v66.0.0
 	github.com/google/go-sev-guest v0.13.0
@@ -51,6 +52,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3 h1:oe6
 github.com/canonical/go-sp800.90a-drbg v0.0.0-20210314144037-6eeb1040d6c3/go.mod h1:qdP0gaj0QtgX2RUZhnlVrceJ+Qln8aSlDyJwelLLFeM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -38,6 +40,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -222,9 +222,14 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 							WithMemoryRequest(700),
 						).
 						WithSecurityContext(SecurityContext().WithPrivileged(true).SecurityContextApplyConfiguration).
-						WithVolumeMounts(VolumeMount().
-							WithName("host-mount").
-							WithMountPath("/host")).
+						WithVolumeMounts(
+							VolumeMount().
+								WithName("host-mount").
+								WithMountPath("/host"),
+							VolumeMount().
+								WithName("var-run-dbus-socket").
+								WithMountPath("/var/run/dbus/system_bus_socket"),
+						).
 						WithCommand("/bin/node-installer", platform.String()),
 					).
 					WithContainers(
@@ -237,6 +242,12 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 							WithHostPath(HostPathVolumeSource().
 								WithPath("/").
 								WithType(corev1.HostPathDirectory),
+							),
+						Volume().
+							WithName("var-run-dbus-socket").
+							WithHostPath(HostPathVolumeSource().
+								WithPath("/var/run/dbus/system_bus_socket").
+								WithType(corev1.HostPathSocket),
 							),
 					)...,
 					),

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -237,7 +237,7 @@ buildGoModule rec {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-GZF1cKzpmMxlJHFvcgv7rk1BHRZjyuBJCme1V+DO1Go=";
+  vendorHash = "sha256-pRSgIOTmpTTx8yVFUaNryNvfRPDufz9IExXnOb4zQB0=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Previously, we only parsed the containerd/k3s restart time with second precision, which lead to unnecessary restarts as we couldn't if the restart happened after or before the config mtime. With this change, we will use micro second precision.

However, there is a bug in the systemd version/build used by azurelinux on AKS, which won't include the micro seconds for unknown reason. So instead of invoking systemctl, we talk to dbus directly to get the raw start time.

However, while we already mount the host path under `/host` into the node-installer, and the dbus socket is under `/var/run/dbus` on the host, `/var/run` is usually a symlink to `/run`, and depending on the way distros create this symlink, it might point out of `/host` to the `/run` inside the container. This is the case on Ubuntu, as the symlink is `/var/run -> /run`. This is a problem, as there is noting under `/run` of the container, especially no dbus socket. On azurelinux, this isn't a problem, as the symlink is relative `/var/run -> ../run`, so it is still pointing to correctly to `/host/run`. To solve this, we mount the dbus socket as separate volume.