### PR TITLE
coordinator: fix race condition in authority test

### DIFF
--- a/coordinator/internal/authority/authority.go
+++ b/coordinator/internal/authority/authority.go
@@ -122,6 +122,7 @@ func (m *Authority) WatchHistory(ctx context.Context) error {
 		m.logger.Error("WatchLatestTransitions failed, starting a new watcher", "error", err)
 		select {
 		case <-m.clock.After(5 * time.Second):
+			m.logger.Info("time for a new watcher")
 			continue
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
It turns out that #1317  introduced two race conditions in test code:

1. If the testclock was stepped before the watcher called `clock.After`, the notification about the step would go nowhere and the watcher would wait forever to restart the loop.
2. In `badStore.Watch` we sent a notification about the call happening before actually handing out the channel. This could lead to the caller receiving the new channel, not the one the test logic was closing.

I fixed both, restructured the test code so that the main test logic is easier to understand (by hiding the channel sends and receives in functions of store and clock), and switched from `clock.After` to `clock.NewTimer` because `clock.After` is still documented to leak resources (not sure whether this is still the case, though, as this was fixed at least in the `time` package).

Tested:

```console
$ go test -count 10000 -failfast -run '^TestBadStoreWatcherIsRestarted$' github.com/edgelesssys/contrast/coordinator/internal/authority -race 
ok  	github.com/edgelesssys/contrast/coordinator/internal/authority	104.262s
```