### PR TITLE
manifest: add and validate SNP PlatformInfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ toolchain go1.23.4
 // The upstream package has some stepping issues with Genoa:
 // https://github.com/google/go-sev-guest/issues/115
 // https://github.com/google/go-sev-guest/issues/103
-replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250402104424-deaf0dfccf3c
+// Includes cherry-pick of unmerged PR to fix platform info validation:
+// https://github.com/google/go-sev-guest/pull/161
+replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f
 
 require (
 	filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgelesssys/go-sev-guest v0.0.0-20250402104424-deaf0dfccf3c h1:uYJZDRTBrk586WqI+BlgSa3kv23NsHMREIvaCJ+4/OA=
-github.com/edgelesssys/go-sev-guest v0.0.0-20250402104424-deaf0dfccf3c/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f h1:oHNe8GacgdRfDccQeGSokAmuCEGh7xqz0By4/d0PRUc=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -142,9 +142,10 @@ func (m *Manifest) SNPValidateOpts(kdsGetter trust.HTTPSGetter) ([]ValidatorOpti
 		idKeyHash := sha512.Sum384(idKeyBytes)
 
 		validateOpts := snpvalidate.Options{
-			Measurement: trustedMeasurement,
-			GuestPolicy: refVal.GuestPolicy,
-			VMPL:        new(int), // VMPL0
+			Measurement:  trustedMeasurement,
+			PlatformInfo: &refVal.PlatformInfo,
+			GuestPolicy:  refVal.GuestPolicy,
+			VMPL:         new(int), // VMPL0
 			MinimumTCB: kds.TCBParts{
 				BlSpl:    refVal.MinimumTCB.BootloaderVersion.UInt8(),
 				TeeSpl:   refVal.MinimumTCB.TEEVersion.UInt8(),

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -88,6 +88,7 @@ type SNPReferenceValues struct {
 	ProductName        ProductName
 	TrustedMeasurement HexString
 	GuestPolicy        abi.SnpPolicy
+	PlatformInfo       abi.SnpPlatformInfo
 }
 
 // Validate checks the validity of all fields in the AKS reference values.

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -234,7 +234,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-pRSgIOTmpTTx8yVFUaNryNvfRPDufz9IExXnOb4zQB0=";
+  vendorHash = "sha256-CcVjfs0+WfJ8tWyaXyrKVb4fp+MqyvroSvm7QS2wklo=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -63,6 +63,9 @@ let
         snp = [
           {
             guestPolicy = builtins.fromJSON (builtins.readFile microsoft.kata-igvm.snp-guest-policy);
+            platformInfo = {
+              SMTEnabled = true;
+            };
             minimumTCB = {
               bootloaderVersion = 3;
               teeVersion = 0;
@@ -84,6 +87,9 @@ let
         snp =
           let
             guestPolicy = builtins.fromJSON (builtins.readFile ./snpGuestPolicyQEMU.json);
+            platformInfo = {
+              SMTEnabled = true;
+            };
             launch-digest = kata.calculateSnpLaunchDigest {
               inherit os-image;
               debug = kata.contrast-node-installer-image.debugRuntime;
@@ -91,12 +97,12 @@ let
           in
           [
             {
-              inherit guestPolicy;
+              inherit guestPolicy platformInfo;
               trustedMeasurement = builtins.readFile "${launch-digest}/milan.hex";
               productName = "Milan";
             }
             {
-              inherit guestPolicy;
+              inherit guestPolicy platformInfo;
               trustedMeasurement = builtins.readFile "${launch-digest}/genoa.hex";
               productName = "Genoa";
             }


### PR DESCRIPTION
This allows more fine grained control over the SNP reference values.