### PR TITLE
coordinator: distributed deployment with auto-recovery

### DIFF
--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -8,16 +8,19 @@ on:
         required: true
         type: choice
         options:
+          # keep-sorted start
+          - atls
           - genpolicy
           - getdents
           - gpu
           - openssl
+          - peerrecovery
           - policy
           - regression
           - servicemesh
           - volumestatefulset
           - workloadsecret
-          - atls
+          # keep-sorted end
         default: "openssl"
       platform:
         description: "Platform"

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -23,7 +23,16 @@ jobs:
           - name: K3s-QEMU-SNP-GPU
             runner: SNP-GPU
             self-hosted: true
-        test-name: [servicemesh, openssl, policy, workloadsecret, volumestatefulset, atls]
+        test-name:
+          # keep-sorted start
+          - atls
+          - openssl
+          - peerrecovery
+          - policy
+          - servicemesh
+          - volumestatefulset
+          - workloadsecret
+          # keep-sorted end
         include:
           - platform:
               name: K3s-QEMU-SNP-GPU
@@ -37,6 +46,9 @@ jobs:
               self-hosted: true
             test-name: gpu
             enterprise: true
+        exclude:
+          - test-name: peerrecovery
+            enterprise: false
       fail-fast: false
     name: "${{ matrix.enterprise && 'enterprise ' || '' }}${{ matrix.platform.name }}"
     uses: ./.github/workflows/e2e.yml

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -129,6 +129,9 @@ func run() (retErr error) {
 	meshapiStarted := &startupHandler.MeshapiStarted
 
 	transitAPIServer, err := transitengine.NewTransitEngineAPI(meshAuth, logger)
+	if err != nil {
+		return fmt.Errorf("creating transit engine API server: %w", err)
+	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/coordinator/main_enterprise.go
+++ b/coordinator/main_enterprise.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build enterprise
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/edgelesssys/contrast/enterprise/coordinator/peerdiscovery"
+	"github.com/edgelesssys/contrast/enterprise/coordinator/peerrecovery"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func registerEnterpriseServices(ctx context.Context, eg *errgroup.Group, c *components) {
+	eg.Go(func() error {
+		c.logger.Info("Watching manifest store")
+		if err := c.guard.WatchHistory(ctx); err != nil {
+			c.logger.Error("Watching manifest store", "err", err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			return err
+		}
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			return err
+		}
+		namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		if err != nil {
+			return err
+		}
+
+		c.logger.Info("Coordinator peer recovery started")
+		discovery := peerdiscovery.New(clientset, string(namespace))
+		return peerrecovery.New(c.guard, discovery, c.issuer, c.httpsGetter, c.logger).RunRecovery(ctx)
+	})
+}

--- a/coordinator/main_oss.go
+++ b/coordinator/main_oss.go
@@ -1,0 +1,14 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !enterprise
+
+package main
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func registerEnterpriseServices(context.Context, *errgroup.Group, *components) {}

--- a/docs/docs/howto/coordinator-ha.md
+++ b/docs/docs/howto/coordinator-ha.md
@@ -1,0 +1,73 @@
+# Coordinator High-Availability
+
+This guide shows how to scale the Contrast Coordinator to more than one instance and make it highly available.
+
+## Workflow
+
+Deploy the Coordinator according to the [basic workflow](../deployment.md).
+By default, there is only one Coordinator instance.
+Verify that this Coordinator is in state `Ready`:
+
+```sh
+kubectl get pods -l app.kubernetes.io/name=coordinator
+```
+
+```raw
+NAME            READY   STATUS    RESTARTS   AGE
+coordinator-0   1/1     Running   0          11m
+```
+
+Next, we increase the number of instances to 3.
+This will create additional Coordinator instances, one after another, as described in the [Kubernetes documentation for `StatefulSet`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#deployment-and-scaling-guarantees).
+After some time, the additional Coordinators should enter the `Ready` state, too.
+
+```sh
+kubectl scale statefulset/coordinator --replicas 3
+kubectl wait statefulset/coordinator --for=jsonpath='{.status.readyReplicas}=3' --timeout=2m
+kubectl get pods -l app.kubernetes.io/name=coordinator
+```
+
+```raw
+statefulset.apps/coordinator scaled
+statefulset.apps/coordinator condition met
+NAME            READY   STATUS    RESTARTS   AGE
+coordinator-0   1/1     Running   0          14m
+coordinator-1   1/1     Running   0          107s
+coordinator-2   1/1     Running   0          73s
+```
+
+You can now try deleting individual Coordinator pods, draining a node in a multi-node cluster, or scheduling a full rollout of the Coordinator.
+Availability of the Coordinator endpoint shouldn't be affected, and all Coordinator pods should automatically recover.
+
+```sh
+kubectl rollout restart statefulset/coordinator
+kubectl rollout status statefulset/coordinator -w
+kubectl get pods -l app.kubernetes.io/name=coordinator
+
+```
+
+```raw
+statefulset.apps/coordinator restarted
+Waiting for 1 pods to be ready...
+Waiting for partitioned roll out to finish: 1 out of 3 new pods have been updated...
+Waiting for 1 pods to be ready...
+Waiting for 1 pods to be ready...
+Waiting for 1 pods to be ready...
+Waiting for partitioned roll out to finish: 2 out of 3 new pods have been updated...
+Waiting for 1 pods to be ready...
+Waiting for 1 pods to be ready...
+Waiting for 1 pods to be ready...
+partitioned roll out complete: 3 new pods have been updated...
+NAME            READY   STATUS    RESTARTS   AGE
+coordinator-0   1/1     Running   0          41s
+coordinator-1   1/1     Running   0          71s
+coordinator-2   1/1     Running   0          99s
+```
+
+## How it works
+
+<!-- TODO(burgerdev): link to Coordinator page after https://github.com/edgelesssys/contrast/pull/1436 landed. -->
+
+Newly started (or restarted) Coordinator instances try to recover from other Coordinator instances in the cluster.
+As long as a single Coordinator is initialized, the other instances eventually recover from it.
+`StatefulSet` semantics guarantee that Coordinator pods are started predictably, and only after all existing Coordinators are recovered.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -157,6 +157,11 @@ const sidebars = {
       items: [
         {
           type: 'doc',
+          label: 'Coordinator high-availability',
+          id: 'howto/coordinator-ha',
+        },
+        {
+          type: 'doc',
           label: 'Registry authentication',
           id: 'howto/registry-authentication',
         },

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -377,6 +377,15 @@ func (c *Kubeclient) ScaleDeployment(ctx context.Context, namespace, name string
 	return err
 }
 
+// ScaleStatefulSet scales a StatefulSet to the given number of replicas.
+func (c *Kubeclient) ScaleStatefulSet(ctx context.Context, namespace, name string, replicas int32) error {
+	_, err := c.Client.AppsV1().StatefulSets(namespace).UpdateScale(ctx, name, &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+	}, metav1.UpdateOptions{})
+	return err
+}
+
 func toPtr[T any](t T) *T {
 	return &t
 }

--- a/e2e/peerrecovery/peerrecovery_test.go
+++ b/e2e/peerrecovery/peerrecovery_test.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build e2e
+
+package peerrecovery
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/contrast/cli/cmd"
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+// TestPeerRecovery tests that enterprise-edition Coordinators started after the first Coordinator
+// recover automatically from the existing peer.
+func TestPeerRecovery(t *testing.T) {
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
+	require.NoError(t, err)
+	ct := contrasttest.New(t)
+
+	runtimeHandler, err := manifest.RuntimeHandler(platform)
+	require.NoError(t, err)
+
+	resources := kuberesource.CoordinatorBundle()
+
+	resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
+
+	resources = kuberesource.AddPortForwarders(resources)
+
+	ct.Init(t, resources)
+
+	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+
+	require.True(t, t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("contrast verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
+
+	numCoordinators := 3
+	require.True(t, t.Run("scale coordinator", func(t *testing.T) {
+		require := require.New(t)
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(3*time.Minute))
+		t.Cleanup(cancel)
+
+		require.NoError(ct.Kubeclient.ScaleStatefulSet(ctx, ct.Namespace, "coordinator", int32(numCoordinators)))
+		require.NoError(ct.Kubeclient.WaitForStatefulSet(ctx, ct.Namespace, "coordinator"))
+	}), "coordinator needs to scale up for subsequent tests to run")
+
+	t.Run("coordinators recover", func(t *testing.T) {
+		// Now that the Coordinator is scaled up, we verify that each of the additional instances
+		// recovers eventually, by running verify against each of the individual pods, from a
+		// fresh directory to rule out any interference between the verify calls.
+		require := require.New(t)
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
+		t.Cleanup(cancel)
+
+		// Read the generated manifest for subsequent verify steps in per-pod subdirectories.
+		manifestBytes, err := os.ReadFile(path.Join(ct.WorkDir, "manifest.json"))
+		require.NoError(err)
+
+		// Create a temporary directory for output of verify commands.
+		workspaceRoot := t.TempDir()
+
+		// Fetch image replacements for patching the port-forwarder pods.
+		f, err := os.Open(ct.ImageReplacementsFile)
+		require.NoError(err)
+		imageReplacements, err := kuberesource.ImageReplacementsFromFile(f)
+		require.NoError(err)
+
+		// Get the list of pods to verify.
+		pods, err := ct.Kubeclient.PodsFromOwner(ctx, ct.Namespace, "StatefulSet", "coordinator")
+		require.NoError(err)
+		require.Len(pods, 3)
+
+		for _, pod := range pods {
+			// Apply a port-forwarder that targets only the current iteration's pod under test.
+			forwarder := kuberesource.PortForwarder(pod.Name, ct.Namespace).
+				WithListenPorts([]int32{1313}).
+				WithForwardTarget(pod.Status.PodIP).
+				PodApplyConfiguration
+			forwarder, ok := kuberesource.PatchImages([]any{forwarder}, imageReplacements)[0].(*applycorev1.PodApplyConfiguration)
+			require.True(ok)
+
+			_, err := ct.Kubeclient.Client.CoreV1().Pods(ct.Namespace).Apply(ctx, forwarder, metav1.ApplyOptions{FieldManager: "peerrecovery_test"})
+			require.NoError(err)
+
+			// Copy the manifest to the subdirectory of this pod.
+			workspace := path.Join(workspaceRoot, pod.Name)
+			require.NoError(os.Mkdir(workspace, 0o777))
+			require.NoError(os.WriteFile(path.Join(workspace, "manifest.json"), manifestBytes, 0o600))
+		}
+
+		require.EventuallyWithT(func(collect *assert.CollectT) {
+			assert := assert.New(collect)
+			for _, pod := range pods {
+				// Run verify from the pod's workspace subdir against the pod's dedicated forwarder.
+				cmd := cmd.NewVerifyCmd()
+				cmd.Flags().String("workspace-dir", path.Join(workspaceRoot, pod.Name), "")
+				cmd.Flags().String("log-level", "debug", "")
+				assert.NoErrorf(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-"+pod.Name, "1313", func(addr string) error {
+					args := []string{
+						"--coordinator", addr,
+					}
+					cmd.SetArgs(args)
+					cmd.SetOut(io.Discard)
+					errBuf := &bytes.Buffer{}
+					cmd.SetErr(errBuf)
+
+					if err := cmd.Execute(); err != nil {
+						return fmt.Errorf("running %q: %s", cmd.Use, errBuf)
+					}
+					return nil
+				}), "pod %s not recovered", pod.Name)
+			}
+		}, 2*time.Minute, 5*time.Second)
+	})
+}
+
+func TestMain(m *testing.M) {
+	contrasttest.RegisterFlags()
+	flag.Parse()
+
+	os.Exit(m.Run())
+}

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -29,18 +29,21 @@ let
     env.CGO_ENABLED = 0;
 
     subPackages = [
+      # keep-sorted start
+      "e2e/aks-runtime"
+      "e2e/atls"
       "e2e/genpolicy"
       "e2e/getdents"
       "e2e/gpu"
       "e2e/openssl"
-      "e2e/servicemesh"
-      "e2e/release"
+      "e2e/peerrecovery"
       "e2e/policy"
-      "e2e/workloadsecret"
-      "e2e/volumestatefulset"
       "e2e/regression"
-      "e2e/aks-runtime"
-      "e2e/atls"
+      "e2e/release"
+      "e2e/servicemesh"
+      "e2e/volumestatefulset"
+      "e2e/workloadsecret"
+      # keep-sorted end
     ];
   };
 


### PR DESCRIPTION
This PR adds support for deploying multiple replicas of the Coordinator.

Further reading:

* [RFC 010](rfc/010-distributed-coordinator.md)
* [Documentation](https://docs.edgeless.systems/contrast/howto/coordinator-ha) (after v1.9 is released)

---

Testing:

* [ ] nightly: TODO
* [x] manual:
  * [x] `just e2e openssl AKS-CLH-SNP`