### PR TITLE
sdk: take cache as input for ValidatorsFromManifest

### DIFF
--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -74,13 +74,11 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("decrypting seed: %w", err)
 	}
 
-	kdsDir, err := cachedir("kds")
+	kdsGetter, err := cachedHTTPSGetter(log)
 	if err != nil {
-		return fmt.Errorf("getting cache dir: %w", err)
+		return fmt.Errorf("configuring KDS cache: %w", err)
 	}
-	log.Debug("Using KDS cache dir", "dir", kdsDir)
-
-	validators, err := sdk.ValidatorsFromManifest(kdsDir, &m, log)
+	validators, err := sdk.ValidatorsFromManifest(kdsGetter, &m, log)
 	if err != nil {
 		return fmt.Errorf("getting validators: %w", err)
 	}

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -99,13 +99,11 @@ func runSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("checking policies match manifest: %w", err)
 	}
 
-	kdsDir, err := cachedir("kds")
+	kdsGetter, err := cachedHTTPSGetter(log)
 	if err != nil {
-		return fmt.Errorf("getting cache dir: %w", err)
+		return fmt.Errorf("configuring KDS cache: %w", err)
 	}
-	log.Debug("Using KDS cache dir", "dir", kdsDir)
-
-	validators, err := sdk.ValidatorsFromManifest(kdsDir, &m, log)
+	validators, err := sdk.ValidatorsFromManifest(kdsGetter, &m, log)
 	if err != nil {
 		return fmt.Errorf("getting validators: %w", err)
 	}

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -11,22 +11,18 @@ import (
 	"strings"
 
 	"github.com/edgelesssys/contrast/internal/atls"
-	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
-	"github.com/edgelesssys/contrast/internal/fsstore"
 	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/google/go-sev-guest/verify/trust"
 )
 
 // ValidatorsFromManifest returns a list of validators corresponding to the reference values in the given manifest.
 // Originally an unexported function in the contrast CLI.
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
 // Validators MUST NOT be used concurrently.
-func ValidatorsFromManifest(kdsDir string, m *manifest.Manifest, log *slog.Logger) ([]atls.Validator, error) {
-	kdsCache := fsstore.New(kdsDir, log.WithGroup("kds-cache"))
-	kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"))
-
+func ValidatorsFromManifest(kdsGetter trust.HTTPSGetter, m *manifest.Manifest, log *slog.Logger) ([]atls.Validator, error) {
 	var validators []atls.Validator
 
 	coordPolicyHash, err := m.CoordinatorPolicyHash()


### PR DESCRIPTION
This allows reusing an existing cache, which will be used from the enterprise recovery code that verifies the peer coordinator. 

I'm leaving the `GetCoordinatorState` signature for now because we have a rework of the `CachedHTTPSGetter` scheduled, which would require changing the signature once more.