### PR TITLE
ci: use the right GPU runner for manual tests

### DIFF
--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -55,8 +55,12 @@ jobs:
               echo "runner=ubuntu-22.04" >> "$GITHUB_OUTPUT"
               echo "self-hosted=false" >> "$GITHUB_OUTPUT"
             ;;
-            "K3s-QEMU-SNP"|"K3s-QEMU-SNP-GPU")
+            "K3s-QEMU-SNP")
               echo "runner=SNP" >> "$GITHUB_OUTPUT"
+              echo "self-hosted=true" >> "$GITHUB_OUTPUT"
+            ;;
+            "K3s-QEMU-SNP-GPU")
+              echo "runner=SNP-GPU" >> "$GITHUB_OUTPUT"
               echo "self-hosted=true" >> "$GITHUB_OUTPUT"
             ;;
             "K3s-QEMU-TDX")


### PR DESCRIPTION
* [ ] [manual test](https://github.com/edgelesssys/contrast/actions/runs/14473919357)