### PR TITLE
transitengineapi: activate and expose in coordinator

### DIFF
--- a/coordinator/internal/transitengineapi/transitengineapi.go
+++ b/coordinator/internal/transitengineapi/transitengineapi.go
@@ -70,13 +70,12 @@ type stateAuthority interface {
 }
 
 // NewTransitEngineAPI sets up the transit engine API with a provided seedEngineAuthority.
-func NewTransitEngineAPI(authority stateAuthority, port int, logger *slog.Logger) (*http.Server, error) {
+func NewTransitEngineAPI(authority stateAuthority, logger *slog.Logger) (*http.Server, error) {
 	privKeyAPI, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating transit engine API private key")
 	}
 	return &http.Server{
-		Addr: fmt.Sprintf(":%d", port),
 		TLSConfig: &tls.Config{
 			ClientAuth: tls.RequireAndVerifyClientCert,
 			GetConfigForClient: func(_ *tls.ClientHelloInfo) (*tls.Config, error) {


### PR DESCRIPTION
This PRs activates the transit engine API in a subroutine of the coordinator. For now the default port to expose the transit engine API will be 8200, following the standard of different Vault implementations.