### PR TITLE
runtime: remove nydus on bare metal

### DIFF
--- a/nodeinstaller/internal/constants/constants.go
+++ b/nodeinstaller/internal/constants/constants.go
@@ -168,7 +168,6 @@ func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platf
 		Path:                         filepath.Join(baseDir, "bin", "containerd-shim-contrast-cc-v2"),
 		PodAnnotations:               []string{"io.katacontainers.*"},
 		PrivilegedWithoutHostDevices: true,
-		Snapshotter:                  snapshotter,
 	}
 
 	switch platform {
@@ -176,6 +175,7 @@ func ContainerdRuntimeConfigFragment(baseDir, snapshotter string, platform platf
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-clh-snp.toml"),
 		}
+		cfg.Snapshotter = snapshotter
 	case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-tdx.toml"),

--- a/nodeinstaller/testdata/expected-bare-metal-qemu-snp-gpu.toml
+++ b/nodeinstaller/testdata/expected-bare-metal-qemu-snp-gpu.toml
@@ -52,7 +52,6 @@ runtime_type = 'io.containerd.contrast-cc.v2'
 runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
 pod_annotations = ['io.katacontainers.*', 'cdi.k8s.io/*']
 privileged_without_host_devices = true
-snapshotter = 'nydus-my-runtime'
 
 [plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
 ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-qemu-snp.toml'

--- a/nodeinstaller/testdata/expected-bare-metal-qemu-snp.toml
+++ b/nodeinstaller/testdata/expected-bare-metal-qemu-snp.toml
@@ -52,7 +52,6 @@ runtime_type = 'io.containerd.contrast-cc.v2'
 runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
 pod_annotations = ['io.katacontainers.*']
 privileged_without_host_devices = true
-snapshotter = 'nydus-my-runtime'
 
 [plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
 ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-qemu-snp.toml'

--- a/nodeinstaller/testdata/expected-bare-metal-qemu-tdx.toml
+++ b/nodeinstaller/testdata/expected-bare-metal-qemu-tdx.toml
@@ -52,7 +52,6 @@ runtime_type = 'io.containerd.contrast-cc.v2'
 runtime_path = '/opt/edgeless/my-runtime/bin/containerd-shim-contrast-cc-v2'
 pod_annotations = ['io.katacontainers.*']
 privileged_without_host_devices = true
-snapshotter = 'nydus-my-runtime'
 
 [plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.my-runtime.options]
 ConfigPath = '/opt/edgeless/my-runtime/etc/configuration-qemu-tdx.toml'

--- a/packages/by-name/kata/kata-runtime/0019-runtime-force-guest-pull.patch
+++ b/packages/by-name/kata/kata-runtime/0019-runtime-force-guest-pull.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Fri, 18 Apr 2025 11:43:43 +0200
+Subject: [PATCH] runtime: force guest pull
+
+---
+ src/runtime/virtcontainers/fs_share_linux.go | 22 ++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/src/runtime/virtcontainers/fs_share_linux.go b/src/runtime/virtcontainers/fs_share_linux.go
+index 0dc11cbed55145c958541cabd52cacaa4e2623f3..da2798ef01f33f7dcf5db82c35a28c5cefbf4f91 100644
+--- a/src/runtime/virtcontainers/fs_share_linux.go
++++ b/src/runtime/virtcontainers/fs_share_linux.go
+@@ -542,9 +542,31 @@ func (f *FilesystemShare) shareRootFilesystemWithVirtualVolume(ctx context.Conte
+ 	}, nil
+ }
+ 
++func forceGuestPull(c *Container) (*SharedFile, error) {
++	sf := &SharedFile{
++		guestPath: filepath.Join("/run/kata-containers/", c.id, c.rootfsSuffix),
++	}
++	guestPullVolume := &types.KataVirtualVolume{
++		VolumeType: types.KataVirtualVolumeImageGuestPullType,
++		ImagePull: &types.ImagePullVolume{
++			Metadata: map[string]string{},
++		},
++	}
++	vol, err := handleVirtualVolumeStorageObject(c, "", guestPullVolume)
++	if err != nil {
++		return nil, fmt.Errorf("forcing guest pull virtual volume: %w", err)
++	}
++	sf.containerStorages = append(sf.containerStorages, vol)
++	return sf, nil
++}
++
+ // func (c *Container) shareRootfs(ctx context.Context) (*grpc.Storage, string, error) {
+ func (f *FilesystemShare) ShareRootFilesystem(ctx context.Context, c *Container) (*SharedFile, error) {
+ 
++	if 1 > 0 { // TODO(burgerdev): should be forced by option
++		return forceGuestPull(c)
++	}
++
+ 	if HasOptionPrefix(c.rootFs.Options, VirtualVolumePrefix) {
+ 		return f.shareRootFilesystemWithVirtualVolume(ctx, c)
+ 	}

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -139,6 +139,9 @@ buildGoModule (finalAttrs: {
       # it makes sense at all, so we're fixing this downstream only.
       # https://github.com/kata-containers/kata-containers/pull/11077#issuecomment-2750400613
       ./0018-genpolicy-allow-RO-and-RW-for-sysfs-with-privileged-.patch
+
+      # Experimental: unconditionally force guest pull without snapshotter.
+      ./0019-runtime-force-guest-pull.patch
     ];
   };
 


### PR DESCRIPTION
This is a PoC of guest pull without Nydus. The Kata patch forces to enter guest pull mode, even if the snapshotter did not provide the Kata virtual volume option. The rest of this PR just removes Nydus from the runtime, to show that it actually works. 