### PR TITLE
treewide: print unified preface string on startup

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
+	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
 	loggerpkg "github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/memstore"
@@ -56,6 +57,9 @@ func main() {
 func run() (retErr error) {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
+
+	fmt.Fprintf(os.Stderr, "Contrast Coordinator %s\n", constants.Version)
+	fmt.Fprintln(os.Stderr, "Report issues at https://github.com/edgelesssys/contrast/issues")
 
 	logger, err := loggerpkg.Default()
 	if err != nil {

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -48,11 +48,12 @@ func execute() error {
 
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:          "initializer",
-		Short:        "initializer",
-		RunE:         run,
-		SilenceUsage: true,
-		Version:      constants.Version,
+		Use:              "initializer",
+		Short:            "initializer",
+		PersistentPreRun: printPreface,
+		RunE:             run,
+		SilenceUsage:     true,
+		Version:          constants.Version,
 	}
 	root.InitDefaultVersionFlag()
 	root.AddCommand(
@@ -183,4 +184,9 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 	defer cancel()
 
 	return setupEncryptedMount(ctx, log, flags)
+}
+
+func printPreface(cmd *cobra.Command, _ []string) {
+	fmt.Fprintf(cmd.ErrOrStderr(), "Contrast initializer %s\n", constants.Version)
+	fmt.Fprintln(cmd.ErrOrStderr(), "Report issues at https://github.com/edgelesssys/contrast/issues")
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,11 +7,13 @@ import (
 	"time"
 )
 
-// Version value is injected at build time.
 var (
-	Version                   = "0.0.0-dev"
+	// Version is the version of Contrast.
+	Version = "0.0.0-dev"
+	// MicrosoftGenpolicyVersion is the version of Microsoft's genpolicy tool.
 	MicrosoftGenpolicyVersion = "0.0.0-dev"
-	KataGenpolicyVersion      = "0.0.0-dev"
+	// KataGenpolicyVersion is the version of Kata's genpolicy tool.
+	KataGenpolicyVersion = "0.0.0-dev"
 )
 
 const (

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
+	globalconstants "github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/nodeinstaller/internal/asset"
@@ -28,6 +29,9 @@ import (
 )
 
 func main() {
+	fmt.Fprintf(os.Stderr, "Contrast node-installer %s\n", globalconstants.Version)
+	fmt.Fprintln(os.Stderr, "Report issues at https://github.com/edgelesssys/contrast/issues")
+
 	shouldRestartContainerd := flag.Bool("restart", true, "Restart containerd after the runtime installation to make the changes effective.")
 	flag.Parse()
 

--- a/packages/by-name/contrast-enterprise/package.nix
+++ b/packages/by-name/contrast-enterprise/package.nix
@@ -4,6 +4,6 @@
 { contrast }:
 
 contrast.overrideAttrs (prevAttrs: {
-  pname = prevAttrs.pname + "-enterprise";
+  version = prevAttrs.version + "+enterprise";
   tags = prevAttrs.tags ++ [ "enterprise" ];
 })

--- a/service-mesh/main.go
+++ b/service-mesh/main.go
@@ -28,7 +28,8 @@ func main() {
 }
 
 func run() (retErr error) {
-	log.Printf("service-mesh version %s\n", version)
+	fmt.Fprintf(os.Stderr, "Contrast service-mesh %s\n", version)
+	fmt.Fprintln(os.Stderr, "Report issues at https://github.com/edgelesssys/contrast/issues")
 
 	egressProxyConfig := os.Getenv(egressProxyConfigEnvVar)
 	log.Println("Ingress Proxy configuration:", egressProxyConfig)


### PR DESCRIPTION
This will help to differentiate enterprise from non-enterprise components, identify the version of running containers as well as guide users to the right place to report issues.