### PR TITLE
docs: configure GPU operator for CC mode

### DIFF
--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -103,7 +103,8 @@ helm install --wait --generate-name \
    --set sandboxWorkloads.defaultWorkload='vm-passthrough' \
    --set nfd.nodefeaturerules=true \
    --set vfioManager.enabled=true \
-   --set ccManager.enabled=true
+   --set ccManager.enabled=true \
+   --set ccManager.defaultMode=on
 ```
 
 Refer to the [official installation instructions](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) for details and further options.

--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -83,7 +83,6 @@ To enable GPU usage on a Contrast cluster, some conditions need to be fulfilled 
 4. A CDI configuration needs to be present on the node. To generate it, you can use the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
    Refer to the official instructions on [how to generate a CDI configuration with it](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html).
 
-
 If the per-node requirements are fulfilled, deploy the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest) to the cluster. It provisions pod-VMs with GPUs via VFIO.
 
 Initially, label all nodes that *should run GPU workloads*:
@@ -92,13 +91,17 @@ Initially, label all nodes that *should run GPU workloads*:
 kubectl label node <node-name> nvidia.com/gpu.workload.config=vm-passthrough
 ```
 
-For a GPU-enabled Contrast cluster, you can then deploy the operator with the following command:
+For a GPU-enabled Contrast cluster, you can then deploy the operator with the following commands:
 
 ```sh
+# Add the NVIDIA Helm repository
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
+
+# Install the GPU Operator
 helm install --wait --generate-name \
    -n gpu-operator --create-namespace \
    nvidia/gpu-operator \
-   --version=v24.9.1 \
+   --version=v25.3.0 \
    --set sandboxWorkloads.enabled=true \
    --set sandboxWorkloads.defaultWorkload='vm-passthrough' \
    --set nfd.nodefeaturerules=true \

--- a/docs/docs/getting-started/bare-metal.md
+++ b/docs/docs/getting-started/bare-metal.md
@@ -38,6 +38,7 @@ Apply this change by running `systemctl restart systemd-sysctl` and verify it us
 ## K3s setup
 
 1. Follow the [K3s setup instructions](https://docs.k3s.io/) to create a cluster.
+   Contrast is currently tested with K3s version `v1.31.5+k3s1`.
 2. Install a block storage provider such as [Longhorn](https://longhorn.io/docs/latest/deploy/install/install-with-kubectl/) and mark it as the default storage class.
 3. Ensure that a load balancer controller is installed. For development and testing purposes, the built-in [ServiceLB](https://docs.k3s.io/networking/networking-services#service-load-balancer) should suffice.
 


### PR DESCRIPTION
Our instructions were lacking the Helm value that makes cc-manager set the GPU to confidential mode. These instructions were taken from [upstream documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-confidential-containers.html#procedure), which is either just wrong or assumes some other component activates CC mode.

---

The other commit includes some minor fixes I found useful while reconfiguring discovery:

* Add instructions for k3s config override. We had these files on some runners in the past, but it appears that they've been lost between reinstalls. The config I'm including here
  * allow the `github` user (and others) to access `k3s.yaml` via `sudo` membership
  * disable the default storage class, since we're installing longhorn
  * increase the CRI request timeout (while not strictly needed right now, it may be for larger VMs; also, it does not hurt and documents how to do this).
* Pin the k3s version.
* Customize longhorn installation to need less _free_ space on the rootfs and to not allocate unneeded replicas.
* Use upstream Nix instead of determinate (determinate comes with a bunch of settings that I'm not sure we want, and I don't see why _not_ to use upstream).
* Configure nix for Cachix.
* Remove `hetzner-*` references where they were hindering my copy-paste routine. 