### PR TITLE
e2e: print stdout on gpu test error

### DIFF
--- a/e2e/gpu/gpu_test.go
+++ b/e2e/gpu/gpu_test.go
@@ -66,7 +66,7 @@ func TestGPU(t *testing.T) {
 
 		argv := []string{"/bin/sh", "-c", "nvidia-smi"}
 		stdout, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, pods[0].Name, argv)
-		require.NoError(err, "stderr: %q", stderr)
+		require.NoError(err, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
 
 		require.Contains(stdout, gpuName, "nvidia-smi output should contain %s", gpuName)
 	})


### PR DESCRIPTION
`nvidia-smi` reports (some?) errors on stdout - for example, when the GPU is missing in the container it will print `No devices were found` on stdout.