### PR TITLE
e2e: better logging in aks runtime test

### DIFF
--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -39,7 +39,7 @@ func TestAKSRuntime(t *testing.T) {
 	kataPolicyGenV, err := az.KataPolicyGenVersion()
 	require.NoError(err)
 	rg := os.Getenv("azure_resource_group")
-	nodeImageV, err := az.NodeImageVersion(rg, rg)
+	nodeImageV, err := az.NodeImageVersion(context.Background(), rg, rg)
 	require.NoError(err)
 	t.Log("katapolicygen version: ", kataPolicyGenV)
 	t.Log("node image version: ", nodeImageV)

--- a/e2e/aks-runtime/aks_runtime_test.go
+++ b/e2e/aks-runtime/aks_runtime_test.go
@@ -39,7 +39,7 @@ func TestAKSRuntime(t *testing.T) {
 	kataPolicyGenV, err := az.KataPolicyGenVersion()
 	require.NoError(err)
 	rg := os.Getenv("azure_resource_group")
-	nodeImageV, err := az.NodeImageVersion(context.Background(), rg, rg)
+	nodeImageV, err := az.NodeImageVersion(t.Context(), rg, rg)
 	require.NoError(err)
 	t.Log("katapolicygen version: ", kataPolicyGenV)
 	t.Log("node image version: ", nodeImageV)


### PR DESCRIPTION
Fix the e2e rutnime test by downgrading the `aks-preview` extension version. Additionally this PR improves logging if the azure CLI errors.