### PR TITLE
treefmt: catch debug default true

### DIFF
--- a/packages/by-name/image-podvm/package.nix
+++ b/packages/by-name/image-podvm/package.nix
@@ -5,7 +5,7 @@
   buildVerityUKI,
   mkNixosConfig,
 
-  withDebug ? true,
+  withDebug ? false,
   withGPU ? false,
   withCSP ? "azure",
 }:

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -612,4 +612,19 @@
       exit $exitcode
     '';
   };
+
+  lint-no-debug = writeShellApplication {
+    name = "lint-no-debug";
+    runtimeInputs = with pkgs; [ gnugrep ];
+    text = ''
+      exitcode=0
+      for file in "$@"; do
+        if grep -i -q -E 'debug.* \? true,' "$file"; then
+          echo "Found enabled debug option in $file" >&2
+          exitcode=1
+        fi
+      done
+      exit $exitcode
+    '';
+  };
 }

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -70,6 +70,11 @@
         "e2e/**/*.go"
       ];
     };
+    # Catch debug arguments in nix code that were accidentally left on true.
+    lint-no-debug = {
+      command = "${lib.getExe pkgs.scripts.lint-no-debug}";
+      includes = [ "*.nix" ];
+    };
     vale = {
       command = "${
         pkgs.vale.withStyles (


### PR DESCRIPTION
Sometimes, one toggles a debug arg and commits it by accident. This check should catch it and ensure debug is disabled by default.