### PR TITLE
e2e/workloadsecret: require first secret to be present

### DIFF
--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -79,7 +79,7 @@ func TestWorkloadSecrets(t *testing.T) {
 
 	var webWorkloadSecretBytes []byte
 	var webPods []corev1.Pod
-	t.Run("workload secret seed exists", func(t *testing.T) {
+	require.True(t, t.Run("workload secret seed exists", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
 
@@ -97,7 +97,7 @@ func TestWorkloadSecrets(t *testing.T) {
 		webWorkloadSecretBytes, err = hex.DecodeString(stdout)
 		require.NoError(err)
 		require.Len(webWorkloadSecretBytes, constants.SecretSeedSize)
-	})
+	}), "workload secret seed needs to be present in the pod for subsequent tests")
 
 	t.Run("workload secret seed is the same between pods in the same deployment", func(t *testing.T) {
 		assert := assert.New(t)


### PR DESCRIPTION
We use this in the following steps to compare against, so continuing doesn't make sense if this step fails.

https://github.com/edgelesssys/contrast/actions/runs/14723444334/job/41321362053