### PR TITLE
scripts.generate: sync go directive after each tidy

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -113,6 +113,11 @@
       while IFS= read -r dir; do
         echo "Running go mod tidy on $dir" >&2
         go mod -C "$dir" tidy
+
+        # go mod tidy bumps the go version if a dependency requires a newer one.
+        # We need to run go-directive-sync again to sync the go version.
+        go-directive-sync
+
         echo "Running go generate on $dir" >&2
         go generate -C "$dir" ./...
       done < <(go list -f '{{.Dir}}' -m)


### PR DESCRIPTION
The codegen + apply on renovate bot failed due to the following error: https://github.com/edgelesssys/contrast/actions/runs/14726095314/job/41328978996?pr=1421

This occurs because the go version in the go.mod is bumped if a dependency requires a newer version. Since we try to `go generate` afterwards our code needs to build, which it only does if the go.work also requires this newer version. Therefore, we need to sync the version after each `go mod tidy`.