### PR TITLE
e2e/aks-runtime: print az extensions

### DIFF
--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -80,6 +80,7 @@ jobs:
 
           az extension add --name aks-preview
           az extension add --name confcom
+          az extension list
       - name: E2E test
         run: |
           nix build .#scripts.get-logs


### PR DESCRIPTION
The current aks runtime test fails with confcom 1.2.3 and aks-preview 14.0.0b6, but works with confcom 1.1.1 and aks-preview 14.0.0b6 For easier reproduction, we should print those versions after installing the latest one.