### PR TITLE
microsoft.genpolicy: fix regression in env var checks

### DIFF
--- a/packages/by-name/microsoft/genpolicy/0011-genpolicy-match-sandbox-name-by-regex.patch
+++ b/packages/by-name/microsoft/genpolicy/0011-genpolicy-match-sandbox-name-by-regex.patch
@@ -220,7 +220,7 @@ index 298af4eb577687246125dc567743a2f49742d905..10091aaff6f8c16ed5fdab26815cd4ed
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/yaml.rs b/src/tools/genpolicy/src/yaml.rs
-index 8ae1000eb319267a7732132ee42731c792ebd48c..37bcd01fe62cc70b5edeef9e47477ba8de10868e 100644
+index 8ae1000eb319267a7732132ee42731c792ebd48c..3adcb87c997dff2359033246b5c6a31626f1dc89 100644
 --- a/src/tools/genpolicy/src/yaml.rs
 +++ b/src/tools/genpolicy/src/yaml.rs
 @@ -15,6 +15,7 @@ use crate::job;
@@ -250,7 +250,7 @@ index 8ae1000eb319267a7732132ee42731c792ebd48c..37bcd01fe62cc70b5edeef9e47477ba8
 +            } else if let Some(name) = &meta.name {
 +                return Some(format!("^{name}-[a-zA-Z0-9-]+$"))
 +            } else if let Some(generate_name) = &meta.generateName {
-+                return Some(format!("^{generate_name}-[a-zA-Z0-9-]+$"))
++                return Some(format!("^{generate_name}[a-zA-Z0-9-]+$"))
 +            }
 +        }
 +        first = false

--- a/packages/by-name/microsoft/genpolicy/0013-genpolicy-don-t-overwrite-env-vars-from-image.patch
+++ b/packages/by-name/microsoft/genpolicy/0013-genpolicy-don-t-overwrite-env-vars-from-image.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Mon, 12 May 2025 20:33:17 +0200
+Subject: [PATCH] genpolicy: don't overwrite env vars from image
+
+If a container image declares the environment variables HOSTNAME or
+TERM, these should take precedence over hard-coded defaults. This commit
+changes the logic to only append the default variables if they are
+absent from image spec.
+
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/tools/genpolicy/src/policy.rs | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
+index 7f442b66262202a2a75daf4b322eea7905092aba..e1ece31e0648a51b1bdbe472ec09ccfec8e27660 100644
+--- a/src/tools/genpolicy/src/policy.rs
++++ b/src/tools/genpolicy/src/policy.rs
+@@ -29,6 +29,7 @@ use serde_yaml::Value;
+ use sha2::{Digest, Sha256};
+ use std::boxed;
+ use std::collections::BTreeMap;
++use std::fmt::format;
+ use std::fs::read_to_string;
+ use std::io::Write;
+ 
+@@ -703,12 +704,12 @@ impl AgentPolicy {
+         if let Some(tty) = yaml_container.tty {
+             process.Terminal = tty;
+             if tty && !is_pause_container {
+-                process.Env.push("TERM=xterm".to_string());
++                add_default_env_var(&mut process.Env, "TERM", "xterm");
+             }
+         }
+ 
+         if !is_pause_container {
+-            process.Env.push("HOSTNAME=$(host-name)".to_string());
++            add_default_env_var(&mut process.Env, "HOSTNAME", "$(host-name)");
+         }
+ 
+         let service_account_name = if let Some(s) = &yaml_container.serviceAccountName {
+@@ -739,6 +740,15 @@ impl AgentPolicy {
+     }
+ }
+ 
++fn add_default_env_var(env: &mut Vec<String>, key: &str, val: &str) {
++    for kv_pair in &mut *env {
++        if kv_pair.split_once("=").filter(|(k, _)| *k == key).is_some() {
++            return
++        }
++    }
++    env.push(format!("{}={}", key, val));
++}
++
+ impl KataSpec {
+     fn add_annotations(&self, annotations: &mut BTreeMap<String, String>) {
+         for a in &self.Annotations {

--- a/packages/by-name/microsoft/genpolicy/package.nix
+++ b/packages/by-name/microsoft/genpolicy/package.nix
@@ -93,6 +93,11 @@ rustPlatform.buildRustPackage rec {
       # Cherry-pick from https://github.com/kata-containers/kata-containers/pull/10925,
       # which isn't yet included in the Microsoft fork.
       ./0012-genpolicy-fail-when-layer-can-t-be-processed.patch
+
+      # Ensure that environment variables from the image configuration are not overwritten by
+      # defaults in genpolicy. Fixes a regression introduced in
+      # https://github.com/microsoft/kata-containers/commit/e82c19e4d5fc771bfe54b97ff0aef8a4f5c98e71.
+      ./0013-genpolicy-don-t-overwrite-env-vars-from-image.patch
     ];
   };
 


### PR DESCRIPTION
Addresses an issue with images that set HOSTNAME in their configuration, and an unrelated issue with `generateName` resources.

Fixed regression test: https://github.com/edgelesssys/contrast/actions/runs/14983444437