### PR TITLE
ci: call nix develop as early as possible

### DIFF
--- a/.github/workflows/asciinema.yml
+++ b/.github/workflows/asciinema.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Configure git
         run: |
           git config --global user.name "edgelessci"
@@ -30,7 +31,6 @@ jobs:
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Create justfile.env
         run: |
           cat <<EOF > justfile.env

--- a/.github/workflows/bm_maintenance.yml
+++ b/.github/workflows/bm_maintenance.yml
@@ -27,13 +27,13 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Create justfile.env
         run: |
           cat <<EOF > justfile.env

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -22,13 +22,13 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Create justfile.env
         run: |
           cat <<EOF > justfile.env

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -52,7 +53,6 @@ jobs:
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Create justfile.env
         run: |
           cat <<EOF > justfile.env

--- a/.github/workflows/e2e_runtime-reproducibility.yml
+++ b/.github/workflows/e2e_runtime-reproducibility.yml
@@ -34,13 +34,13 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: "" # Don't use the cachix cache
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Allow unrestricted user namespaces
         # Ubuntu 24.04 ships strict apparmor defaults, so we have to disable them to be able to call
         # unshare in the Nix sansbox without beeing root. This is used for the microsoft.kata-image for example.
         run: |
           sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
           sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Build
         id: build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,6 +466,8 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        if: (!matrix.platform.self-hosted)
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -477,8 +479,6 @@ jobs:
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
-        if: (!matrix.platform.self-hosted)
       - name: Create justfile.env
         run: |
           cat <<EOF > justfile.env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,7 +467,6 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
-        if: (!matrix.platform.self-hosted)
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:


### PR DESCRIPTION
CI runs failed for the AKS-CLH-SNP platform, throwing the following error:

```
Run just get-credentials
WARNING: The behavior of this command has been altered by the following extension: aks-preview
ERROR: The command failed with an unexpected error. Here is the traceback:
ERROR: Can't get attribute 'NormalizedResponse' on <module 'msal.throttled_http_client' from '/nix/store/y9dfql21dz1pdbih9rbj32ihakd3h5zm-python3.12-msal-1.32.0/lib/python3.12/site-packages/msal/throttled_http_client.py'>
Traceback (most recent call last):
  File "/nix/store/m1laj52lgyi2nbsipvkxqjxbzf0gl[76](https://github.com/edgelesssys/contrast/actions/runs/15036728921/job/42259774549#step:8:77)4-python3.12-knack-0.12.0/lib/python3.12/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 666, in execute
    raise ex
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 734, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 703, in _run_job
    result = cmd_copy(params)
             ^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/__init__.py", line 336, in __call__
    return self.handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/command_operation.py", line 111, in handler
    client = self.client_factory(self.cli_ctx, command_args) if self.client_factory else None
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i8g86rvvvqddm32hqakds2vxihpw41b0-azure-cli-extensions/aks-preview/azext_aks_preview/_client_factory.py", line 31, in cf_managed_clusters
    return get_container_service_client(cli_ctx).managed_clusters
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/i8g86rvvvqddm32hqakds2vxihpw41b0-azure-cli-extensions/aks-preview/azext_aks_preview/_client_factory.py", line 23, in get_container_service_client
    return get_mgmt_service_client(cli_ctx, CUSTOM_MGMT_AKS_PREVIEW, subscription_id=subscription_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/client_factory.py", line [83](https://github.com/edgelesssys/contrast/actions/runs/15036728921/job/42259774549#step:8:84), in get_mgmt_service_client
    client, _ = _get_mgmt_service_client(cli_ctx, client_type, subscription_id=subscription_id,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n[85](https://github.com/edgelesssys/contrast/actions/runs/15036728921/job/42259774549#step:8:86)ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/commands/client_factory.py", line 231, in _get_mgmt_service_client
    credential, subscription_id, _ = profile.get_login_credentials(
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/_profile.py", line 430, in get_login_credentials
    credential = self._create_credential(account)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/_profile.py", line 697, in _create_credential
    return identity.get_service_principal_credential(username_or_sp_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/auth/identity.py", line 243, in get_service_principal_credential
    return ServicePrincipalCredential(client_id, client_credential, **self._msal_app_kwargs)
                                                                      ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/auth/identity.py", line [100](https://github.com/edgelesssys/contrast/actions/runs/15036728921/job/42259774549#step:8:101), in _msal_app_kwargs
    Identity._msal_http_cache = self._load_msal_http_cache()
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/auth/identity.py", line 133, in _load_msal_http_cache
    http_cache = BinaryCache(self._msal_http_cache_file)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/auth/binary_cache.py", line 28, in __init__
    self.load()
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/auth/binary_cache.py", line 44, in load
    self.data = self._load()
                ^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/decorators.py", line [102](https://github.com/edgelesssys/contrast/actions/runs/15036728921/job/42259774549#step:8:103), in _wrapped_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ndmrwwclr6xg1ir2n85ipv0dk7mc2ami-python3.12-azure-cli-core-2.71.0/lib/python3.12/site-packages/azure/cli/core/auth/binary_cache.py", line 35, in _load
    return pickle.load(f)
           ^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'NormalizedResponse' on <module 'msal.throttled_http_client' from '/nix/store/y9dfql21dz1pdbih9rbj32ihakd3h5zm-python3.12-msal-1.32.0/lib/python3.12/site-packages/msal/throttled_http_client.py'>. Did you mean: '_msal_public_app_kwargs'?
error: Recipe `get-credentials` failed with exit code 1
```

This was due to a version mismatch in the msal dependency of azure-cli.

- GitHub runner images were upgraded [from azure-cli v2.71.0 to v2.72.0](https://github.com/actions/runner-images/commit/fb338fd690510ee165305da04cf7c77b5cb687c1#diff-66aec6097318276b09842a3ba2caf3037afbd8dadca2dfcdf76631100613ea69R117)
- v2.72.0 of azure-cli uses [msal 2.32.3](https://github.com/Azure/azure-cli/commit/1696f9fe0e31bb89c5eef0d1a1d73bf424cc4a9a)
- The azure-login action used the azure-cli from the image, as we executed the login before activating the nix shell with nix-develop
- msal version from the login wrote credentials to FS
- We then did nix-develop and used azure-cli from nixpkgs, which is 2.71.0 at this point, using msal 2.32.0
- azure-cli from nixpkgs can't read the existing credentials using the older msal version

Using the same version for login and request solves the issue.

This pointed me also to the fact that I forgot to override msal version when packaging 2.72.0 in nixpkgs (https://github.com/NixOS/nixpkgs/pull/407286, but that didn't play a role here).