### PR TITLE
nixos: exclude non-deterministic dates from NVIDIA man pages

### DIFF
--- a/packages/nixos/gpu.nix
+++ b/packages/nixos/gpu.nix
@@ -42,6 +42,9 @@ let
           ]
         );
 
+        # Override the `date` utility to keep timestamps out of the generated man page.
+        makeFlags = oldAttrs.makeFlags ++ [ "DATE=/bin/true" ];
+
         # Hack to pass the "right" (i.e. the overridden) version of the nvidia driver to the persistenced.
         # Looking at the package definition, it _should_ already do so, but it doesn't.
         # So for now, override all occurences of `nvidia_x11` in the persistenced package "manually".

--- a/packages/nixos/image.nix
+++ b/packages/nixos/image.nix
@@ -20,6 +20,11 @@ in
   config = {
     system.image.version = "1-rc1";
 
+    documentation = {
+      man.enable = false;
+      nixos.enable = false;
+    };
+
     # We build the image with systemd-repart, which integrates well
     # with the systemd utilities we use for dm-verity, UKI, etc.
     # However, we do not use the repart unit, as we don't want


### PR DESCRIPTION
The nvidia-persistenced build includes a man page that's not reproducible because of a dynamically rendered date. Fortunately, it can be overridden with the `DATE` env var.

* `DATE` overrides the `date` utility here: https://github.com/NVIDIA/nvidia-persistenced/blob/8c620178a92c835ab921811938bea8a4d41ba49e/utils.mk#L112,
* is then used to render a date string here: https://github.com/NVIDIA/nvidia-persistenced/blob/8c620178a92c835ab921811938bea8a4d41ba49e/Makefile#L178
* which is finally included in the man page here: https://github.com/NVIDIA/nvidia-persistenced/blob/8c620178a92c835ab921811938bea8a4d41ba49e/nvidia-persistenced.1.m4#L15

I first tried disabling the man pages altogether, but the persistenced package does not seem to respect that setting. Anyway, I decided to keep man pages disabled because we won't need them in the guest vm.