### PR TITLE
[release/v1.8] cli: correct manifest generation for CronJob

### DIFF
--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -67,7 +67,7 @@ func policiesFromKubeResources(yamlPaths []string) ([]deployment, error) {
 		case *kubeapi.Job:
 			annotation = obj.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = manifest.Role(obj.Spec.Template.Annotations[contrastRoleAnnotationKey])
-		case kubeapi.CronJob:
+		case *kubeapi.CronJob:
 			name = obj.Name
 			annotation = obj.Spec.JobTemplate.Spec.Template.Annotations[kataPolicyAnnotationKey]
 			role = manifest.Role(obj.Spec.JobTemplate.Spec.Template.Annotations[contrastRoleAnnotationKey])


### PR DESCRIPTION
Backport of #1452 to `release/v1.8`.

Original description:

---

Cronjobs used to be skipped by accident, works now.