### PR TITLE
dev-docs: update tcb specs for TDX

### DIFF
--- a/dev-docs/e2e/tcb-specs.json
+++ b/dev-docs/e2e/tcb-specs.json
@@ -14,7 +14,7 @@
     "tdx": [
         {
             "MinimumTeeTcbSvn": "04010200000000000000000000000000",
-            "MrSeam": "1cc6a17ab799e9a693fac7536be61c12ee1e0fabada82d0c999e08ccee2aa86de77b0870f558c570e7ffe55d6d47fa04"
+            "MrSeam": "49b66faa451d19ebbdbe89371b8daf2b65aa3984ec90110343e9e2eec116af08850fa20e3b1aa9a874d77a65380ee7e6"
         }
     ]
 }


### PR DESCRIPTION
This updates the tcb spec for TDX after the firmware update on our TDX platform. The config map in the runners cluster is already updated. 

Also, remove constants in just for tcb override and instead use the values from the config map of the used cluster. Notice that it would be less correct to use the locally present tcb spec file, as that would require all devs to rebase when the spec changes, whereas using the config map allows fast switching and less noise.