### PR TITLE
coordinator: consider instances with stale or no manifests unready

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -421,7 +421,7 @@ spec:
   initContainers:
     - env:
         - name: COORDINATOR_HOST
-          value: coordinator
+          value: coordinator-ready
       image: "ghcr.io/edgelesssys/contrast/initializer:latest"
       name: contrast-initializer
       volumeMounts:

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -401,7 +401,7 @@ func (ct *ContrastTest) installRuntime(t *testing.T) {
 
 // runAgainstCoordinator forwards the coordinator port and executes the command against it.
 func (ct *ContrastTest) runAgainstCoordinator(ctx context.Context, cmd *cobra.Command, args ...string) error {
-	if err := ct.Kubeclient.WaitForStatefulSet(ctx, ct.Namespace, "coordinator"); err != nil {
+	if err := ct.Kubeclient.WaitForCoordinator(ctx, ct.Namespace); err != nil {
 		return fmt.Errorf("waiting for coordinator: %w", err)
 	}
 

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -234,7 +234,7 @@ func TestOpenSSL(t *testing.T) {
 		c := kubeclient.NewForTest(t)
 
 		require.NoError(c.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
-		require.NoError(c.WaitForStatefulSet(ctx, ct.Namespace, "coordinator"))
+		require.NoError(c.WaitForCoordinator(ctx, ct.Namespace))
 
 		// TODO(freax13): The following verify sometimes fails spuriously due to
 		//                connection issues. Waiting a little bit longer makes

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -219,7 +219,7 @@ func TestRelease(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
 
-		require.NoError(k.WaitForStatefulSet(ctx, "default", "coordinator"))
+		require.NoError(k.WaitForCoordinator(ctx, "default"))
 		var err error
 		coordinatorIP, err = k.WaitForService(ctx, "default", "coordinator", hasLoadBalancer)
 		require.NoError(err)

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -18,8 +18,13 @@ import (
 // CoordinatorBundle returns the Coordinator and a matching Service.
 func CoordinatorBundle() []any {
 	coordinator := Coordinator("")
+
 	coordinatorService := ServiceForStatefulSet(coordinator.StatefulSetApplyConfiguration).
 		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"})
+	coordinatorService.Spec.WithPublishNotReadyAddresses(true)
+
+	coordinatorReadyService := ServiceForStatefulSet(coordinator.StatefulSetApplyConfiguration).
+		WithName(*coordinatorService.GetName() + "-ready")
 
 	return []any{
 		coordinator.StatefulSetApplyConfiguration,
@@ -27,6 +32,7 @@ func CoordinatorBundle() []any {
 		coordinator.RoleApplyConfiguration,
 		coordinator.RoleBindingApplyConfiguration,
 		coordinatorService,
+		coordinatorReadyService,
 	}
 }
 

--- a/justfile
+++ b/justfile
@@ -226,7 +226,7 @@ set cli=default_cli:
     #!/usr/bin/env bash
     set -euo pipefail
     ns=$(cat ./{{ workspace_dir }}/just.namespace)
-    nix run -L .#scripts.kubectl-wait-ready -- $ns coordinator
+    nix run -L .#scripts.kubectl-wait-coordinator -- $ns
     nix run -L .#scripts.kubectl-wait-ready -- $ns port-forwarder-coordinator
     kubectl -n $ns port-forward pod/port-forwarder-coordinator 1313 &
     PID=$!
@@ -243,7 +243,7 @@ verify cli=default_cli:
     set -euo pipefail
     rm -rf ./{{ workspace_dir }}/verify
     ns=$(cat ./{{ workspace_dir }}/just.namespace)
-    nix run -L .#scripts.kubectl-wait-ready -- $ns coordinator
+    nix run -L .#scripts.kubectl-wait-coordinator -- $ns
     kubectl -n $ns port-forward pod/port-forwarder-coordinator 1314:1313 &
     PID=$!
     trap "kill $PID" EXIT
@@ -257,7 +257,7 @@ recover cli=default_cli:
     #!/usr/bin/env bash
     set -euo pipefail
     ns=$(cat ./{{ workspace_dir }}/just.namespace)
-    nix run -L .#scripts.kubectl-wait-ready -- $ns coordinator
+    nix run -L .#scripts.kubectl-wait-coordinator -- $ns
     nix run -L .#scripts.kubectl-wait-ready -- $ns port-forwarder-coordinator
     kubectl -n $ns port-forward pod/port-forwarder-coordinator 1313 &
     PID=$!

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -207,6 +207,34 @@
     '';
   };
 
+  kubectl-wait-coordinator = writeShellApplication {
+    name = "kubectl-wait-coordinator";
+    runtimeInputs = with pkgs; [ kubectl ];
+    text = ''
+      namespace=$1
+      name="coordinator-0"
+
+      echo "Waiting for $name.$namespace to become ready" >&2
+
+      timeout=180
+
+      interval=4
+      while [ $timeout -gt 0 ]; do
+        if kubectl -n "$namespace" get pods "$name"; then
+          break
+        fi
+        sleep "$interval"
+        timeout=$((timeout - interval))
+      done
+
+      kubectl wait \
+         --namespace "$namespace" \
+         --for=jsonpath='{.status.phase}'=Running \
+         --timeout="''${timeout}s" \
+         pod/$name
+    '';
+  };
+
   wait-for-port-listen = writeShellApplication {
     name = "wait-for-port-listen";
     runtimeInputs = with pkgs; [ iproute2 ];


### PR DESCRIPTION
This PR adds a readiness probe to the Coordinator that checks whether the Coordinator is ready to serve `meshapi` requests, i.e. has a manifest configured that is not stale. The `userapi` can still be reached via the `coordinator:1313` service endpoint, even if unready, to allow initial `SetManifest` calls. Users may need to update any logic that waits for a Coordinator instance to be `Ready` before calling `contrast set`: it now only needs to be in phase `Running`.

---

Internally, we add a new service - `coordinator-ready` - backed by `Ready` Coordinators. This service is used by initializers and in peerrecovery, so that we only hit Coordinator endpoints that can actually serve requests. The idea is described in RFC 010:

https://github.com/edgelesssys/contrast/blob/cc41f2021a307f0dd9c00f4aa7a166b2f1eafe79/rfc/010-distributed-coordinator.md?plain=1#L113-L121 