### PR TITLE
kubeclient: ignore terminating pods

### DIFF
--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -288,6 +288,10 @@ func (c *Kubeclient) toJSON(a any) string {
 }
 
 func isPodReady(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		// Terminating pods lose their ready condition only eventually.
+		return false
+	}
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
 			return true

--- a/e2e/internal/kubeclient/wait.go
+++ b/e2e/internal/kubeclient/wait.go
@@ -203,6 +203,9 @@ func (or *oneRunning) Check(lister listerscorev1.PodLister) (bool, error) {
 		return false, err
 	}
 	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 		if pod.Status.Phase == corev1.PodRunning {
 			return true, nil
 		}


### PR DESCRIPTION
We've been running into CI issues where exec into a pod failed with the `container not found` message ([ex](https://github.com/edgelesssys/contrast/actions/runs/15178262019/job/42682507768#step:11:216)). I ran this test a couple of times with additional logging, and found that the pod that we waited for is not the pod we're executing in. Looking closer, I noticed that we just restarted the deployment, which means there are additional pods around that are terminated, but not fully gone yet (because that takes a little while), and we end up executing into the terminating pods, which don't host that container anymore.

This PR fixes the situation by filtering terminating pods from most kubeclient results. We don't currently have a use case for keeping them.