### PR TITLE
deps: patch go-sev-guest with AMD Siena support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ toolchain go1.24.2
 // https://github.com/google/go-sev-guest/issues/103
 // Includes cherry-pick of unmerged PR to fix platform info validation:
 // https://github.com/google/go-sev-guest/pull/161
-replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f
+// Includes cherry-pick of unmerged PR for Siena support:
+// https://github.com/google/go-sev-guest/pull/167
+replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250522132418-02d4f5059bf3
 
 require (
 	filippo.io/keygen v0.0.0-20240718133620-7f162efbbd87

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f h1:oHNe8GacgdRfDccQeGSokAmuCEGh7xqz0By4/d0PRUc=
-github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250522132418-02d4f5059bf3 h1:l7oWjRr+4QuqckTe8wyloIF29Uu2KRN5wSjCQefzN8A=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250522132418-02d4f5059bf3/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -244,7 +244,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-iX+eMVSEfFAtEVCRmtM8zyvbA6Jeix0ybiUJSXYe1dU=";
+  vendorHash = "sha256-0Ieclyvlw4FkIznwyNP63BLCPE2kM9Po077mWse8KvQ=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
The used library for AMD SEV-SNP attestation doesn't support Siena. With this, we ship a patched version to support that product line.