### PR TITLE
[release/v1.8] microsoft.genpolicy: fix sandbox-name policy for pod controllers

### DIFF
--- a/packages/by-name/microsoft/genpolicy/0011-genpolicy-match-sandbox-name-by-regex.patch
+++ b/packages/by-name/microsoft/genpolicy/0011-genpolicy-match-sandbox-name-by-regex.patch
@@ -4,19 +4,21 @@ Date: Mon, 5 May 2025 16:39:24 +0200
 Subject: [PATCH] genpolicy: match sandbox name by regex
 
 Signed-off-by: Paul Meyer <katexochen0@gmail.com>
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
 ---
- src/tools/genpolicy/rules.rego                |  7 +++---
- src/tools/genpolicy/src/cronjob.rs            |  9 +++++++-
- src/tools/genpolicy/src/daemon_set.rs         |  7 +++++-
- src/tools/genpolicy/src/deployment.rs         |  7 +++++-
- src/tools/genpolicy/src/job.rs                |  7 +++++-
- src/tools/genpolicy/src/obj_meta.rs           |  2 +-
- src/tools/genpolicy/src/pod.rs                | 10 ++++----
- src/tools/genpolicy/src/replica_set.rs        |  7 +++++-
- .../genpolicy/src/replication_controller.rs   |  7 +++++-
- src/tools/genpolicy/src/stateful_set.rs       |  7 +++++-
- src/tools/genpolicy/src/yaml.rs               | 23 +++++++++++++++++++
- 11 files changed, 76 insertions(+), 17 deletions(-)
+ src/tools/genpolicy/rules.rego                    |  7 +++----
+ src/tools/genpolicy/src/cronjob.rs                |  8 +++++++-
+ src/tools/genpolicy/src/daemon_set.rs             |  4 +++-
+ src/tools/genpolicy/src/deployment.rs             |  6 +++++-
+ src/tools/genpolicy/src/job.rs                    | 12 +++++++++++-
+ src/tools/genpolicy/src/obj_meta.rs               |  2 +-
+ src/tools/genpolicy/src/pod.rs                    |  6 +-----
+ src/tools/genpolicy/src/policy.rs                 |  2 +-
+ src/tools/genpolicy/src/replica_set.rs            |  4 +++-
+ src/tools/genpolicy/src/replication_controller.rs |  5 ++++-
+ src/tools/genpolicy/src/stateful_set.rs           |  3 ++-
+ src/tools/genpolicy/src/yaml.rs                   | 13 +++++++++++++
+ 12 files changed, 54 insertions(+), 18 deletions(-)
 
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
 index c16439f24e2e591d115bc1d54ee1d9fb085cd775..a5450554c6eeb8b025aa0c469ef3e453ddcc6c75 100644
@@ -51,7 +53,7 @@ index c16439f24e2e591d115bc1d54ee1d9fb085cd775..a5450554c6eeb8b025aa0c469ef3e453
      print("allow_var 2: true")
  }
 diff --git a/src/tools/genpolicy/src/cronjob.rs b/src/tools/genpolicy/src/cronjob.rs
-index 6a2d63de3138d7728d430aad1a9b15201f61b62a..00d4ac56c529795b7148544c6aee4b45736653bc 100644
+index 6a2d63de3138d7728d430aad1a9b15201f61b62a..251db8352d399687bedf6f1208c553b0a3b427d5 100644
 --- a/src/tools/genpolicy/src/cronjob.rs
 +++ b/src/tools/genpolicy/src/cronjob.rs
 @@ -19,6 +19,7 @@ use crate::yaml;
@@ -62,75 +64,79 @@ index 6a2d63de3138d7728d430aad1a9b15201f61b62a..00d4ac56c529795b7148544c6aee4b45
  
  /// See Reference / Kubernetes API / Workload Resources / CronJob.
  #[derive(Clone, Debug, Serialize, Deserialize)]
-@@ -81,7 +82,13 @@ impl yaml::K8sResource for CronJob {
+@@ -81,7 +82,12 @@ impl yaml::K8sResource for CronJob {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.jobTemplate.spec.template.metadata,
-+                &self.spec.jobTemplate.metadata,
-+                &Some(self.metadata.clone()),
-+            ],
-+        )
++        // CronJob name - time[min]
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/cronjob/cronjob_controllerv2.go#L672
++        let cronjob_name = yaml::name_regex_from_meta(&self.metadata);
++        let job_name = cronjob_name.map(|prefix| format!("{prefix}-[0-9]+"));
++        // Pod name now derives from the generated job name.
++        job_name.map(job::pod_name_regex)
      }
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/daemon_set.rs b/src/tools/genpolicy/src/daemon_set.rs
-index bed1eb8bc88a4b0a94a988d712bc155d1bb14d25..5fb7df587a32bf25481d61d6fd586c2cd31fcafb 100644
+index bed1eb8bc88a4b0a94a988d712bc155d1bb14d25..c47cb34eca46007ee66d80841ad968e3880b8041 100644
 --- a/src/tools/genpolicy/src/daemon_set.rs
 +++ b/src/tools/genpolicy/src/daemon_set.rs
-@@ -83,7 +83,12 @@ impl yaml::K8sResource for DaemonSet {
+@@ -83,7 +83,9 @@ impl yaml::K8sResource for DaemonSet {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.template.metadata,
-+                &Some(self.metadata.clone()),
-+            ]
-+        )
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/daemon/daemon_controller.go#L1045
++        let suffix = yaml::GENERATE_NAME_SUFFIX_REGEX;
++        yaml::name_regex_from_meta(&self.metadata).map(|prefix| format!("{prefix}-{suffix}"))
      }
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/deployment.rs b/src/tools/genpolicy/src/deployment.rs
-index 90f15617ec6b68a1410d9077df26f7290c817397..3e5e14a188196e7261ad7670bb9fb94a40a699a3 100644
+index 90f15617ec6b68a1410d9077df26f7290c817397..a289be8abc462817e33d0fc7380e72387b7b05cd 100644
 --- a/src/tools/genpolicy/src/deployment.rs
 +++ b/src/tools/genpolicy/src/deployment.rs
-@@ -81,7 +81,12 @@ impl yaml::K8sResource for Deployment {
+@@ -81,7 +81,11 @@ impl yaml::K8sResource for Deployment {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.template.metadata,
-+                &Some(self.metadata.clone()),
-+            ]
-+        )
++        // Deployment name - pod template hash - suffix
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/deployment/sync.go#L201
++        let suffix = yaml::GENERATE_NAME_SUFFIX_REGEX;
++        yaml::name_regex_from_meta(&self.metadata)
++            .map(|prefix| format!("{prefix}-{suffix}-{suffix}"))
      }
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/job.rs b/src/tools/genpolicy/src/job.rs
-index e9dc76532d8bdd975cdff16bdc4b8c981ea93d33..f58e9f66b35702e9cd1a835fd6cfefefe7751a4a 100644
+index e9dc76532d8bdd975cdff16bdc4b8c981ea93d33..941fa909cf60faeca6500e4b0672a2c50603af09 100644
 --- a/src/tools/genpolicy/src/job.rs
 +++ b/src/tools/genpolicy/src/job.rs
-@@ -55,7 +55,12 @@ impl yaml::K8sResource for Job {
+@@ -55,7 +55,8 @@ impl yaml::K8sResource for Job {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.template.metadata,
-+                &Some(self.metadata.clone()),
-+            ]
-+        )
++        let job_name = yaml::name_regex_from_meta(&self.metadata);
++        job_name.map(pod_name_regex)
      }
  
      fn get_namespace(&self) -> Option<String> {
+@@ -118,3 +119,12 @@ impl yaml::K8sResource for Job {
+         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
+     }
+ }
++
++pub fn pod_name_regex(job_name: String) -> String {
++    // Job name - optional index - generateNameSuffix
++    // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/job/job_controller.go#L1767
++    // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/job/indexed_job_utils.go#L501
++    // TODO(burgerdev): does not handle long names correctly!
++    let suffix = yaml::GENERATE_NAME_SUFFIX_REGEX;
++    format!("{job_name}(-[0-9]+)?-{suffix}")
++}
 diff --git a/src/tools/genpolicy/src/obj_meta.rs b/src/tools/genpolicy/src/obj_meta.rs
 index e7458c604d568119ce5c60a9d3db6f6d89d44ab7..efc052331fd3fac0c98c93b947870a70796e805e 100644
 --- a/src/tools/genpolicy/src/obj_meta.rs
@@ -145,10 +151,10 @@ index e7458c604d568119ce5c60a9d3db6f6d89d44ab7..efc052331fd3fac0c98c93b947870a70
      #[serde(skip_serializing_if = "Option::is_none")]
      labels: Option<BTreeMap<String, String>>,
 diff --git a/src/tools/genpolicy/src/pod.rs b/src/tools/genpolicy/src/pod.rs
-index 111aef73d3866efe885a351d93c902bde085350d..b0c734a45f47b9fde44925cb08c0bbb65b8f3d10 100644
+index 111aef73d3866efe885a351d93c902bde085350d..dd1979884c18b86d19d1f6967da60a9694441612 100644
 --- a/src/tools/genpolicy/src/pod.rs
 +++ b/src/tools/genpolicy/src/pod.rs
-@@ -839,11 +839,11 @@ impl yaml::K8sResource for Pod {
+@@ -839,11 +839,7 @@ impl yaml::K8sResource for Pod {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
@@ -157,70 +163,70 @@ index 111aef73d3866efe885a351d93c902bde085350d..b0c734a45f47b9fde44925cb08c0bbb6
 -            return Some(name);
 -        }
 -        panic!("No pod name.");
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &Some(self.metadata.clone()),
-+            ],
-+        )
++        yaml::name_regex_from_meta(&self.metadata)
      }
  
      fn get_namespace(&self) -> Option<String> {
+diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
+index 7f442b66262202a2a75daf4b322eea7905092aba..0b66065813ad51b6be8d06c75dde0527ba22c927 100644
+--- a/src/tools/genpolicy/src/policy.rs
++++ b/src/tools/genpolicy/src/policy.rs
+@@ -995,7 +995,7 @@ fn get_container_annotations(
+     if let Some(name) = resource.get_sandbox_name() {
+         annotations
+             .entry("io.kubernetes.cri.sandbox-name".to_string())
+-            .or_insert(name);
++            .or_insert(format!("^{name}$"));
+     }
+ 
+     if !is_pause_container {
 diff --git a/src/tools/genpolicy/src/replica_set.rs b/src/tools/genpolicy/src/replica_set.rs
-index 27e70d20f0085e36b7170d6c24eea3f7771cbb1f..9c7f152496ccb85b4b5421036528eb8b29ab168f 100644
+index 27e70d20f0085e36b7170d6c24eea3f7771cbb1f..81f4d3351d916779de79b2b228da05ff8e608ca8 100644
 --- a/src/tools/genpolicy/src/replica_set.rs
 +++ b/src/tools/genpolicy/src/replica_set.rs
-@@ -53,7 +53,12 @@ impl yaml::K8sResource for ReplicaSet {
+@@ -53,7 +53,9 @@ impl yaml::K8sResource for ReplicaSet {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.template.metadata,
-+                &Some(self.metadata.clone()),
-+            ]
-+        )
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/controller_utils.go#L541
++        let suffix = yaml::GENERATE_NAME_SUFFIX_REGEX;
++        yaml::name_regex_from_meta(&self.metadata).map(|prefix| format!("{prefix}-{suffix}"))
      }
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/replication_controller.rs b/src/tools/genpolicy/src/replication_controller.rs
-index 9029c5a9173c1aa0e6b27f4314f35eacdd7a5e65..c744cc25ea0e2213d8e54f34abbd7c0cb47a8732 100644
+index 9029c5a9173c1aa0e6b27f4314f35eacdd7a5e65..3c385d411634574f06f970deec58343718530037 100644
 --- a/src/tools/genpolicy/src/replication_controller.rs
 +++ b/src/tools/genpolicy/src/replication_controller.rs
-@@ -55,7 +55,12 @@ impl yaml::K8sResource for ReplicationController {
+@@ -55,7 +55,10 @@ impl yaml::K8sResource for ReplicationController {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.template.metadata,
-+                &Some(self.metadata.clone()),
-+            ]
-+        )
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/controller_utils.go#L541
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/replication/replication_controller.go#L47-L50
++        let suffix = yaml::GENERATE_NAME_SUFFIX_REGEX;
++        yaml::name_regex_from_meta(&self.metadata).map(|prefix| format!("{prefix}-{suffix}"))
      }
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/stateful_set.rs b/src/tools/genpolicy/src/stateful_set.rs
-index 298af4eb577687246125dc567743a2f49742d905..10091aaff6f8c16ed5fdab26815cd4ed7dbd60c7 100644
+index 298af4eb577687246125dc567743a2f49742d905..5d2bc18691b561faa3ad343504995725b169ecaa 100644
 --- a/src/tools/genpolicy/src/stateful_set.rs
 +++ b/src/tools/genpolicy/src/stateful_set.rs
-@@ -103,7 +103,12 @@ impl yaml::K8sResource for StatefulSet {
+@@ -103,7 +103,8 @@ impl yaml::K8sResource for StatefulSet {
      }
  
      fn get_sandbox_name(&self) -> Option<String> {
 -        None
-+        yaml::get_sandbox_regex(
-+            vec![
-+                &self.spec.template.metadata,
-+                &Some(self.metadata.clone()),
-+            ]
-+        )
++        // https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/pkg/controller/statefulset/stateful_set_utils.go#L113
++        yaml::name_regex_from_meta(&self.metadata).map(|prefix| format!("{prefix}-[0-9]+"))
      }
  
      fn get_namespace(&self) -> Option<String> {
 diff --git a/src/tools/genpolicy/src/yaml.rs b/src/tools/genpolicy/src/yaml.rs
-index 8ae1000eb319267a7732132ee42731c792ebd48c..5e96ba9b1b365783005bd8ecf3f69935abf7f768 100644
+index 8ae1000eb319267a7732132ee42731c792ebd48c..03dec274768b9aaef416a6203b5244225336acc2 100644
 --- a/src/tools/genpolicy/src/yaml.rs
 +++ b/src/tools/genpolicy/src/yaml.rs
 @@ -15,6 +15,7 @@ use crate::job;
@@ -231,29 +237,19 @@ index 8ae1000eb319267a7732132ee42731c792ebd48c..5e96ba9b1b365783005bd8ecf3f69935
  use crate::pod;
  use crate::policy;
  use crate::pvc;
-@@ -371,3 +372,25 @@ pub fn get_process_fields(
+@@ -371,3 +372,15 @@ pub fn get_process_fields(
          }
      }
  }
 +
-+/// The order of metas is expected to be from the most specific to the least specific,
-+/// e.g.: self.spec.template.metadata before self.metadata.
-+pub fn get_sandbox_regex(
-+    metas: Vec<&Option<ObjectMeta>>,
-+) -> Option<String> {
-+    let mut first = true;
-+    for meta in metas {
-+        if let Some(meta) = meta {
-+            if first && meta.name.is_some() {
-+                let name = meta.name.as_ref().unwrap();
-+                return Some(format!("^{name}$"))
-+            } else if let Some(name) = &meta.name {
-+                return Some(format!("^{name}-[a-zA-Z0-9-]+$"))
-+            } else if let Some(generate_name) = &meta.generateName {
-+                return Some(format!("^{generate_name}[a-zA-Z0-9-]+$"))
-+            }
-+        }
-+        first = false
-+    }
-+    return None
++/// Constructs a non-anchored regex for an object according to k8s naming conventions:
++/// 1. If the name field is set, return that literally.
++/// 2. If name is unset but generateName is set, return regex that matches generateName and a random suffix.
++/// 3. Otherwise, return None. This object is not considered valid by the k8s API server!
++pub fn name_regex_from_meta(meta: &ObjectMeta) -> Option<String> {
++        let generateName = meta.generateName.clone().map(|prefix| format!("{prefix}{GENERATE_NAME_SUFFIX_REGEX}"));
++        meta.name.clone().or(generateName)
 +}
++
++// https://github.com/kubernetes/kubernetes/blob/b35c5c0a301d326fdfa353943fca077778544ac6/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L81-L83
++pub const GENERATE_NAME_SUFFIX_REGEX: &str = "[bcdfghjklmnpqrstvwxz2456789]+";

--- a/packages/by-name/microsoft/genpolicy/0013-genpolicy-don-t-overwrite-env-vars-from-image.patch
+++ b/packages/by-name/microsoft/genpolicy/0013-genpolicy-don-t-overwrite-env-vars-from-image.patch
@@ -14,7 +14,7 @@ Signed-off-by: Markus Rudy <mr@edgeless.systems>
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
-index 7f442b66262202a2a75daf4b322eea7905092aba..e1ece31e0648a51b1bdbe472ec09ccfec8e27660 100644
+index 0b66065813ad51b6be8d06c75dde0527ba22c927..22cbd0dc029b94e088c3b30b7e040fa796281f07 100644
 --- a/src/tools/genpolicy/src/policy.rs
 +++ b/src/tools/genpolicy/src/policy.rs
 @@ -29,6 +29,7 @@ use serde_yaml::Value;


### PR DESCRIPTION
Backport of #1477 to `release/v1.8`.

Original description:

---

Policies for controller workloads (DaemonSet, Deployment, StatefulSet, ReplicaSet, ReplicationController, Job, CronJob) used to be incorrect if the embedded pod template had `metadata.name` or `metadata.generateName` set, because the permissible pod sandbox names were derived wrongly. This PR corrects the expected generated pod names.

---

The logic we implemented in #1447 ff. does not actually correspond to Kubernetes' implementation. It's surprisingly hard to get authoritative sources for naming schemes ([except for Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment)), but looking at the controller implementations confirms that `name` and `generateName` from [`PodTemplateSpec.metadata`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#podtemplatespec-v1-core) are _always_ ignored, and the pod names are derived from their controllers' names in various ways. I tried to link all the relevant k8s sources to explain the regexes for the different controllers.