### PR TITLE
[release/v1.8] initializer: safer data handling for encrypted mount

### DIFF
--- a/internal/mount/mount.go
+++ b/internal/mount/mount.go
@@ -109,7 +109,7 @@ func mount(ctx context.Context, devPath, mountPoint string) error {
 	if err := os.MkdirAll(mountPoint, 0o755); err != nil {
 		return fmt.Errorf("mkdir: %w", err)
 	}
-	if out, err := exec.CommandContext(ctx, "mount", devPath, mountPoint).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "mount", "-o", "sync,data=journal", devPath, mountPoint).CombinedOutput(); err != nil {
 		return fmt.Errorf("mount: %w, output: %q", err, out)
 	}
 	return nil


### PR DESCRIPTION
Backport of #1490 to `release/v1.8`.

Original description:

---

Since we're using raw block devices for our pods and mount from a container, neither the Kubelet nor the CSI driver is aware of our LUKS mapper + ext4 mount and can thus not clean them up before removing the block device, which may lead to data loss if caches are not synced.

This PR activates two mount options for increased safety of these encrypted volume mounts. They are not strictly necessary for the Coordinator volume mount, but that one will be phased out soon.

* `sync` makes writes synchronous: https://www.man7.org/linux/man-pages/man8/mount.8.html#FILESYSTEM-INDEPENDENT_MOUNT_OPTIONS
* `data=journal` is the most conservative journaling mode of ext4: https://www.kernel.org/doc/Documentation/filesystems/ext4.txt

The `sync` option in particular comes with a high throughput cost, but that trade-off is acceptable considering the alternative is data loss.