### PR TITLE
[release/v1.8] kata.kata-runtime: genpolicy fix svc_name

### DIFF
--- a/e2e/regression/testdata/prometheus.yml
+++ b/e2e/regression/testdata/prometheus.yml
@@ -26,3 +26,17 @@ spec:
             requests:
               memory: 600Mi
       runtimeClassName: contrast-cc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Ensure we accept RFC 1035 Label Names, see https://github.com/kata-containers/kata-containers/pull/11314
+  name: prometheus-24
+  namespace: "@@REPLACE_NAMESPACE@@"
+spec:
+  ports:
+    - port: 9090
+      targetPort: 9090
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus

--- a/packages/by-name/kata/kata-runtime/0019-genpolicy-fix-svc_name-regex.patch
+++ b/packages/by-name/kata/kata-runtime/0019-genpolicy-fix-svc_name-regex.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Meyer <katexochen0@gmail.com>
+Date: Mon, 26 May 2025 16:28:09 +0200
+Subject: [PATCH] genpolicy: fix svc_name regex
+
+The service name is specified as RFC 1035 lable name [1]. The svc_name
+regex in the genpolicy settings is applied to the downward API env
+variables created based on the service name. So it tries to match
+RFC 1035 labels after they are transformed to downward API variable
+names [2]. So the set of lower case alphanumerics and dashes is
+transformed to upper case alphanumerics and underscores.
+The previous regex wronly permitted use of numbers, but did allow
+dot and dash, which shouldn't be allowed (dot not because they aren't
+conform with RFC 1035, dash not because it is transformed to underscore).
+
+We have to take care not to also try to use the regex in places where
+we actually want to check for RFC 1035 label instead of the downward
+API transformed version of it.
+
+Further, we should consider using a format like JSON5/JSONC for the
+policy settings, as these are far from trivial and would highly benefit
+from proper documentation through comments.
+
+[1]: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+[2]: https://github.com/kubernetes/kubernetes/blob/b2dfba4151b859c31a27fe31f8703f9b2b758270/pkg/kubelet/envvars/envvars.go#L29-L70
+
+Signed-off-by: Paul Meyer <katexochen0@gmail.com>
+---
+ src/tools/genpolicy/genpolicy-settings.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
+index bc1d3fc5289fbf4f258e3b181f9af2bb0feb9ada..e935956e9f36b067e7f94f1340a31a22fe4992f0 100644
+--- a/src/tools/genpolicy/genpolicy-settings.json
++++ b/src/tools/genpolicy/genpolicy-settings.json
+@@ -249,7 +249,7 @@
+         "sfprefix": "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-",
+         "ip_p": "[0-9]{1,5}",
+         "ipv4_a": "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])",
+-        "svc_name": "[A-Z_\\.\\-]+",
++        "svc_name": "[A-Z](?:[A-Z0-9_]{0,61}[A-Z0-9])?",
+         "dns_label": "[a-zA-Z0-9_\\.\\-]+",
+         "default_caps": [
+             "CAP_CHOWN",

--- a/packages/by-name/kata/kata-runtime/0020-genpolicy-rename-svc_name-to-svc_name_downward_env.patch
+++ b/packages/by-name/kata/kata-runtime/0020-genpolicy-rename-svc_name-to-svc_name_downward_env.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Meyer <katexochen0@gmail.com>
+Date: Tue, 27 May 2025 08:53:23 +0200
+Subject: [PATCH] genpolicy: rename svc_name to svc_name_downward_env
+
+Just to be more explicit what this matches.
+
+Signed-off-by: Paul Meyer <katexochen0@gmail.com>
+---
+ src/tools/genpolicy/genpolicy-settings.json | 18 +++++++++---------
+ src/tools/genpolicy/rules.rego              |  2 +-
+ src/tools/genpolicy/src/policy.rs           |  4 ++--
+ 3 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/src/tools/genpolicy/genpolicy-settings.json b/src/tools/genpolicy/genpolicy-settings.json
+index e935956e9f36b067e7f94f1340a31a22fe4992f0..68cf43c75f8476adc96fead363f1880002e0f9d7 100644
+--- a/src/tools/genpolicy/genpolicy-settings.json
++++ b/src/tools/genpolicy/genpolicy-settings.json
+@@ -249,7 +249,7 @@
+         "sfprefix": "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-",
+         "ip_p": "[0-9]{1,5}",
+         "ipv4_a": "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])",
+-        "svc_name": "[A-Z](?:[A-Z0-9_]{0,61}[A-Z0-9])?",
++        "svc_name_downward_env": "[A-Z](?:[A-Z0-9_]{0,61}[A-Z0-9])?",
+         "dns_label": "[a-zA-Z0-9_\\.\\-]+",
+         "default_caps": [
+             "CAP_CHOWN",
+@@ -325,14 +325,14 @@
+         "CreateContainerRequest": {
+             "allow_env_regex": [
+                 "^HOSTNAME=$(dns_label)$",
+-                "^$(svc_name)_PORT_$(ip_p)_TCP=tcp://$(ipv4_a):$(ip_p)$",
+-                "^$(svc_name)_PORT_$(ip_p)_TCP_PROTO=tcp$",
+-                "^$(svc_name)_PORT_$(ip_p)_TCP_PORT=$(ip_p)$",
+-                "^$(svc_name)_PORT_$(ip_p)_TCP_ADDR=$(ipv4_a)$",
+-                "^$(svc_name)_SERVICE_HOST=$(ipv4_a)$",
+-                "^$(svc_name)_SERVICE_PORT=$(ip_p)$",
+-                "^$(svc_name)_SERVICE_PORT_$(dns_label)=$(ip_p)$",
+-                "^$(svc_name)_PORT=tcp://$(ipv4_a):$(ip_p)$",
++                "^$(svc_name_downward_env)_PORT_$(ip_p)_TCP=tcp://$(ipv4_a):$(ip_p)$",
++                "^$(svc_name_downward_env)_PORT_$(ip_p)_TCP_PROTO=tcp$",
++                "^$(svc_name_downward_env)_PORT_$(ip_p)_TCP_PORT=$(ip_p)$",
++                "^$(svc_name_downward_env)_PORT_$(ip_p)_TCP_ADDR=$(ipv4_a)$",
++                "^$(svc_name_downward_env)_SERVICE_HOST=$(ipv4_a)$",
++                "^$(svc_name_downward_env)_SERVICE_PORT=$(ip_p)$",
++                "^$(svc_name_downward_env)_SERVICE_PORT_$(dns_label)=$(ip_p)$",
++                "^$(svc_name_downward_env)_PORT=tcp://$(ipv4_a):$(ip_p)$",
+                 "^AZURE_CLIENT_ID=[A-Fa-f0-9-]*$",
+                 "^AZURE_TENANT_ID=[A-Fa-f0-9-]*$",
+                 "^AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token$",
+diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
+index edb815832eac3a052a1a4435e22cf7cbab44942f..552abec65a5e9250cff1b6002f2637f28dccd390 100644
+--- a/src/tools/genpolicy/rules.rego
++++ b/src/tools/genpolicy/rules.rego
+@@ -801,7 +801,7 @@ allow_var(p_process, i_process, i_var, s_name) {
+     some p_regex1 in policy_data.request_defaults.CreateContainerRequest.allow_env_regex
+     p_regex2 := replace(p_regex1, "$(ipv4_a)", policy_data.common.ipv4_a)
+     p_regex3 := replace(p_regex2, "$(ip_p)", policy_data.common.ip_p)
+-    p_regex4 := replace(p_regex3, "$(svc_name)", policy_data.common.svc_name)
++    p_regex4 := replace(p_regex3, "$(svc_name_downward_env)", policy_data.common.svc_name_downward_env)
+     p_regex5 := replace(p_regex4, "$(dns_label)", policy_data.common.dns_label)
+ 
+     print("allow_var 3: p_regex5 =", p_regex5)
+diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
+index 010e73635d70777c8a3724185c6af757c4b22acd..e19bd8a5b41b2698d0f7832bdab7b45761625342 100644
+--- a/src/tools/genpolicy/src/policy.rs
++++ b/src/tools/genpolicy/src/policy.rs
+@@ -410,8 +410,8 @@ pub struct CommonData {
+     /// Regex for an IP port number.
+     pub ip_p: String,
+ 
+-    /// Regex for a K8s service name.
+-    pub svc_name: String,
++    /// Regex for a K8s service name (RFC 1035), after downward API transformation.
++    pub svc_name_downward_env: String,
+ 
+     // Regex for a DNS label (e.g., host name).
+     pub dns_label: String,

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -136,6 +136,12 @@ buildGoModule (finalAttrs: {
       # Support to enforce guest pull without (nydus) snapshotter.
       # Cherry-picked from https://github.com/kata-containers/kata-containers/pull/11244
       ./0018-runtime-add-option-to-force-guest-pull.patch
+
+      # Fixes a bug in the genpolicy settings where the service_name regex used to match downward
+      # API env vars wouldn't accept numbers in the service name.
+      # Upstream PR: https://github.com/kata-containers/kata-containers/pull/11314
+      ./0019-genpolicy-fix-svc_name-regex.patch
+      ./0020-genpolicy-rename-svc_name-to-svc_name_downward_env.patch
     ];
   };
 


### PR DESCRIPTION
Backport of #1491 to `release/v1.8`.

Original description:

---

The genpolicy-settings.json generated by the Contrast CLI contained a regex that didn't allow service names containing numbers, but allowed invalid service names containing dots. This PR corrects the regex to match RFC 1035.