### PR TITLE
Clean up a few obsolete code paths

### DIFF
--- a/e2e/volumestatefulset/volumestatefulset_test.go
+++ b/e2e/volumestatefulset/volumestatefulset_test.go
@@ -73,9 +73,6 @@ func TestVolumeStatefulSet(t *testing.T) {
 		stdOut, stdErr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, pods[0].Name, []string{"sh", "-c", fmt.Sprintf("echo test > %s", filePath)})
 		require.NoError(err, "stdout: %s, stderr: %s", stdOut, stdErr)
 
-		stdOut, stdErr, err = ct.Kubeclient.Exec(ctx, ct.Namespace, pods[0].Name, []string{"sync"})
-		require.NoError(err, "stdout: %s, stderr: %s", stdOut, stdErr)
-
 		stdOut, stdErr, err = ct.Kubeclient.Exec(ctx, ct.Namespace, pods[0].Name, []string{"cat", filePath})
 		require.NoError(err, "stdout: %s, stderr: %s", stdOut, stdErr)
 		require.Equal("test\n", stdOut)

--- a/internal/logger/handler.go
+++ b/internal/logger/handler.go
@@ -43,7 +43,7 @@ func NewHandler(inner slog.Handler, subsystem string) *Handler {
 		enabled:   subsystemEnvEnabled(os.Getenv, subsystem),
 		level:     slog.LevelWarn,
 	}
-	slog.New(handler).Info("Subsystem logger initialized", "subsystem", subsystem, "state", handler.state())
+	slog.New(handler).Debug("Subsystem logger initialized", "subsystem", subsystem, "state", handler.state())
 	return handler
 }
 


### PR DESCRIPTION
* reduce log level of logger init - this should remove log messages on AKS LB health checks at INFO and above.
* encrypted volume is mounted with `-o sync` already (#1490)