### PR TITLE
ci: fix bugs in cluster_recreate

### DIFF
--- a/.github/workflows/cluster_recreate.yml
+++ b/.github/workflows/cluster_recreate.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
       - name: Login to Azure
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:

--- a/.github/workflows/cluster_recreate.yml
+++ b/.github/workflows/cluster_recreate.yml
@@ -21,7 +21,8 @@ jobs:
           creds: ${{ secrets.CONTRAST_CI_INFRA_AZURE }}
       - name: Cleanup .azure dir
         run: |
-          rm "$HOME/.azure/{commandIndex.json,versionCheck.json}"
+          # TODO(burgerdev): Check whether this step is still needed.
+          rm -f "$HOME"/.azure/{commandIndex.json,versionCheck.json}
       - name: Destroy existing CI cluster
         continue-on-error: true
         run: |


### PR DESCRIPTION
* the quotation marks added in b344d04d48e699e1dc71d99b41ce65f35af32b6c disabled the curly brace expansion
* ensure correct `az` CLI by calling `nix develop`, like #1449 