### PR TITLE
docs: multiple CPUs are not supported on bare metal

### DIFF
--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -26,7 +26,6 @@ jobs:
         test-name:
           # keep-sorted start
           - atls
-          - multiple-cpus
           - openssl
           - peerrecovery
           - policy
@@ -40,6 +39,11 @@ jobs:
               runner: SNP-GPU
               self-hosted: true
             test-name: gpu
+          - platform:
+              name: AKS-CLH-SNP
+              runner: ubuntu-22.04
+              self-hosted: false
+            test-name: multiple-cpus
       fail-fast: false
     name: "${{ matrix.platform.name }}"
     uses: ./.github/workflows/e2e.yml

--- a/docs/docs/components/service-mesh.md
+++ b/docs/docs/components/service-mesh.md
@@ -15,6 +15,7 @@ sets up `iptables` rules based on its configuration and then starts
 [Envoy](https://www.envoyproxy.io/) for TLS origination and termination.
 
 ## Service mesh startup enforcement
+
 Since Contrast doesn't yet enforce the order in which the containers are started
 (see [Limitations](../features-limitations.md)), we deny all incoming connections
 until the service mesh is fully configured.

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -11,7 +11,7 @@ This section lists planned features and current limitations of Contrast.
 
 - **Persistent volumes**: Contrast only supports volumes with [`volumeMode: Block`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode). These block devices are provided by the untrusted environment and should be treated accordingly. We plan to provide transparent encryption on top of block devices in a future release.
 - **Port forwarding**: This feature [isn't yet supported by Kata Containers](https://github.com/kata-containers/kata-containers/issues/1693). You can [deploy a port-forwarder](https://docs.edgeless.systems/contrast/deployment#connect-to-the-contrast-coordinator) as a workaround.
-- **Resource limits**: There is an existing bug on AKS where container memory limits are incorrectly applied. The current workaround involves using only memory requests instead of limits.
+- **Resource limits**: Contrast doesn't support setting CPU limits on bare metal. Adding a resource request for CPUs will lead to attestation failures.
 - **Image pull secrets**: registry authentication is only supported on AKS, see [Registry Authentication](howto/registry-authentication.md#bare-metal) for details.
 
 ## Runtime policies

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -21,9 +21,8 @@ This section lists planned features and current limitations of Contrast.
 - **Absence of events**: Policies can't ensure certain events have happened. A container, such as the [service mesh sidecar](components/service-mesh.md), can be omitted entirely. Environment variables may be missing.
 - **Volume integrity checks**: Integrity checks don't cover any volume mounts, such as `ConfigMaps` and `Secrets`.
 
-:::warning
-The policy limitations, in particular the missing guarantee that our service mesh sidecar has been started before the workload container, affect the service mesh implementation of Contrast.
-Currently, this requires inspecting the iptables rules on startup or terminating TLS connections in the workload directly.
+:::note
+The missing guarantee for startup order doesn't affect the security of Contrast's service mesh, see [Service mesh startup enforcement](components/service-mesh.md#service-mesh-startup-enforcement).
 :::
 
 ## Tooling integration

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -31,9 +31,9 @@ The missing guarantee for startup order doesn't affect the security of Contrast'
 
 ## Automatic recovery and high availability
 
-The Contrast Coordinator is a singleton and can't be scaled to more than one instance.
-When this instance's pod is restarted, for example for node maintenance, it needs to be recovered manually.
-In a future release, we plan to support distributed Coordinator instances that can recover automatically.
+The Contrast Coordinator is deployed as a single replica in its default configuration.
+When this replica is restarted, for example for node maintenance, it needs to be recovered manually.
+For automatic peer recovery and high-availability, the Coordinator should be [scaled to at least 3 replicas](howto/coordinator-ha.md).
 
 ## Overriding Kata configuration
 

--- a/docs/docs/features-limitations.md
+++ b/docs/docs/features-limitations.md
@@ -9,7 +9,7 @@ This section lists planned features and current limitations of Contrast.
 
 ## Kubernetes features
 
-- **Persistent volumes**: Contrast only supports volumes with [`volumeMode: Block`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode). These block devices are provided by the untrusted environment and should be treated accordingly. We plan to provide transparent encryption on top of block devices in a future release.
+- **Persistent volumes**: Contrast only supports volumes with [`volumeMode: Block`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode). These block devices are provided by the untrusted environment and should be treated accordingly. The [transparent encryption feature](architecture/secrets.md#secure-persistence) is recommended for secure persistence.
 - **Port forwarding**: This feature [isn't yet supported by Kata Containers](https://github.com/kata-containers/kata-containers/issues/1693). You can [deploy a port-forwarder](https://docs.edgeless.systems/contrast/deployment#connect-to-the-contrast-coordinator) as a workaround.
 - **Resource limits**: Contrast doesn't support setting CPU limits on bare metal. Adding a resource request for CPUs will lead to attestation failures.
 - **Image pull secrets**: registry authentication is only supported on AKS, see [Registry Authentication](howto/registry-authentication.md#bare-metal) for details.


### PR DESCRIPTION
The number of CPUs affects the launch measurement / RTMR of the VMs due to the interactions of QEMU and OVMF. This PR documents the situation and disables the associated test on bare metal.

Bundled are small fixes to the limitation docs I found while working on it.