### PR TITLE
ci: recreate ci cluster weekly

### DIFF
--- a/.github/workflows/cluster_recreate.yml
+++ b/.github/workflows/cluster_recreate.yml
@@ -2,6 +2,8 @@ name: recreate ci cluster
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # 0:00 on Sundays
 
 env:
   azure_resource_group: contrast-ci


### PR DESCRIPTION
This calls the `cluster_recreate` workflow for the AKS CI cluster on a weekly basis to keep the cluster fresh and cleaned up. Sunday 0:00 should not interfere with any other tests. Weekly tests run on Saturday and the nightly tests run at 4:30 which should be enough time for the cluster to be up and running again.