### PR TITLE
ci: only cleanup nix store if disk space is low

### DIFF
--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -160,6 +160,7 @@ let
         scripts.cleanup-bare-metal
         scripts.cleanup-namespaces
         scripts.cleanup-containerd
+        scripts.nix-gc
       ];
       config = {
         Cmd = [ "cleanup-bare-metal" ];

--- a/tools/bm-maintenance/nix-gc.yml
+++ b/tools/bm-maintenance/nix-gc.yml
@@ -20,8 +20,13 @@ spec:
           imagePullPolicy: Always
           securityContext:
             privileged: true
-          command:
-            - /bin/sh
-            - -c
-            - nsenter --target 1 --mount -- /root/.nix-profile/bin/nix store gc
+          command: ["nix-gc"]
+          volumeMounts:
+            - name: host-mount
+              mountPath: /host
+      volumes:
+        - name: host-mount
+          hostPath:
+            path: /
+            type: Directory
       restartPolicy: OnFailure


### PR DESCRIPTION
The nix garbage collection only deletes enough bytes, such that at least 1/4 of disk space is always free. With our current setup, that should still be around 400GB. Depending on the server, the `/nix` directory is mounted on a separate partition, which should make this even less of a problem.

Successful run (no store paths should be deleted, since there is enough space): https://github.com/edgelesssys/contrast/actions/runs/15678983961