### PR TITLE
coordinator: change liveness probe to startup

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -322,7 +322,7 @@ func Coordinator(namespace string) *CoordinatorConfig {
 								WithFailureThreshold(3).
 								WithHTTPGet(applycorev1.HTTPGetAction().
 									WithPort(intstr.FromInt(9102)).
-									WithPath("/probe/liveness")),
+									WithPath("/probe/startup")),
 							).
 							WithReadinessProbe(Probe().
 								WithPeriodSeconds(5).


### PR DESCRIPTION
The current liveness probe implementation for the Coordinator container depends on reading the Contrast history stored in a ConfigMap via the Kubernetes API, which in turn depends on `etcd`. During a recent incident, `etcd` was degraded, causing the Coodinator's liveness probe sending the  `GET` ConfigMap request to hang and eventually time out. This led to repeated liveness probe failures, resulting in kubelet killing all Coordinator containers—even though they were otherwise healthy—creating a cascading failure and blocking peer recovery.

According to Kubernetes best practices, liveness probes should reflect the internal health of the container itself, not the availability of external dependencies. This PR replaces the current liveness probe with a simplified `/probe/startup` check to ensure reachability without relying on etcd. While this is a temporary workaround rather than a final solution, it effectively removes the Coordinator’s liveness probe dependency on `etcd`.