### PR TITLE
cli: warn volume mount sharing

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -158,7 +158,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Generated workload policy annotations")
 
-	policies, err := policiesFromKubeResources(paths)
+	policies, err := policiesFromKubeResources(paths, log)
 	if err != nil {
 		return fmt.Errorf("find kube resources with policy: %w", err)
 	}

--- a/cli/cmd/policies_test.go
+++ b/cli/cmd/policies_test.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"encoding/base64"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -128,7 +129,7 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 				paths = append(paths, path)
 			}
 
-			deployments, err := policiesFromKubeResources(paths)
+			deployments, err := policiesFromKubeResources(paths, slog.Default())
 			sort.Slice(deployments, func(i, j int) bool {
 				return deployments[i].name < deployments[j].name
 			})

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -92,7 +92,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("finding yaml files: %w", err)
 	}
 
-	policies, err := policiesFromKubeResources(paths)
+	policies, err := policiesFromKubeResources(paths, log)
 	if err != nil {
 		return fmt.Errorf("finding kube resources with policy: %w", err)
 	}

--- a/internal/kubeapi/kubeapi.go
+++ b/internal/kubeapi/kubeapi.go
@@ -35,6 +35,8 @@ type (
 	CronJob = batchv1.CronJob
 	// ReplicationController is a Kubernetes ReplicationController.
 	ReplicationController = corev1.ReplicationController
+	// PodTemplateSpec is a Kubernetes PodTemplateSpec.
+	PodTemplateSpec = corev1.PodTemplateSpec
 )
 
 // UnmarshalK8SResources unmarshals a Kubernetes resource into a list of objects that can be


### PR DESCRIPTION
This PR adds a mechanism to detect and warn about volumes mounted by more than one container—whether within the same Pod or across different Pods (e.g. PVCs, ConfigMaps). We introduce a `volumeInfoMap` in `policiesFromKubeResources()`—where we already have direct access to each resource’s `PodTemplateSpec`—to accumulate mount data as we process every workload.

- **Accumulation Phase:**  
  As we iterate each resource, we increment mount counts and record which resources reference each volume in `volumeInfoMap`.

- **Reporting Phase:**  
  Once all resources are processed, `reportVolumeSharing()` walks the map and emits one warning per shared volume.

- **Unique Map Keys:**  
  Each entry’s key combines the volume’s name and its type, aiming to create UID, as it is missing before the resources are applied.

- **`emptyDir` Isolation:**  
  Because `emptyDir` volumes are confined to a single Pod, we prefix their keys with the owning resource name. This prevents false positives when multiple Pods declare emptyDirs with identical names.


