### PR TITLE
node-installer: don't require snpIDBlock on TDX

### DIFF
--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -143,3 +143,23 @@ func DefaultMemoryInMegaBytes(p Platform) int {
 		return 512
 	}
 }
+
+// IsSNP returns true if the platform is a SEV-SNP platform.
+func IsSNP(p Platform) bool {
+	switch p {
+	case AKSCloudHypervisorSNP, K3sQEMUSNP, K3sQEMUSNPGPU, MetalQEMUSNP, MetalQEMUSNPGPU:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsTDX returns true if the platform is a TDX platform.
+func IsTDX(p Platform) bool {
+	switch p {
+	case K3sQEMUTDX, RKE2QEMUTDX, MetalQEMUTDX:
+		return true
+	default:
+		return false
+	}
+}

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -185,9 +185,13 @@ func envWithDefault(key, dflt string) string {
 }
 
 func containerdRuntimeConfig(basePath, configPath string, platform platforms.Platform, qemuExtraKernelParams string, debugRuntime bool) error {
-	snpIDBlock, err := kataconfig.SnpIDBlockForPlatform(platform, abi.SevProduct().Name)
-	if err != nil {
-		return err
+	var snpIDBlock kataconfig.SnpIDBlock
+	if platforms.IsSNP(platform) {
+		var err error
+		snpIDBlock, err = kataconfig.SnpIDBlockForPlatform(platform, abi.SevProduct().Name)
+		if err != nil {
+			return err
+		}
 	}
 	kataRuntimeConfig, err := kataconfig.KataRuntimeConfig(basePath, platform, qemuExtraKernelParams, snpIDBlock, debugRuntime)
 	if err != nil {


### PR DESCRIPTION
This broke in the last refactoring.