### PR TITLE
tools/bm-maintenance: only use one host mount

### DIFF
--- a/packages/cleanup-bare-metal.sh
+++ b/packages/cleanup-bare-metal.sh
@@ -39,7 +39,7 @@ mapfile -t unusedRuntimeClasses < <(
         tr ' ' '\n' |
         grep '^contrast-cc' || true
       # Get all (maybe already deleted) runtime classes with a reference in /opt/edgeless
-      ls -1 "${OPTEDGELESS}"
+      ls -1 "${HOST_MOUNT:?}/opt/edgeless"
     } | sort -u
   )
 )
@@ -50,23 +50,23 @@ for runtimeClass in "${unusedRuntimeClasses[@]}"; do
   kubectl delete runtimeclass "${runtimeClass}" || true
 
   # Delete unused files
-  if [[ -d "${OPTEDGELESS}/${runtimeClass}" ]]; then
-    echo "Deleting files from ${OPTEDGELESS}/${runtimeClass} ..."
-    rm -rf "${OPTEDGELESS:?}/${runtimeClass}"
+  if [[ -d "${HOST_MOUNT}/opt/edgeless/${runtimeClass}" ]]; then
+    echo "Deleting files from ${HOST_MOUNT}/opt/edgeless/${runtimeClass} ..."
+    rm -rf "${HOST_MOUNT:?}/opt/edgeless/${runtimeClass}"
   fi
-  if [[ -d "/var/lib/${SNAPSHOTTER}-snapshotter" ]]; then
-    echo "Deleting files from /var/lib/${SNAPSHOTTER}-snapshotter/${runtimeClass} ..."
-    rm -rf "/var/lib/${SNAPSHOTTER}-snapshotter/${runtimeClass}"
+  if [[ -d "${HOST_MOUNT}/var/lib/${SNAPSHOTTER}-snapshotter" ]]; then
+    echo "Deleting files from ${HOST_MOUNT}/var/lib/${SNAPSHOTTER}-snapshotter/${runtimeClass} ..."
+    rm -rf "${HOST_MOUNT:?}/var/lib/${SNAPSHOTTER}-snapshotter/${runtimeClass}"
   fi
 
   # Remove references from containerd config
-  echo "Removing ${runtimeClass} from ${CONFIG} ..."
+  echo "Removing ${runtimeClass} from ${HOST_MOUNT}/${CONFIG} ..."
   # First try config v3 path. If this fails, try config v2 path.
-  dasel delete --file "${CONFIG}" --indent 0 --read toml --write toml "plugins.io\.containerd\.cri\.v1\.runtime.containerd.runtimes.${runtimeClass}" ||
-    dasel delete --file "${CONFIG}" --indent 0 --read toml --write toml "plugins.io\.containerd\.grpc\.v1\.cri.containerd.runtimes.${runtimeClass}" ||
+  dasel delete --file "${HOST_MOUNT:?}/${CONFIG}" --indent 0 --read toml --write toml "plugins.io\.containerd\.cri\.v1\.runtime.containerd.runtimes.${runtimeClass}" ||
+    dasel delete --file "${HOST_MOUNT:?}/${CONFIG}" --indent 0 --read toml --write toml "plugins.io\.containerd\.grpc\.v1\.cri.containerd.runtimes.${runtimeClass}" ||
     true
 
-  dasel delete --file "${CONFIG}" --indent 0 --read toml --write toml "proxy_plugins.${SNAPSHOTTER}-${runtimeClass}" 2>/dev/null || true
+  dasel delete --file "${HOST_MOUNT:?}/${CONFIG}" --indent 0 --read toml --write toml "proxy_plugins.${SNAPSHOTTER}-${runtimeClass}" 2>/dev/null || true
 done
 
 echo "Cleanup finished"

--- a/tools/bm-maintenance/cleanup.yml
+++ b/tools/bm-maintenance/cleanup.yml
@@ -56,36 +56,18 @@ spec:
           image: "@@REPLACE_IMAGE@@"
           imagePullPolicy: Always
           env:
-            - name: OPTEDGELESS
-              value: /opt/edgeless
+            - name: HOST_MOUNT
+              value: /host
             - name: CONFIG
               value: /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
             - name: SNAPSHOTTER
               value: nydus
           volumeMounts:
-            - name: opt-edgeless
-              mountPath: /opt/edgeless
-            - name: snapshotter-data
-              mountPath: /var/lib/nydus-snapshotter
-            - name: containerd-config
-              mountPath: /var/lib/rancher/k3s/agent/etc/containerd
-            - name: containerd-run
-              mountPath: /run/k3s/containerd/
+            - name: host-mount
+              mountPath: /host
       volumes:
-        - name: opt-edgeless
+        - name: host-mount
           hostPath:
-            path: /opt/edgeless
-            type: Directory
-        - name: snapshotter-data
-          hostPath:
-            path: /var/lib/nydus-snapshotter
-            type: Directory
-        - name: containerd-config
-          hostPath:
-            path: /var/lib/rancher/k3s/agent/etc/containerd
-            type: Directory
-        - name: containerd-run
-          hostPath:
-            path: /run/k3s/containerd/
+            path: /
             type: Directory
       restartPolicy: OnFailure


### PR DESCRIPTION
In cases where no `/var/lib/nydus-snapshotter` directory is on the host (since we don't use it anymore), the volume mount would fail. This simplifies the deployment with only one `/host` mount, so if `/var/lib/nydus-snapshotter` does not exist, nothing happens.