### PR TITLE
coordinator: don't fail liveness probe if Kubernetes API server is unavailable

### DIFF
--- a/coordinator/internal/peerrecovery/recovery.go
+++ b/coordinator/internal/peerrecovery/recovery.go
@@ -70,7 +70,7 @@ func New(guard guard, peerGetter peerGetter, issuer atls.Issuer, httpsGetter *ce
 // The function returns only when the context expires, with the error returned from the context.
 func (r *Recoverer) RunRecovery(ctx context.Context) error {
 	return periodically(ctx, r.clock, peerRecoveryInterval, func(ctx context.Context) {
-		if err := r.recoverFromAvailablePeers(ctx); err != nil {
+		if err := r.RecoverOnce(ctx); err != nil {
 			r.logger.Warn("Could not recover from any peer.", "err", err)
 		}
 	})
@@ -78,8 +78,8 @@ func (r *Recoverer) RunRecovery(ctx context.Context) error {
 
 var errNoPeers = errors.New("no peers found")
 
-// recoverFromAvailablePeers performs one round of recovery attempts over all discovered peers.
-func (r *Recoverer) recoverFromAvailablePeers(ctx context.Context) error {
+// RecoverOnce performs one round of recovery attempts over all discovered peers.
+func (r *Recoverer) RecoverOnce(ctx context.Context) error {
 	oldState, err := r.guard.GetState(ctx)
 	if !errors.Is(err, stateguard.ErrStaleState) {
 		return nil

--- a/coordinator/internal/peerrecovery/recovery_test.go
+++ b/coordinator/internal/peerrecovery/recovery_test.go
@@ -108,7 +108,7 @@ func TestRecoverOnce(t *testing.T) {
 				dialer:     &stubDialer{responses: tc.dialResponse},
 				logger:     logger,
 			}
-			err := r.recoverFromAvailablePeers(ctx)
+			err := r.RecoverOnce(ctx)
 			require.ErrorIs(err, tc.wantErr)
 		})
 	}

--- a/coordinator/internal/probes/probes.go
+++ b/coordinator/internal/probes/probes.go
@@ -13,16 +13,16 @@ import (
 
 // StartupHandler is the http handler for `/probes/startup`.
 type StartupHandler struct {
-	UserapiStarted *atomic.Bool
-	MeshapiStarted *atomic.Bool
+	UserapiStarted  *atomic.Bool
+	MeshapiStarted  *atomic.Bool
+	RecoveryStarted *atomic.Bool
 }
 
 func (h StartupHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	if !h.UserapiStarted.Load() || !h.MeshapiStarted.Load() {
+	if !h.UserapiStarted.Load() || !h.MeshapiStarted.Load() || !h.RecoveryStarted.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
-	// TODO(miampf): Check if peer recovery was attempted once
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/coordinator/internal/probes/probes.go
+++ b/coordinator/internal/probes/probes.go
@@ -52,7 +52,6 @@ func (h ReadinessHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
-	// TODO(miampf): Check that coordinator isn't in recovery mode
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/coordinator/internal/probes/probes.go
+++ b/coordinator/internal/probes/probes.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"sync/atomic"
 
-	"github.com/edgelesssys/contrast/coordinator/internal/history"
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 )
 
@@ -24,20 +23,6 @@ func (h StartupHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 	// TODO(miampf): Check if peer recovery was attempted once
-	w.WriteHeader(http.StatusOK)
-}
-
-// LivenessHandler is the http handler for `/probes/liveness`.
-type LivenessHandler struct {
-	Hist *history.History
-}
-
-func (h LivenessHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	_, err := h.Hist.HasLatest()
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		return
-	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/coordinator/internal/probes/probes_test.go
+++ b/coordinator/internal/probes/probes_test.go
@@ -16,60 +16,94 @@ import (
 
 func TestStartupProbe(t *testing.T) {
 	testCases := map[string]struct {
-		userapiStartedFirst  bool
-		meshapiStartedFirst  bool
-		userapiStartedSecond bool
-		meshapiStartedSecond bool
-		want503First         bool
-		want503Second        bool
+		userapiStartedFirst   bool
+		meshapiStartedFirst   bool
+		recoveryStartedFirst  bool
+		userapiStartedSecond  bool
+		meshapiStartedSecond  bool
+		recoveryStartedSecond bool
+		want503First          bool
+		want503Second         bool
 	}{
 		"all immediately online": {
-			userapiStartedFirst:  true,
-			meshapiStartedFirst:  true,
-			userapiStartedSecond: true,
-			meshapiStartedSecond: true,
-			want503First:         false,
-			want503Second:        false,
+			userapiStartedFirst:   true,
+			meshapiStartedFirst:   true,
+			recoveryStartedFirst:  true,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: true,
+			want503First:          false,
+			want503Second:         false,
 		},
 		"userapi never starts": {
-			userapiStartedFirst:  false,
-			meshapiStartedFirst:  true,
-			userapiStartedSecond: false,
-			meshapiStartedSecond: true,
-			want503First:         true,
-			want503Second:        true,
+			userapiStartedFirst:   false,
+			meshapiStartedFirst:   true,
+			recoveryStartedFirst:  true,
+			userapiStartedSecond:  false,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: true,
+			want503First:          true,
+			want503Second:         true,
 		},
 		"meshapi never starts": {
-			userapiStartedFirst:  true,
-			meshapiStartedFirst:  false,
-			userapiStartedSecond: true,
-			meshapiStartedSecond: false,
-			want503First:         true,
-			want503Second:        true,
+			userapiStartedFirst:   true,
+			meshapiStartedFirst:   false,
+			recoveryStartedFirst:  true,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  false,
+			recoveryStartedSecond: true,
+			want503First:          true,
+			want503Second:         true,
+		},
+		"recovery never starts": {
+			userapiStartedFirst:   true,
+			meshapiStartedFirst:   true,
+			recoveryStartedFirst:  false,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: false,
+			want503First:          true,
+			want503Second:         true,
 		},
 		"userapi starts later": {
-			userapiStartedFirst:  false,
-			meshapiStartedFirst:  true,
-			userapiStartedSecond: true,
-			meshapiStartedSecond: true,
-			want503First:         true,
-			want503Second:        false,
+			userapiStartedFirst:   false,
+			meshapiStartedFirst:   true,
+			recoveryStartedFirst:  true,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: true,
+			want503First:          true,
+			want503Second:         false,
 		},
 		"meshapi starts later": {
-			userapiStartedFirst:  true,
-			meshapiStartedFirst:  false,
-			userapiStartedSecond: true,
-			meshapiStartedSecond: true,
-			want503First:         true,
-			want503Second:        false,
+			userapiStartedFirst:   true,
+			meshapiStartedFirst:   false,
+			recoveryStartedFirst:  true,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: true,
+			want503First:          true,
+			want503Second:         false,
 		},
-		"both start later": {
-			userapiStartedFirst:  false,
-			meshapiStartedFirst:  false,
-			userapiStartedSecond: true,
-			meshapiStartedSecond: true,
-			want503First:         true,
-			want503Second:        false,
+		"recovery starts later": {
+			userapiStartedFirst:   true,
+			meshapiStartedFirst:   true,
+			recoveryStartedFirst:  false,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: true,
+			want503First:          true,
+			want503Second:         false,
+		},
+		"all start later": {
+			userapiStartedFirst:   false,
+			meshapiStartedFirst:   false,
+			recoveryStartedFirst:  false,
+			userapiStartedSecond:  true,
+			meshapiStartedSecond:  true,
+			recoveryStartedSecond: true,
+			want503First:          true,
+			want503Second:         false,
 		},
 	}
 
@@ -82,13 +116,17 @@ func TestStartupProbe(t *testing.T) {
 
 			mux := http.NewServeMux()
 
-			var userapiStarted atomic.Bool
-			var meshapiStarted atomic.Bool
+			var userapiStarted, meshapiStarted, recoveryStarted atomic.Bool
 
 			userapiStarted.Store(tc.userapiStartedFirst)
 			meshapiStarted.Store(tc.meshapiStartedFirst)
+			recoveryStarted.Store(tc.recoveryStartedFirst)
 
-			handler := StartupHandler{MeshapiStarted: &meshapiStarted, UserapiStarted: &userapiStarted}
+			handler := StartupHandler{
+				UserapiStarted:  &userapiStarted,
+				MeshapiStarted:  &meshapiStarted,
+				RecoveryStarted: &recoveryStarted,
+			}
 
 			mux.Handle("/probes/startup", &handler)
 
@@ -103,6 +141,7 @@ func TestStartupProbe(t *testing.T) {
 			resp = httptest.NewRecorder()
 			userapiStarted.Store(tc.userapiStartedSecond)
 			meshapiStarted.Store(tc.meshapiStartedSecond)
+			recoveryStarted.Store(tc.recoveryStartedSecond)
 
 			mux.ServeHTTP(resp, req)
 

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -124,7 +124,6 @@ func run() (retErr error) {
 	var meshapiStarted atomic.Bool
 
 	startupHandler := probes.StartupHandler{UserapiStarted: &userapiStarted, MeshapiStarted: &meshapiStarted}
-	livenessHandler := probes.LivenessHandler{Hist: hist}
 	readinessHandler := probes.ReadinessHandler{Guard: meshAuth}
 
 	transitAPIServer, err := transitengine.NewTransitEngineAPI(meshAuth, logger)
@@ -147,7 +146,7 @@ func run() (retErr error) {
 			))
 		}
 		mux.Handle("/probe/startup", &startupHandler)
-		mux.Handle("/probe/liveness", &livenessHandler)
+		mux.Handle("/probe/liveness", &startupHandler)
 		mux.Handle("/probe/readiness", &readinessHandler)
 		httpServer.Addr = ":" + strconv.Itoa(probeAndMetricsPort)
 		httpServer.Handler = mux

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -120,10 +120,13 @@ func run() (retErr error) {
 
 	httpServer := &http.Server{}
 
-	var userapiStarted atomic.Bool
-	var meshapiStarted atomic.Bool
+	var userapiStarted, meshapiStarted, recoveryStarted atomic.Bool
 
-	startupHandler := probes.StartupHandler{UserapiStarted: &userapiStarted, MeshapiStarted: &meshapiStarted}
+	startupHandler := probes.StartupHandler{
+		UserapiStarted:  &userapiStarted,
+		MeshapiStarted:  &meshapiStarted,
+		RecoveryStarted: &recoveryStarted,
+	}
 	readinessHandler := probes.ReadinessHandler{Guard: meshAuth}
 
 	transitAPIServer, err := transitengine.NewTransitEngineAPI(meshAuth, logger)
@@ -210,6 +213,14 @@ func run() (retErr error) {
 		logger.Info("Coordinator peer recovery started")
 		discovery := peerdiscovery.New(clientset, string(namespace))
 		recoverer := peerrecovery.New(meshAuth, discovery, issuer, kdsGetter, logger)
+
+		onceCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		if err := recoverer.RecoverOnce(onceCtx); err != nil {
+			logger.Warn("Running initial peer recovery", "err", err)
+		}
+		cancel()
+		recoveryStarted.Store(true)
+
 		if err := recoverer.RunRecovery(ctx); err != nil {
 			logger.Error("Running peer recovery", "err", err)
 			return fmt.Errorf("running peer recovery: %w", err)


### PR DESCRIPTION
If the Kubernetes API becomes unavailable, the Coordinator will fail the liveness probe and be restarted eventually. This defeats the point of automatic peer recovery, because it is very likely that all Coordinators are experiencing the API downtime at the same time, so will all be restarted and not have any peers to recover from.

This PR replaces the liveness probe with the startup probe, because there are no liveness conditions within the Coordinator that do not explicitly lead to process termination. Checking the startup probe again should suffice for detecting network or VM problems. This is aligned with [k8s best practices](https://codefresh.io/learn/kubernetes-management/kubernetes-liveness-probes/), h/t @thomasten. 

Bundled with this change, the startup probe now includes one round of peer recovery, as was [originally planned](https://github.com/edgelesssys/contrast/blob/177a84f03ed9c00cb4df8d881c62ceab3b4af345/rfc/010-distributed-coordinator.md?plain=1#L113).