### PR TITLE
chore: add .tmp directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ out.env
 infra/**/kustomization.yaml
 uplosi.conf*
 .custom/
+.tmp*


### PR DESCRIPTION
Occasionally when running `just e2e ...`, `.tmp...` directories are created. These are unwanted in the source tree and should be ignored