### PR TITLE
e2e/regression: extend test for secrets and config maps

### DIFF
--- a/e2e/regression/testdata/pod-secret-and-cm/cm.yml
+++ b/e2e/regression/testdata/pod-secret-and-cm/cm.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  namespace: "@@REPLACE_NAMESPACE@@"
+data:
+  CM_CONTENT: foobar

--- a/e2e/regression/testdata/pod-secret-and-cm/pod.yml
+++ b/e2e/regression/testdata/pod-secret-and-cm/pod.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  namespace: "@@REPLACE_NAMESPACE@@"
+spec:
+  runtimeClassName: contrast-cc
+  containers:
+    - name: test
+      image: ghcr.io/edgelesssys/bash@sha256:cabc70d68e38584052cff2c271748a0506b47069ebbd3d26096478524e9b270b
+      command:
+        - /usr/local/bin/bash
+        - -xec
+        - |
+          [[ $CM_CONTENT == "foobar" ]]
+          [[ $SECRET_CONTENT == "barfoo" ]]
+          touch /tmp/works
+          sleep infinity
+      envFrom:
+        - configMapRef:
+            name: cm
+        - secretRef:
+            name: secret
+      readinessProbe:
+        exec:
+          command:
+            - /usr/local/bin/bash
+            - -c
+            - cat /tmp/works
+        initialDelaySeconds: 5
+        periodSeconds: 5

--- a/e2e/regression/testdata/pod-secret-and-cm/secret.yml
+++ b/e2e/regression/testdata/pod-secret-and-cm/secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+  namespace: "@@REPLACE_NAMESPACE@@"
+type: Opaque
+data:
+  SECRET_CONTENT: YmFyZm9v


### PR DESCRIPTION
Add a test that consumes a secret and a config map in a pod. Needs https://github.com/edgelesssys/contrast/pull/1535 before merging.