### PR TITLE
nixos: enforce cgroupv2

### DIFF
--- a/packages/by-name/buildVerityMicroVM/package.nix
+++ b/packages/by-name/buildVerityMicroVM/package.nix
@@ -51,6 +51,7 @@ lib.throwIf
           ++ [
             "init=${nixos-config.config.system.build.toplevel}/init"
             "roothash=${roothash}"
+            "cgroup_no_v1=all"
           ]
         );
         inherit (image) imageFileName;

--- a/packages/by-name/kata/kata-runtime/package.nix
+++ b/packages/by-name/kata/kata-runtime/package.nix
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 {
+  lib,
   buildGoModule,
   fetchFromGitHub,
   yq-go,
@@ -227,10 +228,61 @@ buildGoModule (finalAttrs: {
   # is used when Kata starts a VM.
   # For example, this command should do the job:
   # `journalctl -t kata -l --no-pager | grep launching | tail -1`
-  passthru.cmdline = {
-    default = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none";
-    debug = "tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 root=/dev/vda1 rootflags=ro rootfstype=erofs console=hvc0 console=hvc1 debug systemd.show_status=true systemd.log_level=debug panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.log=debug agent.debug_console agent.debug_console_vport=1026";
-  };
+  #
+  # Notice! Ordering matters and depends on the order in which kata-runtime adds these values.
+  passthru.cmdline =
+    let
+      cmdline =
+        debug:
+        lib.concatStringsSep " " (
+          [
+            "tsc=reliable"
+            "no_timer_check"
+            "rcupdate.rcu_expedited=1"
+            "i8042.direct=1"
+            "i8042.dumbkbd=1"
+            "i8042.nopnp=1"
+            "i8042.noaux=1"
+            "noreplace-smp"
+            "reboot=k"
+            "cryptomgr.notests"
+            "net.ifnames=0"
+            "pci=lastbus=0"
+            "root=/dev/vda1"
+            "rootflags=ro"
+            "rootfstype=erofs"
+            "console=hvc0"
+            "console=hvc1"
+          ]
+          ++ lib.optionals debug [
+            "debug"
+            "systemd.show_status=true"
+            "systemd.log_level=debug"
+          ]
+          ++ lib.optionals (!debug) [
+            "quiet"
+            "systemd.show_status=false"
+          ]
+          ++ [
+            "panic=1"
+            "nr_cpus=1"
+            "selinux=0"
+            "systemd.unit=kata-containers.target"
+            "systemd.mask=systemd-networkd.service"
+            "systemd.mask=systemd-networkd.socket"
+            "scsi_mod.scan=none"
+          ]
+          ++ lib.optionals debug [
+            "agent.log=debug"
+            "agent.debug_console"
+            "agent.debug_console_vport=1026"
+          ]
+        );
+    in
+    {
+      default = cmdline false;
+      debug = cmdline true;
+    };
 
   meta.mainProgram = "containerd-shim-kata-v2";
 })


### PR DESCRIPTION
This is based on https://github.com/kata-containers/kata-containers/commit/c6537192701a5843328191f0ef7b61a9b34cc1b6
The `systemd.unified_cgroup_hierarchy=1` is deprecated in current systemd versions.

First commit just improves readability, no functional change.