### PR TITLE
overlays: update libnvidia-container patch

### DIFF
--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -105,7 +105,7 @@ final: prev:
         [
           # Patch No. 1 needs a rebase on the new version, fetch the rebased version from the upstream PR.
           (final.fetchpatch {
-            url = "https://raw.githubusercontent.com/katexochen/nixpkgs/refs/heads/libnvidia-container/1.17.8/pkgs/by-name/li/libnvidia-container/0001-ldcache-don-t-use-ldcache.patch";
+            url = "https://raw.githubusercontent.com/NixOS/nixpkgs/0c909a5522020455d518a7f028e4850d55080bf6/pkgs/by-name/li/libnvidia-container/0001-ldcache-don-t-use-ldcache.patch";
             hash = "sha256-mdjWLa7kSWVaoyOSNKKt59I0XxyKO+QJEnmNCh+/pPU=";
           })
         ]


### PR DESCRIPTION
Used the wrong url when introducing this, the head of that pull is now gone.