### PR TITLE
just: acquire fifo ticket for gpu platform

### DIFF
--- a/.github/workflows/bm_maintenance.yml
+++ b/.github/workflows/bm_maintenance.yml
@@ -108,6 +108,12 @@ jobs:
         if: (!matrix.platform.self-hosted)
         run: |
           just get-credentials
+      - name: Update sync fifo for GPU platform
+        if: ${{ matrix.platform.name == 'K3s-QEMU-SNP-GPU' }}
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/4eaded61e6943af308b0236ee88b8766b6f52e86/server/deployment.yml
+          kubectl wait --for=condition=available --timeout=5m deployment/sync
+          nix run .#scripts.renew-sync-fifo
       - name: Update namespace cleanup cronjob
         id: update
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           just get-credentials
       - name: Set sync environment
-        if: (!inputs.self-hosted)
+        if: (!inputs.self-hosted || inputs.platform == 'K3s-QEMU-SNP-GPU')
         run: |
           sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
           echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a "$GITHUB_ENV"

--- a/packages/cleanup-namespaces.sh
+++ b/packages/cleanup-namespaces.sh
@@ -27,7 +27,13 @@ kubectl get namespaces --no-headers | while read -r ns _; do
 
   if [[ $time -lt "$(($(date +%s) - 3600))" ]]; then
     echo "Deleting namespace: $ns"
+    sync_ticket=$(kubectl get namespace "$ns" -o jsonpath='{.metadata.labels.contrast\.edgeless\.systems/sync-ticket}')
     kubectl delete namespace "$ns"
+    if [[ -n $sync_ticket ]]; then
+      sync_ip=$(kubectl get svc -n default sync -o jsonpath='{.spec.clusterIP}')
+      sync_uuid=$(kubectl get configmap -n default sync-server-fifo -o jsonpath='{.data.uuid}')
+      curl -fsSL "$sync_ip:8080/fifo/$sync_uuid/done/$sync_ticket"
+    fi
   else
     echo "Skipping namespace: $ns (created within the last hour)"
   fi

--- a/tools/bm-maintenance/cleanup-namespaces.yml
+++ b/tools/bm-maintenance/cleanup-namespaces.yml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "configmaps"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
When running `just` on the GPU CI cluster, devs and CI jobs are now both required to get a sync ticket. This primarily prevents failing E2E tests due to a blocked GPU by a dev. A sync ticket is acquired on `just apply` and released on `just undeploy`. The ticket acquired in the `justfile` has a lifetime of 90m, but note that any namespace older than 1h will automatically be cleaned up. This requires https://github.com/katexochen/sync/pull/1.