### PR TITLE
[release/v1.9] initializer: create /run directory for cryptsetup

### DIFF
--- a/initializer/main.go
+++ b/initializer/main.go
@@ -186,6 +186,11 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 
 	log.Info("Setting up encrypted mount")
 
+	// Create tmp dir for cryptsetup lock files.
+	if err := os.MkdirAll("/run/cryptsetup", 0o755); err != nil {
+		return fmt.Errorf("creating cryptestup lock directory: %w", err)
+	}
+
 	flags := &cryptsetupFlags{
 		devicePath:       cryptsetupDevicePath,
 		volumeMountPoint: "/state",


### PR DESCRIPTION
Backport of #1565 to `release/v1.9`.

Original description:

---

Fixes a regression introduced by 830c2ebf63dedb0b3657a30313779913a1fcb648, which did not take LUKS2 lock files into account.

* [x] [volumestatefulset e2e](https://github.com/edgelesssys/contrast/actions/runs/16045552549), which was affected