### PR TITLE
ci: fix nix build dir setup after update to nix 2.30

### DIFF
--- a/.github/actions/setup_nix/action.yml
+++ b/.github/actions/setup_nix/action.yml
@@ -37,8 +37,6 @@ runs:
         sudo truncate -s 20G /mnt/btrfs.img
         sudo mkfs.btrfs -f /mnt/btrfs.img
         sudo mount /mnt/btrfs.img /mnt/nixbld
-        sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-        echo -e "[Service]\nEnvironment=TMPDIR=/mnt/nixbld" | sudo tee /etc/systemd/system/nix-daemon.service.d/btrfs.conf
-        sudo systemctl daemon-reload
+        echo "build-dir = /mnt/nixbld" | sudo tee -a /etc/nix/nix.conf
         sudo systemctl restart nix-daemon
         sudo df -h


### PR DESCRIPTION
'build dir' no longer defaults to TMPDIR:
https://nix.dev/manual/nix/2.30/release-notes/rl-2.30.html#backward-incompatible-changes-and-deprecations