### PR TITLE
ci: don't run docs-publish on PRs from forks

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -30,6 +30,7 @@ jobs:
   deploy:
     name: Publish docs to GitHub Pages
     runs-on: ubuntu-22.04
+    if: github.repository_owner == github.event.pull_request.head.repo.owner.login
     env:
       PREVIEW: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
     steps:
@@ -57,7 +58,7 @@ jobs:
         run: |
           nix build -L --impure --expr "(builtins.getFlake \"git+file://$(pwd)?shallow=1\").outputs.legacyPackages.x86_64-linux.contrast-docs.override { docusaurusBaseUrl = \"contrast/pr-preview/pr-${{ github.event.number }}\"; }"
       - name: Deploy preview
-        if: env.PREVIEW == 'true' && !github.event.pull_request.head.repo.fork
+        if: env.PREVIEW == 'true'
         uses: rossjrw/pr-preview-action@9f77b1d057b494e662c50b8ca40ecc63f21e0887 # v1.6.2
         with:
           source-dir: ./result


### PR DESCRIPTION
To harden the workflow, don't run it on any PRs originating from forks.