### PR TITLE
nodeinstaller: automatically update testdata on kata config update

### DIFF
--- a/nodeinstaller/internal/kataconfig/update-testdata/main.go
+++ b/nodeinstaller/internal/kataconfig/update-testdata/main.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// Update the configs and testdata for all platforms when they change upstream in kata-containers.
+// Should be invoked via `nix run .#scripts.update-kata-configurations`.
+// This is also part of the `static` CI workflow through `nix run .#scripts.generate`.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/edgelesssys/contrast/nodeinstaller/internal/kataconfig"
+)
+
+func main() {
+	tarball := os.Args[1]
+	gitroot := os.Args[2]
+
+	platforms := map[platforms.Platform]struct {
+		upstream string
+		config   string
+		testdata string
+	}{
+		platforms.AKSCloudHypervisorSNP: {
+			upstream: "clh",
+			config:   "clh-snp",
+			testdata: "clh-snp",
+		},
+		platforms.K3sQEMUSNP: {
+			upstream: "qemu-snp",
+			config:   "qemu-snp",
+			testdata: "qemu-snp",
+		},
+		platforms.K3sQEMUTDX: {
+			upstream: "qemu-tdx",
+			config:   "qemu-tdx",
+			testdata: "qemu-tdx",
+		},
+		platforms.K3sQEMUSNPGPU: {
+			upstream: "qemu-snp",
+			config:   "qemu-snp",
+			testdata: "qemu-snp-gpu",
+		},
+	}
+
+	snpIDBlock := kataconfig.SnpIDBlock{
+		IDAuth:  "PLACEHOLDER_ID_AUTH",
+		IDBlock: "PLACEHOLDER_ID_BLOCK",
+	}
+
+	exit := 0
+	for platform, platformConfig := range platforms {
+		upstreamFile := filepath.Join(tarball, "opt", "kata", "share", "defaults", "kata-containers", fmt.Sprintf("configuration-%s.toml", platformConfig.upstream))
+		configFile := filepath.Join(gitroot, "nodeinstaller", "internal", "kataconfig", fmt.Sprintf("configuration-%s.toml", platformConfig.config))
+		testdataFile := filepath.Join(gitroot, "nodeinstaller", "internal", "kataconfig", "testdata", fmt.Sprintf("expected-configuration-%s.toml", platformConfig.testdata))
+
+		upstream, err := os.ReadFile(upstreamFile)
+		if err != nil {
+			log.Fatalf("opening upstream file: %s", err)
+		}
+
+		config, err := os.ReadFile(configFile)
+		if err != nil {
+			log.Fatalf("opening config file: %s", err)
+		}
+
+		if bytes.Equal(upstream, config) {
+			log.Printf("✔ No upstream changes for platform %s.", platform.String())
+		} else {
+			// Continuing anyway to prevent missing config updates due to the platformConfig.config file changing in iteration i,
+			// and then being assessed as unchanged in iteration i+j (example: changes to qemu-snp also need updates in qemu-snp-gpu)
+			log.Printf("⚠ Updating config for platform %s.", platform.String())
+			exit = 1
+		}
+
+		if err := os.WriteFile(configFile, upstream, 0o644); err != nil {
+			log.Fatalf("failed to write new config: %s", err)
+		}
+
+		cfg, err := kataconfig.KataRuntimeConfig("/", platform, "", snpIDBlock, false)
+		if err != nil {
+			log.Fatalf("failed to create config: %s", err)
+		}
+
+		cfgBytes, err := cfg.Marshal()
+		if err != nil {
+			log.Fatalf("failed to marshal config: %s", err)
+		}
+
+		if err := os.WriteFile(testdataFile, cfgBytes, 0o644); err != nil {
+			log.Fatalf("failed to write testdata: %s", err)
+		}
+	}
+
+	os.Exit(exit)
+}

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -577,43 +577,40 @@
 
   update-kata-configurations = writeShellApplication {
     name = "update-kata-configurations";
-    runtimeInputs = with pkgs; [
-      yq
-      diffutils
+    runtimeInputs = [
+      (pkgs.buildGoModule {
+        inherit (pkgs.contrast) vendorHash;
+        name = "nodeinstaller-kataconfig-update-testdata";
+
+        src =
+          let
+            inherit (lib) fileset path hasSuffix;
+            root = ../.;
+          in
+          lib.fileset.toSource {
+            inherit root;
+            fileset = fileset.unions [
+              (path.append root "go.mod")
+              (path.append root "go.sum")
+              (fileset.fileFilter (file: hasSuffix ".go" file.name) (path.append root "internal/platforms"))
+              (fileset.fileFilter (file: hasSuffix ".go" file.name) (path.append root "nodeinstaller"))
+              (fileset.fileFilter (file: hasSuffix ".toml" file.name) (path.append root "nodeinstaller"))
+              (fileset.fileFilter (file: hasSuffix ".json" file.name) (path.append root "nodeinstaller"))
+            ];
+          };
+
+        proxyVendor = true;
+        subPackages = [ "nodeinstaller/internal/kataconfig/update-testdata" ];
+
+        env.CGO_ENABLED = 0;
+        ldflags = [ "-s" ];
+        doCheck = false;
+      })
+      pkgs.git
     ];
     text = # bash
       ''
-        old_defaults="$(git rev-parse --show-toplevel)/nodeinstaller/internal/kataconfig"
-        new_defaults="${pkgs.kata.release-tarball}/opt/kata/share/defaults/kata-containers"
-
-        declare -A PLATFORMS=(
-          ["clh"]="clh-snp"
-          ["qemu-snp"]="qemu-snp"
-          ["qemu-tdx"]="qemu-tdx"
-        )
-
-        exit_code=0
-        for upstream_name in "''${!PLATFORMS[@]}"; do
-          platform="''${PLATFORMS[$upstream_name]}"
-          old_file="$old_defaults/configuration-$platform.toml"
-          new_file="$new_defaults/configuration-$upstream_name.toml"
-
-          if [[ ! -f "$new_file" ]]; then
-            # platform has been removed or renamed upstream
-            echo "✖ No config for $upstream_name available in upstream source."
-            exit_code=1
-            continue
-          fi
-
-          diff=$(diff "$old_file" "$new_file" || true)
-          if [[ -n "$diff" ]]; then
-            cp -f "$new_file" "$old_file"
-            echo "⚠ Updated config for platform $platform."
-          else
-            echo "✔ No upstream changes for platform $platform."
-          fi
-        done
-        exit $exit_code
+        update-testdata ${pkgs.kata.release-tarball} "$(git rev-parse --show-toplevel)"
       '';
   };
 


### PR DESCRIPTION
Decided to re-do the bash script in go because it seemed easiest to access `KataRuntimeConfig` directly, and splitting the config update between a bash script and a go bin didn't seem super intuitive.

Having a separate `go.mod` here seems wrong, not sure how else to access the `internal` package though?