### PR TITLE
e2e: increase timeout limits for tests that restart pods

### DIFF
--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -82,12 +82,11 @@ func TestPolicy(t *testing.T) {
 	})
 
 	// initial deployment with pod allowed
-
-	ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(1*time.Minute))
-	defer cancel()
-
 	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
 	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+
+	ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
+	defer cancel()
 
 	require.NoError(t, ct.Kubeclient.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, coordinator))
 	require.NoError(t, ct.Kubeclient.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, opensslFrontend))

--- a/e2e/volumestatefulset/volumestatefulset_test.go
+++ b/e2e/volumestatefulset/volumestatefulset_test.go
@@ -81,7 +81,7 @@ func TestVolumeStatefulSet(t *testing.T) {
 	t.Run("file still exists when pod is restarted", func(t *testing.T) {
 		require := require.New(t)
 
-		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(30*time.Second))
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
 		defer cancel()
 
 		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "volume-tester"))

--- a/e2e/workloadsecret/workloadsecret_test.go
+++ b/e2e/workloadsecret/workloadsecret_test.go
@@ -151,7 +151,7 @@ func TestWorkloadSecrets(t *testing.T) {
 
 		t.Run("set", ct.Set)
 
-		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(60*time.Second))
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
 		defer cancel()
 
 		deployments := []string{"web", "emoji"}
@@ -183,8 +183,6 @@ func TestWorkloadSecrets(t *testing.T) {
 	t.Run("workload secrets are not created if not configured in the manifest", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
-		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(60*time.Second))
-		defer cancel()
 
 		ct.PatchManifest(t, func(m manifest.Manifest) manifest.Manifest {
 			for key, policy := range m.Policies {
@@ -195,6 +193,9 @@ func TestWorkloadSecrets(t *testing.T) {
 		})
 
 		t.Run("set", ct.Set)
+
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
+		defer cancel()
 		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.Deployment{}, ct.Namespace, "web"))
 		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, "web"))
 


### PR DESCRIPTION
Some pods may fail to restart fast enough to satisfy context timeouts. This PR increases the timeouts for all cases where a pod is restarted to 2 minutes.