### PR TITLE
ci: fix docs build on main

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -30,7 +30,10 @@ jobs:
   deploy:
     name: Publish docs to GitHub Pages
     runs-on: ubuntu-22.04
-    if: github.repository_owner == github.event.pull_request.head.repo.owner.login
+    # Prevent the job from running on forked PRs, for security reasons.
+    if: |
+      (github.event_name == 'push' && github.ref_name == 'main') ||
+      (github.repository_owner == github.event.pull_request.head.repo.owner.login)
     env:
       PREVIEW: ${{ !(github.event_name == 'push' && github.ref_name == 'main') }}
     steps:


### PR DESCRIPTION
This fixes an issue introduced in ce49f90072fba55ed27821c4b4e13606df9d873c.

Docs aren't build anymore on main, as the event.pull_request doesn't exist (the event is push on main).