### PR TITLE
imagepuller: test against evil registry

### DIFF
--- a/imagepuller/go.mod
+++ b/imagepuller/go.mod
@@ -3,10 +3,13 @@ module github.com/edgelesssys/contrast/imagepuller
 go 1.24.0
 
 require (
+	github.com/burgerdev/evil-registry/registry v0.0.0-20250724134721-b94d02f82d16
 	github.com/containerd/ttrpc v1.2.7
 	github.com/containers/storage v1.58.0
 	github.com/google/go-containerregistry v0.20.6
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0
 	google.golang.org/protobuf v1.36.3
@@ -23,6 +26,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/containerd/typeurl/v2 v2.2.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v28.2.2+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
@@ -42,11 +46,11 @@ require (
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.12.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.2 // indirect
@@ -55,4 +59,5 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/imagepuller/go.sum
+++ b/imagepuller/go.sum
@@ -6,6 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=
 github.com/Microsoft/hcsshim v0.12.9/go.mod h1:fJ0gkFAna6ukt0bLdKB8djt4XIJhF/vEPuoIWYVvZ8Y=
+github.com/burgerdev/evil-registry/registry v0.0.0-20250724134721-b94d02f82d16 h1:nrPcyZj6bejwu9itrnebXZ1Wl28hl4dQpekTu3bbOC0=
+github.com/burgerdev/evil-registry/registry v0.0.0-20250724134721-b94d02f82d16/go.mod h1:4WU3m9OnWN4YORULs53iEJNYCYfVqpmQMbuRvtAfek8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -219,6 +221,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
 google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/imagepuller/internal/service/verify.go
+++ b/imagepuller/internal/service/verify.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -20,24 +21,18 @@ func (s *ImagePullerService) getAndVerifyImage(ctx context.Context, log *slog.Lo
 	if err != nil {
 		return nil, fmt.Errorf("parsing image digest: %w", err)
 	}
-	digestExpected := ref.DigestStr()
 
 	tr := transport.NewRetry(remote.DefaultTransport)
 
+	remoteImgIndex, err := remote.Index(ref, remote.WithContext(ctx), remote.WithTransport(tr))
+	if isDigestMismatch(err) {
+		return nil, fmt.Errorf("validating image ref: %w", err)
+	}
+
 	var remoteImg v1.Image
 	var imgErr error
-	remoteImgIndex, err := remote.Index(ref, remote.WithContext(ctx), remote.WithTransport(tr))
 	if err == nil {
 		log.Info("Received manifest list")
-
-		digestGot, err := remoteImgIndex.Digest()
-		if err != nil {
-			return nil, fmt.Errorf("obtaining actual image index digest: %w", err)
-		}
-		if digestGot.String() != digestExpected {
-			return nil, fmt.Errorf("validating image index: expected digest '%s', got digest '%s'", digestExpected, digestGot)
-		}
-		log.Info("Validated image index digest")
 
 		manifest, err := remoteImgIndex.IndexManifest()
 		if err != nil {
@@ -55,28 +50,74 @@ func (s *ImagePullerService) getAndVerifyImage(ctx context.Context, log *slog.Lo
 		if digestFound.String() == "" {
 			return nil, fmt.Errorf("obtaining image digest for linux/amd64: platform missing from image index")
 		}
-
-		digestExpected = digestFound.String()
-		log.Info("Obtained actual image digest", "image_digest_linux", digestExpected)
+		log.Info("Obtained actual image digest", "image_digest_linux", digestFound.String())
 
 		remoteImg, imgErr = remoteImgIndex.Image(digestFound)
 	} else {
 		remoteImg, imgErr = remote.Image(ref, remote.WithContext(ctx), remote.WithTransport(tr))
 	}
 
-	if errors.Is(imgErr, context.DeadlineExceeded) {
+	if isDigestMismatch(imgErr) {
+		return nil, fmt.Errorf("validating image: %w", imgErr)
+	} else if errors.Is(imgErr, context.DeadlineExceeded) {
 		return nil, fmt.Errorf("pull aborted (deadline exceeded): %w", imgErr)
 	} else if imgErr != nil {
 		return nil, fmt.Errorf("accessing the remote image URL: %w", imgErr)
 	}
 
-	digestGot, err := remoteImg.Digest()
+	return remoteImg, nil
+}
+
+func (s *ImagePullerService) storeAndVerifyLayers(log *slog.Logger, remoteImg v1.Image) (string, error) {
+	layers, err := remoteImg.Layers()
 	if err != nil {
-		return nil, fmt.Errorf("obtaining actual image digest: %w", err)
-	}
-	if digestGot.String() != digestExpected {
-		return nil, fmt.Errorf("validating image: expected digest '%s', got digest '%s'", digestExpected, digestGot)
+		return "", fmt.Errorf("obtaining the image layers: %w", err)
 	}
 
-	return remoteImg, nil
+	manifest, err := remoteImg.Manifest()
+	if err != nil {
+		return "", fmt.Errorf("obtaining image manifest: %w", err)
+	}
+
+	previousLayer := ""
+	for idx, layer := range layers {
+		rc, err := layer.Compressed()
+		if err != nil {
+			return "", fmt.Errorf("reading layer %d: %w", idx, err)
+		}
+
+		putLayer, n, err := s.Store.PutLayer(
+			"",            // empty ID -> let store decide
+			previousLayer, // parent is previous layer
+			nil,           // empty parent chain -> let store decide
+			"",            // mount label
+			false,         // readonly
+			nil,           // mount options
+			rc,            // tar stream
+		)
+		if err != nil {
+			return "", errors.Join(
+				fmt.Errorf("putting layer to store: %w", err),
+				fmt.Errorf("closing layer reader: %w", rc.Close()),
+			)
+		}
+		if err := rc.Close(); err != nil {
+			return "", fmt.Errorf("closing layer reader: %w", err)
+		}
+
+		ldManifest := manifest.Layers[idx].Digest.String()
+		ld := putLayer.CompressedDigest.String()
+		if ldManifest != ld {
+			return "", fmt.Errorf("validating layer: expected digest '%s' but got digest '%s'", ldManifest, ld)
+		}
+
+		log.Info("Applied and validated layer", "id", putLayer.ID, "size", n, "digest", ld)
+		previousLayer = putLayer.ID
+	}
+
+	return previousLayer, nil
+}
+
+func isDigestMismatch(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "does not match requested digest")
 }

--- a/imagepuller/internal/service/verify_test.go
+++ b/imagepuller/internal/service/verify_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/burgerdev/evil-registry/registry"
+	"github.com/containers/storage"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type StubStore struct {
+	putLayerLayer digest.Digest
+	storage.Store
+}
+
+func (s *StubStore) PutLayer(_, _ string, _ []string, _ string, _ bool, _ *storage.LayerOptions, _ io.Reader) (*storage.Layer, int64, error) {
+	return &storage.Layer{CompressedDigest: s.putLayerLayer}, 0, nil
+}
+
+func TestGetAndVerifyImage_EvilRegistry(t *testing.T) {
+	tests := map[string]struct {
+		digest  string
+		wantErr string
+	}{
+		"missing digest is rejected": {
+			digest:  "",
+			wantErr: "parsing image digest",
+		},
+		"wrong manifest digest is caught": {
+			// the evil registry responds to unknown digests with a default manifest
+			digest:  "sha256:6ad6bbb5735b84b10af42d2441e8d686b1d9a6cbf096b53842711ef5ddabd28d",
+			wantErr: "validating image ref:",
+		},
+		"wrong index digest is caught": {
+			digest:  registry.WrongIndexDigest,
+			wantErr: "validating image ref:",
+		},
+		"correct index digest, wrong manifest digest is caught": {
+			digest:  registry.IndexForEvilManifestDigest,
+			wantErr: "validating image:",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			mux := http.NewServeMux()
+			server := httptest.NewUnstartedServer(mux)
+			go registry.Run(server.Listener, mux)
+			server.Start()
+			defer server.Close()
+
+			var s ImagePullerService
+			_, err := s.getAndVerifyImage(
+				context.Background(),
+				slog.Default(),
+				fmt.Sprintf("%s/busybox:v0.0.1@%s", server.Listener.Addr().String(), tc.digest),
+			)
+
+			assert.ErrorContains(err, tc.wantErr)
+		})
+	}
+}
+
+func TestStoreAndVerifyLayers_EvilRegistry(t *testing.T) {
+	tests := map[string]struct {
+		digest  string
+		wantErr string
+	}{
+		"correct manifest digest, wrong layer digest is caught": {
+			digest:  registry.ManifestForEvilBlobDigest,
+			wantErr: "validating layer:",
+		},
+		"correct index digest, correct manifest digest, wrong layer digest is caught": {
+			digest:  registry.IndexForManifestForEvilBlobDigest,
+			wantErr: "validating layer:",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			log := slog.Default()
+			mux := http.NewServeMux()
+			server := httptest.NewUnstartedServer(mux)
+			go registry.Run(server.Listener, mux)
+			server.Start()
+			defer server.Close()
+
+			s := ImagePullerService{Logger: log, Store: &StubStore{
+				putLayerLayer: digest.NewDigestFromBytes(digest.SHA256, []byte{}),
+			}}
+			remoteImg, err := s.getAndVerifyImage(context.Background(), log, fmt.Sprintf("%s/busybox:v0.0.1@%s", server.URL[7:], tc.digest))
+			require.NoError(err)
+
+			_, err = s.storeAndVerifyLayers(log, remoteImg)
+
+			assert.ErrorContains(err, tc.wantErr)
+		})
+	}
+}

--- a/packages/by-name/imagepuller/package.nix
+++ b/packages/by-name/imagepuller/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   src = ../../../imagepuller;
 
   proxyVendor = true;
-  vendorHash = "sha256-3Fqr4Px19ODx4fWfyme5jOate21wtU42dAIivojQvYY=";
+  vendorHash = "sha256-xb4iRpnxU++/LADXkTHvqmAstfMspzO758TPuMRQdgE=";
 
   env.CGO_ENABLED = 0;
   dontFixup = true;


### PR DESCRIPTION
Things found during testing:
-  `ImageIndex` and `Image` already perform digest validation.
- layer validation was always trivially true 😬

One further issue: the tests (just as the linter and building the imagepuller binary itself) requires `CGO_ENABLED=0`, not sure if there's a good "central" place to put it?