### PR TITLE
dev-shells: make kata shell work for cdh

### DIFF
--- a/dev-shells/by-name/kata.nix
+++ b/dev-shells/by-name/kata.nix
@@ -58,5 +58,6 @@ mkShell {
   shellHook = ''
     export CC_x86_64_unknown_linux_musl=${pkgsCross.musl64.buildPackages.gcc}/bin/x86_64-unknown-linux-musl-gcc
     export AR_x86_64_unknown_linux_musl=${pkgsCross.musl64.buildPackages.gcc}/bin/x86_64-unknown-linux-musl-ar
+    export LIBCLANG_PATH=${llvmPackages.libclang.lib}/lib
   '';
 }


### PR DESCRIPTION
image-rs, cdh, and possibly some other parts of https://github.com/confidential-containers/guest-components/tree/main need this.

Didn't think it worth creating an almost identical shell to the kata one...