### PR TITLE
e2e/aks-runtime: install openssl-1.1

### DIFF
--- a/.github/workflows/e2e_aks_runtime.yml
+++ b/.github/workflows/e2e_aks_runtime.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Build and prepare deployments
         run: |
           nix shell .#just --command just coordinator initializer port-forwarder openssl service-mesh-proxy node-installer
+      - name: Install libssl.so.1.1
+        run: |
+          curl -O http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.24_amd64.deb
       # steps taken from https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
       - name: Install `az` with extensions
         run: |


### PR DESCRIPTION
This fixes the E2E test since `confcom` depends on openssl-1.1, but it wasn't installed.