### PR TITLE
ci: allow unrestricted namespaces in setup_nix

### DIFF
--- a/.github/actions/setup_nix/action.yml
+++ b/.github/actions/setup_nix/action.yml
@@ -12,6 +12,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Allow unrestricted user namespaces
+      # Ubuntu 24.04 ships strict apparmor defaults, so we have to disable them to be able to call
+      # unshare in the Nix sansbox without beeing root.
+      shell: bash
+      run: |
+        sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
+        sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
     - uses: cachix/install-nix-action@c134e4c9e34bac6cab09cf239815f9339aaaf84e # v31.5.1
       with:
         github_access_token: ${{ inputs.githubToken }}


### PR DESCRIPTION
As we upgraded hosted CI runners to Ubuntu 24.04, we run into this issues in various situations. The fix was previously present in the e2e_runtime_reproducibility, where we used 24.04 before.