### PR TITLE
ci: set branch for rim/rpm update PRs

### DIFF
--- a/.github/workflows/rim_updates.yml
+++ b/.github/workflows/rim_updates.yml
@@ -34,6 +34,7 @@ jobs:
           base: main
           draft: false
           labels: "no changelog"
+          branch: automated/nvidia-rim-updates
           committer: edgelessci <edgelessci@users.noreply.github.com>
           author: edgelessci <edgelessci@users.noreply.github.com>
           token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}

--- a/.github/workflows/rpm_updates.yml
+++ b/.github/workflows/rpm_updates.yml
@@ -33,6 +33,7 @@ jobs:
           base: main
           draft: false
           labels: "dependencies"
+          branch: automated/azurelinux-rpm-updates
           committer: edgelessci <edgelessci@users.noreply.github.com>
           author: edgelessci <edgelessci@users.noreply.github.com>
           token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}


### PR DESCRIPTION
Update PRs were silently closed for some reason: https://github.com/edgelesssys/contrast/pull/1644

Setting a branch for the update fixes it (and prevents rim updates from landing in the rpm update pr), see https://github.com/edgelesssys/contrast/pull/1645

