### PR TITLE
logger: configure google/logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/go-github/v72 v72.0.0
 	github.com/google/go-sev-guest v0.13.0
 	github.com/google/go-tdx-guest v0.3.2-0.20250505161510-9efd53b4a100
+	github.com/google/logger v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/katexochen/sync v0.0.0-20250707120738-685c5b1d507d
 	github.com/klauspost/cpuid/v2 v2.2.11
@@ -61,7 +62,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-configfs-tsm v0.3.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/logger v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect

--- a/internal/logger/handler.go
+++ b/internal/logger/handler.go
@@ -92,7 +92,7 @@ func subsystemAllowListMatch(subsystem string, allowList string) bool {
 	}
 	for _, allow := range strings.Split(allowList, ",") {
 		allow = strings.ToLower(strings.TrimSpace(allow))
-		if allow == subsystem {
+		if allow == subsystem || allow == "*" {
 			return true
 		}
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -16,6 +16,8 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+
+	glogger "github.com/google/logger"
 )
 
 const (
@@ -37,6 +39,11 @@ func Default() (*slog.Logger, error) {
 		Level: logLevel,
 	}))
 	logger.Info("Logger initialized", "level", logLevel.String())
+	if strings.Contains(os.Getenv(LogSubsystems), "google") {
+		// Used by go-sev-guest/go-tdx-guest.
+		glogger.SetLevel(10)
+		logger.Info("Google logger initialized")
+	}
 	return logger, nil
 }
 

--- a/packages/by-name/service-mesh/package.nix
+++ b/packages/by-name/service-mesh/package.nix
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-GdnyvjiqT5sGxc0G2+euqxcnvp7CJEOdFplRBvyqcrc=";
+  vendorHash = "sha256-fLYbI9SzxUbqmB9mM+CgKb6ka0/GSozJXacFe9baRiM=";
 
   sourceRoot = "${finalAttrs.src.name}/service-mesh";
   subPackages = [ "." ];

--- a/service-mesh/go.mod
+++ b/service-mesh/go.mod
@@ -18,9 +18,11 @@ require (
 	cel.dev/expr v0.19.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
+	github.com/google/logger v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	golang.org/x/sys v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/service-mesh/go.sum
+++ b/service-mesh/go.sum
@@ -13,6 +13,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/logger v1.1.1 h1:+6Z2geNxc9G+4D4oDO9njjjn2d0wN5d7uOo0vOIW1NQ=
+github.com/google/logger v1.1.1/go.mod h1:BkeJZ+1FhQ+/d087r4dzojEg1u2ZX+ZqG1jTUrLM+zQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -25,6 +27,9 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a h1:OAiGFfOiA0v9MRYsSidp3ubZaBnteRUyn3xB2ZQ5G/E=
 google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a/go.mod h1:jehYqy3+AhJU9ve55aNOaSml7wUXjF9x6z2LcCfpAhY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 h1:e0AIkUUhxyBKh6ssZNrAMeqhA7RKUj42346d1y02i2g=


### PR DESCRIPTION
This enables getting logs from go-sev-guest/go-tdx-guest libraries.

Logs can be enables by setting 

```bash
CONTRAST_LOG_SUBSYSTEMS="*,google"
```

for example in `justfile.env` for Contrast devs.