### PR TITLE
manifest: remove TDX SVNs

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -75,15 +75,6 @@ func buildVersionString() (string, error) {
 			}
 			fmt.Fprint(versionsWriter, "\n")
 		}
-		printOptionalUint16 := func(label string, value *uint16) {
-			fmt.Fprintf(versionsWriter, "\t  %s:\t", label)
-			if value != nil {
-				fmt.Fprintf(versionsWriter, "%d", *value)
-			} else {
-				fmt.Fprint(versionsWriter, "(no default)")
-			}
-			fmt.Fprint(versionsWriter, "\n")
-		}
 		for _, snp := range values.SNP {
 			fmt.Fprintf(versionsWriter, "\t- launch digest:\t%s\n", snp.TrustedMeasurement.String())
 			fmt.Fprint(versionsWriter, "\t  default SNP TCB:\t\n")
@@ -97,9 +88,6 @@ func buildVersionString() (string, error) {
 			for i, rtmr := range tdx.Rtrms {
 				fmt.Fprintf(versionsWriter, "\t  rtrm[%d]:\t%s\n", i, rtmr.String())
 			}
-			printOptionalUint16("minimum qe svn", tdx.MinimumPceSvn)
-			printOptionalUint16("minimum pce svn", tdx.MinimumPceSvn)
-			fmt.Fprintf(versionsWriter, "\t  minimum tee tcb svn:\t%s\n", tdx.MinimumTeeTcbSvn.String())
 			fmt.Fprintf(versionsWriter, "\t  mrSeam:\t%s\n", tdx.MrSeam.String())
 			fmt.Fprintf(versionsWriter, "\t  tdAttributes:\t%s\n", tdx.TdAttributes.String())
 			fmt.Fprintf(versionsWriter, "\t  xfam:\t%s\n", tdx.Xfam.String())

--- a/dev-docs/e2e/tcb-specs.json
+++ b/dev-docs/e2e/tcb-specs.json
@@ -13,7 +13,6 @@
     ],
     "tdx": [
         {
-            "MinimumTeeTcbSvn": "06010300000000000000000000000000",
             "MrSeam": "5b38e33a6487958b72c3c12a938eaa5e3fd4510c51aeeab58c7d5ecee41d7c436489d6c8e4f92f160b7cad34207b00c1"
         }
     ]

--- a/docs/docs/howto/workload-deployment/generate-annotations.md
+++ b/docs/docs/howto/workload-deployment/generate-annotations.md
@@ -114,19 +114,13 @@ This must be done on a trusted machine, with a secure and trusted connection to 
 contrast generate --reference-values k3s-qemu-tdx resources/
 ```
 
-On bare-metal TDX, `contrast generate` is unable to fill in the `MinimumTeeTcbSvn` and `MrSeam` TCB values as they can vary between platforms.
-They will have to be filled in manually.
+On bare-metal TDX, `contrast generate` is unable to fill in the `MrSeam` value as it depends on your platform configuration.
+It will have to be filled in manually.
 
 `MrSeam` is the SHA384 hash of the TDX module. You can retrieve it by executing
 
 ```sh
 sha384sum /boot/efi/EFI/TDX/TDX-SEAM.so | cut -d' ' -f1
-```
-
-`MinimumTeeTcbSvn` is contained in the `TDX-SEAM.so.sigstruct` and can be extracted via
-
-```sh
-xxd -ps -s 948 -l 8  /boot/efi/EFI/TDX/TDX-SEAM.so.sigstruct
 ```
 
 :::note[Attention!]

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -224,7 +224,6 @@ func addInvalidReferenceValues(platform platforms.Platform) PatchManifestFunc {
 			m.ReferenceValues.TDX = append(m.ReferenceValues.TDX, m.ReferenceValues.TDX[len(m.ReferenceValues.TDX)-1])
 
 			// Make the last set of reference values invalid by changing the SVNs.
-			m.ReferenceValues.TDX[len(m.ReferenceValues.TDX)-1].MinimumTeeTcbSvn = manifest.HexString("11111111111111111111111111111111")
 			m.ReferenceValues.TDX[len(m.ReferenceValues.TDX)-1].MrSeam = manifest.HexString("111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
 		}
 		return m
@@ -266,12 +265,11 @@ func PatchReferenceValues(ctx context.Context, k *kubeclient.Kubeclient, platfor
 
 		case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
 
-			// Overwrite the fields MinimumTeeTcbSvn and MrSeam with the ones loaded from the path tcbSpecificationFile.
+			// Overwrite the field MrSeam with the ones loaded from the path tcbSpecificationFile.
 			var tdxReferenceValues []manifest.TDXReferenceValues
 			for _, manifestTDX := range m.ReferenceValues.TDX {
 				for _, overwriteTDX := range baremetalRefVal.TDX {
 					manifestTDX.MrSeam = overwriteTDX.MrSeam
-					manifestTDX.MinimumTeeTcbSvn = overwriteTDX.MinimumTeeTcbSvn
 					// Filter to only use the reference values of specified baremetal SNP runners
 					tdxReferenceValues = append(tdxReferenceValues, manifestTDX)
 				}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -195,27 +195,18 @@ func (m *Manifest) TDXValidateOpts(kdsGetter *certcache.CachedHTTPSGetter) ([]TD
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert MrTd from manifest to byte slices: %w", err)
 		}
-
-		minimumTeeTcbSvn, err := refVal.MinimumTeeTcbSvn.Bytes()
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert MinimumTeeTcbSvn from manifest to byte slices: %w", err)
-		}
-
 		mrSeam, err := refVal.MrSeam.Bytes()
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert MrSeam from manifest to byte slices: %w", err)
 		}
-
 		tdAttributes, err := refVal.TdAttributes.Bytes()
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert TdAttributes from manifest to byte slices: %w", err)
 		}
-
 		xfam, err := refVal.Xfam.Bytes()
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert Xfam from manifest to byte slices: %w", err)
 		}
-
 		var rtmrs [4][]byte
 		for i, rtmr := range refVal.Rtrms {
 			bytes, err := rtmr.Bytes()
@@ -227,17 +218,14 @@ func (m *Manifest) TDXValidateOpts(kdsGetter *certcache.CachedHTTPSGetter) ([]TD
 
 		validateOptions := &tdxvalidate.Options{
 			HeaderOptions: tdxvalidate.HeaderOptions{
-				MinimumQeSvn:  *refVal.MinimumQeSvn,
-				MinimumPceSvn: *refVal.MinimumPceSvn,
-				QeVendorID:    intelQeVendorID,
+				QeVendorID: intelQeVendorID,
 			},
 			TdQuoteBodyOptions: tdxvalidate.TdQuoteBodyOptions{
-				MinimumTeeTcbSvn: minimumTeeTcbSvn,
-				MrSeam:           mrSeam,
-				TdAttributes:     tdAttributes,
-				Xfam:             xfam,
-				MrTd:             mrTd,
-				Rtmrs:            rtmrs[:],
+				MrSeam:       mrSeam,
+				TdAttributes: tdAttributes,
+				Xfam:         xfam,
+				MrTd:         mrTd,
+				Rtmrs:        rtmrs[:],
 			},
 		}
 		out = append(out, TDXValidatorOptions{

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -59,12 +59,9 @@ func newTestManifestTDX() *Manifest {
 					"777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777",
 					"888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888",
 				},
-				MinimumQeSvn:     toPtr(uint16(5)),
-				MinimumPceSvn:    toPtr(uint16(6)),
-				MinimumTeeTcbSvn: HexString("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-				MrSeam:           HexString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
-				TdAttributes:     HexString("3333333333333333"),
-				Xfam:             HexString("4444444444444444"),
+				MrSeam:       HexString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+				TdAttributes: HexString("3333333333333333"),
+				Xfam:         HexString("4444444444444444"),
 			},
 		},
 	}
@@ -194,27 +191,6 @@ func TestValidate(t *testing.T) {
 			m: newTestManifestTDX(),
 			mutate: func(m *Manifest) {
 				m.ReferenceValues.TDX[0].Rtrms = [4]HexString{}
-			},
-			wantErr: true,
-		},
-		"tdx minimum qe svn empty": {
-			m: newTestManifestTDX(),
-			mutate: func(m *Manifest) {
-				m.ReferenceValues.TDX[0].MinimumQeSvn = nil
-			},
-			wantErr: true,
-		},
-		"tdx minimum pce svn empty": {
-			m: newTestManifestTDX(),
-			mutate: func(m *Manifest) {
-				m.ReferenceValues.TDX[0].MinimumPceSvn = nil
-			},
-			wantErr: true,
-		},
-		"tdx minimum tee tcb svn empty": {
-			m: newTestManifestTDX(),
-			mutate: func(m *Manifest) {
-				m.ReferenceValues.TDX[0].MinimumTeeTcbSvn = ""
 			},
 			wantErr: true,
 		},

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -210,14 +210,11 @@ func amdTrustedRootCerts(productName ProductName) (map[string][]*trust.AMDRootCe
 
 // TDXReferenceValues contains reference values for TDX.
 type TDXReferenceValues struct {
-	MrTd             HexString
-	Rtrms            [4]HexString
-	MinimumQeSvn     *uint16
-	MinimumPceSvn    *uint16
-	MinimumTeeTcbSvn HexString
-	MrSeam           HexString
-	TdAttributes     HexString
-	Xfam             HexString
+	MrTd         HexString
+	Rtrms        [4]HexString
+	MrSeam       HexString
+	TdAttributes HexString
+	Xfam         HexString
 }
 
 // Validate checks the validity of all fields in the bare metal TDX reference values.
@@ -225,15 +222,6 @@ func (r TDXReferenceValues) Validate() error {
 	var errs []error
 	if err := validateHexString(r.MrTd, 48); err != nil {
 		errs = append(errs, newValidationError("MrTd", err))
-	}
-	if r.MinimumQeSvn == nil {
-		errs = append(errs, newValidationError("MinimumQeSvn", fmt.Errorf("field cannot be empty")))
-	}
-	if r.MinimumPceSvn == nil {
-		errs = append(errs, newValidationError("MinimumPceSvn", fmt.Errorf("field cannot be empty")))
-	}
-	if err := validateHexString(r.MinimumTeeTcbSvn, 16); err != nil {
-		errs = append(errs, newValidationError("MinimumTeeTcbSvn", ExpectedMissingReferenceValueError{Err: err}))
 	}
 	if err := validateHexString(r.MrSeam, 48); err != nil {
 		errs = append(errs, newValidationError("MrSeam", ExpectedMissingReferenceValueError{Err: err}))

--- a/justfile
+++ b/justfile
@@ -129,9 +129,8 @@ generate cli=default_cli platform=default_platform:
         "Metal-QEMU-TDX"|"K3s-QEMU-TDX" | "RKE2-QEMU-TDX")
             cm=$(kubectl get -n default cm bm-tcb-specs -o "jsonpath={.data['tcb-specs\.json']}")
             mrSeam=$(echo "$cm" | yq '.tdx.[].MrSeam') \
-                minTee=$(echo "$cm" | yq '.tdx.[].MinimumTeeTcbSvn') \
                 yq -i \
-                '.ReferenceValues.tdx.[].MinimumTeeTcbSvn = strenv(minTee) | .ReferenceValues.tdx.[].MrSeam = strenv(mrSeam)' \
+                '.ReferenceValues.tdx.[].MrSeam = strenv(mrSeam)' \
                 {{ workspace_dir }}/manifest.json
         ;;
     esac

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -135,8 +135,6 @@ let
                 (builtins.readFile "${launch-digests}/rtmr2.hex")
                 (builtins.readFile "${launch-digests}/rtmr3.hex")
               ];
-              minimumQeSvn = 0;
-              minimumPceSvn = 0;
               tdAttributes = "0000001000000000";
               xfam = "e702060000000000";
             }


### PR DESCRIPTION
This removes the following fields from the Contrast manifest:

- `.ReferenceValues.tdx.[].MinimumQeSvn`
- `.ReferenceValues.tdx.[].MinimumPceSvn`
- `.ReferenceValues.tdx.[].MinimumTeeTcbSvn`

These values are verified via collateral from the Intel PCS already, so there is no need for users to configure specific values. 