### PR TITLE
imagepuller: add unit tests

### DIFF
--- a/imagepuller/internal/remote/remote.go
+++ b/imagepuller/internal/remote/remote.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package remote
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// DefaultRemote implements Remote, passing all function calls to the remote module.
+type DefaultRemote struct{}
+
+// Head returns a gcr.Descriptor for the given reference by issuing a HEAD request.
+func (DefaultRemote) Head(ref name.Reference, opts ...remote.Option) (*gcr.Descriptor, error) {
+	return remote.Head(ref, opts...)
+}
+
+// Image provides access to a remote image reference.
+func (DefaultRemote) Image(ref name.Reference, opts ...remote.Option) (gcr.Image, error) {
+	return remote.Image(ref, opts...)
+}
+
+// Index provides access to a remote index reference.
+func (DefaultRemote) Index(ref name.Reference, opts ...remote.Option) (gcr.ImageIndex, error) {
+	return remote.Index(ref, opts...)
+}

--- a/imagepuller/internal/service/service.go
+++ b/imagepuller/internal/service/service.go
@@ -10,12 +10,23 @@ import (
 
 	"github.com/containers/storage"
 	"github.com/edgelesssys/contrast/imagepuller/internal/api"
+	"github.com/google/go-containerregistry/pkg/name"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
+	gcrRemote "github.com/google/go-containerregistry/pkg/v1/remote"
 )
+
+// Remote allows stubbing remote calls.
+type Remote interface {
+	Head(ref name.Reference, options ...gcrRemote.Option) (*gcr.Descriptor, error)
+	Image(ref name.Reference, opts ...gcrRemote.Option) (gcr.Image, error)
+	Index(ref name.Reference, opts ...gcrRemote.Option) (gcr.ImageIndex, error)
+}
 
 // ImagePullerService is the struct for which the PullImage ttRPC service is implemented.
 type ImagePullerService struct {
 	Logger *slog.Logger
 	Store  storage.Store
+	Remote Remote
 }
 
 // PullImage is a ttRPC service which pulls and mounts docker images.

--- a/imagepuller/internal/service/stubs_test.go
+++ b/imagepuller/internal/service/stubs_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package service
+
+import (
+	"io"
+
+	"github.com/containers/storage"
+	r "github.com/edgelesssys/contrast/imagepuller/internal/remote"
+	"github.com/google/go-containerregistry/pkg/name"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/opencontainers/go-digest"
+)
+
+type stubStore struct {
+	putLayerDigest digest.Digest
+	putLayerErr    error
+
+	storage.Store
+}
+
+func (s *stubStore) PutLayer(_, _ string, _ []string, _ string, _ bool, _ *storage.LayerOptions, _ io.Reader) (*storage.Layer, int64, error) {
+	if s.putLayerErr != nil {
+		return nil, 0, s.putLayerErr
+	}
+	return &storage.Layer{CompressedDigest: s.putLayerDigest}, 0, nil
+}
+
+type stubRemote struct {
+	mediaType  types.MediaType
+	imageIndex stubImageIndex
+
+	errDescriptor  error
+	errRemoteImage error
+	errRemoteIndex error
+
+	r.DefaultRemote
+}
+
+func (s stubRemote) Head(_ name.Reference, _ ...remote.Option) (*gcr.Descriptor, error) {
+	if s.errDescriptor != nil {
+		return nil, s.errDescriptor
+	}
+	if s.mediaType != "" {
+		return &gcr.Descriptor{MediaType: s.mediaType}, nil
+	}
+	return &gcr.Descriptor{MediaType: types.DockerManifestSchema2}, nil
+}
+
+func (s stubRemote) Image(_ name.Reference, _ ...remote.Option) (gcr.Image, error) {
+	if s.errRemoteImage != nil {
+		return nil, s.errRemoteImage
+	}
+	return nil, nil
+}
+
+func (s stubRemote) Index(_ name.Reference, _ ...remote.Option) (gcr.ImageIndex, error) {
+	if s.errRemoteIndex != nil {
+		return nil, s.errRemoteIndex
+	}
+	return s.imageIndex, nil
+}
+
+type stubImageIndex struct {
+	indexManifestIndexManifest *gcr.IndexManifest
+	errImage                   error
+}
+
+func (s stubImageIndex) MediaType() (types.MediaType, error) {
+	return "", nil
+}
+
+func (s stubImageIndex) Digest() (gcr.Hash, error) {
+	return gcr.Hash{}, nil
+}
+
+func (s stubImageIndex) Size() (int64, error) {
+	return 0, nil
+}
+
+func (s stubImageIndex) IndexManifest() (*gcr.IndexManifest, error) {
+	if s.indexManifestIndexManifest != nil {
+		return s.indexManifestIndexManifest, nil
+	}
+	return &gcr.IndexManifest{}, nil
+}
+
+func (s stubImageIndex) RawManifest() ([]byte, error) {
+	return nil, nil
+}
+
+func (s stubImageIndex) Image(_ gcr.Hash) (gcr.Image, error) {
+	if s.errImage != nil {
+		return nil, s.errImage
+	}
+	return nil, nil
+}
+
+func (s stubImageIndex) ImageIndex(_ gcr.Hash) (gcr.ImageIndex, error) {
+	return nil, nil
+}
+
+type stubImage struct {
+	layersLayers []gcr.Layer
+	layersErr    error
+	manifestErr  error
+
+	gcr.Image
+}
+
+func (s stubImage) Layers() ([]gcr.Layer, error) {
+	if s.layersLayers != nil {
+		return s.layersLayers, nil
+	}
+	if s.layersErr != nil {
+		return nil, s.layersErr
+	}
+	return s.Image.Layers()
+}
+
+func (s stubImage) Manifest() (*gcr.Manifest, error) {
+	if s.manifestErr != nil {
+		return nil, s.manifestErr
+	}
+	return s.Image.Manifest()
+}
+
+type stubLayer struct {
+	compressedErr error
+
+	gcr.Layer
+}
+
+func (s stubLayer) Compressed() (io.ReadCloser, error) {
+	return nil, s.compressedErr
+}

--- a/imagepuller/internal/service/verify_test.go
+++ b/imagepuller/internal/service/verify_test.go
@@ -4,62 +4,153 @@
 package service
 
 import (
+	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/containers/storage"
+	"github.com/edgelesssys/contrast/imagepuller/internal/remote"
 	"github.com/edgelesssys/contrast/imagepuller/internal/test/registry"
+	gcr "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type StubStore struct {
-	putLayerLayer digest.Digest
-	storage.Store
-}
+var zeroDigest = "0000000000000000000000000000000000000000000000000000000000000000"
 
-func (s *StubStore) PutLayer(_, _ string, _ []string, _ string, _ bool, _ *storage.LayerOptions, _ io.Reader) (*storage.Layer, int64, error) {
-	return &storage.Layer{CompressedDigest: s.putLayerLayer}, 0, nil
-}
-
-func TestGetAndVerifyImage_EvilRegistry(t *testing.T) {
+// TestGetAndVerifyImage contains unit tests for the getAndVerifyImage function.
+func TestGetAndVerifyImage(t *testing.T) {
 	tests := map[string]struct {
-		digest  string
-		wantErr error
+		digest     string
+		imageRef   string
+		wantErr    error
+		stubRemote stubRemote
 	}{
-		"missing digest is rejected": {
-			digest:  "",
-			wantErr: ErrParseDigest,
+		"digest missing, no tag": {
+			imageRef: "busybox",
+			wantErr:  errParseDigest,
 		},
-		"wrong manifest digest is caught": {
-			digest:  registry.WrongManifestDigest(),
-			wantErr: ErrRemoteImage,
+		"digest malformed, no tag": {
+			digest:   "sha256:000",
+			imageRef: "busybox",
+			wantErr:  errParseDigest,
 		},
-		"wrong index digest is caught": {
-			digest:  registry.WrongIndexDigest(),
-			wantErr: ErrRemoteIndex,
+		"digest missing algorithm, no tag": {
+			digest:   zeroDigest,
+			imageRef: "busybox",
+			wantErr:  errParseDigest,
 		},
-		"correct index digest, wrong manifest digest is caught": {
-			digest:  registry.IndexForWrongManifestDigest(),
-			wantErr: ErrRemoteImage,
+		"digest missing, with tag": {
+			imageRef: "busybox:v0.0.1",
+			wantErr:  errParseDigest,
+		},
+		"digest malformed, with tag": {
+			digest:   "sha256:000",
+			imageRef: "busybox:v0.0.1",
+			wantErr:  errParseDigest,
+		},
+		"digest missing algorithm, with tag": {
+			digest:   zeroDigest,
+			imageRef: "busybox:v0.0.1",
+			wantErr:  errParseDigest,
+		},
+		"head request error": {
+			digest:     fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef:   "busybox:v0.0.1",
+			stubRemote: stubRemote{errDescriptor: assert.AnError},
+			wantErr:    assert.AnError,
+		},
+		"remote image failure": {
+			digest:     fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef:   "busybox:v0.0.1",
+			stubRemote: stubRemote{errRemoteImage: assert.AnError, mediaType: types.DockerManifestSchema2},
+			wantErr:    assert.AnError,
+		},
+		"remote index failure": {
+			digest:     fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef:   "busybox:v0.0.1",
+			stubRemote: stubRemote{errRemoteIndex: assert.AnError, mediaType: types.DockerManifestList},
+			wantErr:    assert.AnError,
+		},
+		"unexpected media type": {
+			digest:     fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef:   "busybox:v0.0.1",
+			wantErr:    errUnexpectedMediaType,
+			stubRemote: stubRemote{mediaType: types.DockerForeignLayer},
+		},
+		"index valid, linux/amd64 missing": {
+			digest:     fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef:   "busybox:v0.0.1",
+			wantErr:    errMissingPlatform,
+			stubRemote: stubRemote{mediaType: types.DockerManifestList},
+		},
+		"index remote image failure": {
+			digest:   fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef: "busybox:v0.0.1",
+			stubRemote: stubRemote{
+				mediaType: types.DockerManifestList,
+				imageIndex: stubImageIndex{
+					errImage: assert.AnError,
+					indexManifestIndexManifest: &gcr.IndexManifest{
+						Manifests: []gcr.Descriptor{{
+							Platform: &gcr.Platform{
+								OS:           "linux",
+								Architecture: "amd64",
+							},
+							Digest: gcr.Hash{
+								Algorithm: "sha256",
+								Hex:       "",
+							},
+						}},
+					},
+				},
+			},
+			wantErr: assert.AnError,
+		},
+		"success, simple manifest": {
+			digest:     fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef:   "busybox:v0.0.1",
+			stubRemote: stubRemote{mediaType: types.DockerManifestSchema2},
+		},
+		"success, index pointing to manifest": {
+			digest:   fmt.Sprintf("sha256:%s", zeroDigest),
+			imageRef: "busybox:v0.0.1",
+			stubRemote: stubRemote{
+				mediaType: types.DockerManifestList,
+				imageIndex: stubImageIndex{
+					indexManifestIndexManifest: &gcr.IndexManifest{
+						Manifests: []gcr.Descriptor{{
+							Platform: &gcr.Platform{
+								OS:           "linux",
+								Architecture: "amd64",
+							},
+							Digest: gcr.Hash{
+								Algorithm: "sha256",
+								Hex:       "",
+							},
+						}},
+					},
+				},
+			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
+			log := slog.Default()
 
-			server := httptest.NewServer(registry.New())
-			t.Cleanup(server.Close)
-
-			var s ImagePullerService
+			s := ImagePullerService{Remote: tc.stubRemote}
 			_, err := s.getAndVerifyImage(
-				t.Context(),
-				slog.Default(),
-				fmt.Sprintf("%s/busybox:v0.0.1@%s", server.Listener.Addr().String(), tc.digest),
+				context.Background(),
+				log,
+				fmt.Sprintf(
+					"%s@%s",
+					tc.imageRef,
+					tc.digest,
+				),
 			)
 
 			assert.ErrorIs(err, tc.wantErr)
@@ -67,6 +158,69 @@ func TestGetAndVerifyImage_EvilRegistry(t *testing.T) {
 	}
 }
 
+// TestStoreAndVerifyLayers contains unit tests for the storeAndVerifyLayers function.
+func TestStoreAndVerifyLayers(t *testing.T) {
+	tests := map[string]struct {
+		stubImg    stubImage
+		stubRemote stubRemote
+		wantErr    error
+	}{
+		"layers fails": {
+			stubImg: stubImage{layersErr: assert.AnError},
+			wantErr: assert.AnError,
+		},
+		"manifest fails": {
+			stubImg: stubImage{manifestErr: assert.AnError},
+			wantErr: assert.AnError,
+		},
+		"compressed fails": {
+			stubImg: stubImage{layersLayers: []gcr.Layer{stubLayer{compressedErr: assert.AnError}}},
+			wantErr: assert.AnError,
+		},
+		"put layer fails": {
+			stubImg: stubImage{},
+			wantErr: assert.AnError,
+		},
+		"success": {
+			stubImg: stubImage{},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			log := slog.Default()
+			server := httptest.NewServer(registry.New())
+			t.Cleanup(server.Close)
+
+			t.Log(registry.BlobDigest())
+
+			store := &stubStore{
+				putLayerDigest: digest.NewDigestFromEncoded(digest.SHA256, registry.BlobDigest()[7:]),
+				putLayerErr:    tc.wantErr,
+			}
+			s := ImagePullerService{Logger: log, Store: store, Remote: tc.stubRemote.DefaultRemote}
+			realImg, err := s.getAndVerifyImage(
+				t.Context(),
+				log,
+				fmt.Sprintf("%s/busybox:v0.0.1@%s",
+					server.Listener.Addr().String(),
+					registry.ManifestDigest(),
+				),
+			)
+			require.NoError(err)
+
+			tc.stubImg.Image = realImg
+			_, err = s.storeAndVerifyLayers(log, tc.stubImg)
+
+			assert.ErrorIs(err, tc.wantErr)
+		})
+	}
+}
+
+// TestStoreAndVerifyLayers_EvilRegistry contains integration tests for the storeAndVerifyLayers function.
+// Unlike the unittests for this function, responses of the evil registry depend on test parameters.
+// This allows testing the behavior against arbitrary (evil) responses.
 func TestStoreAndVerifyLayers_EvilRegistry(t *testing.T) {
 	tests := map[string]struct {
 		digest  string
@@ -74,11 +228,11 @@ func TestStoreAndVerifyLayers_EvilRegistry(t *testing.T) {
 	}{
 		"correct manifest digest, wrong layer digest is caught": {
 			digest:  registry.ManifestForWrongBlobDigest(),
-			wantErr: ErrValidateLayer,
+			wantErr: errValidateLayer,
 		},
 		"correct index digest, correct manifest digest, wrong layer digest is caught": {
 			digest:  registry.IndexForManifestForWrongBlobDigest(),
-			wantErr: ErrValidateLayer,
+			wantErr: errValidateLayer,
 		},
 	}
 	for name, tc := range tests {
@@ -90,10 +244,22 @@ func TestStoreAndVerifyLayers_EvilRegistry(t *testing.T) {
 			server := httptest.NewServer(registry.New())
 			t.Cleanup(server.Close)
 
-			s := ImagePullerService{Logger: log, Store: &StubStore{
-				putLayerLayer: digest.NewDigestFromBytes(digest.SHA256, []byte{}),
-			}}
-			remoteImg, err := s.getAndVerifyImage(t.Context(), log, fmt.Sprintf("%s/busybox:v0.0.1@%s", server.Listener.Addr().String(), tc.digest))
+			s := ImagePullerService{
+				Logger: log,
+				Store: &stubStore{
+					putLayerDigest: digest.NewDigestFromBytes(digest.SHA256, []byte{}),
+				},
+				Remote: remote.DefaultRemote{},
+			}
+			remoteImg, err := s.getAndVerifyImage(
+				t.Context(),
+				log,
+				fmt.Sprintf(
+					"%s/busybox:v0.0.1@%s",
+					server.Listener.Addr().String(),
+					tc.digest,
+				),
+			)
 			require.NoError(err)
 
 			_, err = s.storeAndVerifyLayers(log, remoteImg)

--- a/imagepuller/internal/test/registry/content.go
+++ b/imagepuller/internal/test/registry/content.go
@@ -13,9 +13,19 @@ import (
 	"time"
 )
 
+// BlobDigest is the digest of the blob.
+func BlobDigest() string {
+	return blob().digest()
+}
+
 // WrongBlobDigest is a digest for which a blob with a different digest will be served.
 func WrongBlobDigest() string {
 	return digested("BAD BLOB").digest()
+}
+
+// ManifestDigest is the digest of the well-formed manifest.
+func ManifestDigest() string {
+	return manifest().digest()
 }
 
 // WrongManifestDigest is a digest for which an image manifest with a different digest will be served.

--- a/imagepuller/main.go
+++ b/imagepuller/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/types"
 	"github.com/edgelesssys/contrast/imagepuller/internal/api"
+	"github.com/edgelesssys/contrast/imagepuller/internal/remote"
 	"github.com/edgelesssys/contrast/imagepuller/internal/service"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -99,7 +100,11 @@ func run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("opening storage: %w", err)
 	}
 
-	api.RegisterImagePullServiceService(s, &service.ImagePullerService{Logger: log, Store: store})
+	api.RegisterImagePullServiceService(s, &service.ImagePullerService{
+		Logger: log,
+		Store:  store,
+		Remote: remote.DefaultRemote{},
+	})
 	eg, ctx := errgroup.WithContext(ctxSignal)
 
 	eg.Go(func() error {


### PR DESCRIPTION
This PR adds more in-depth tests of `getAndVerifyImage` and `storeAndVerifyLayers`, not focusing on the validation side like the evil registry tests did.

However, I've still used the (sometimes) evil registry extensively in this; AFAICT, it's by far the easiest way to test the functions' behaviors depending on what the registry answers, as well as getting an actual oci image for use in the layer-specific tests.

As a result, these tests look very similar to those against the evil registry; I'm ambivalent on keeping them separate or combining them. They *do* serve slightly different purposes, and it might be nice to tell just from the names.