### PR TITLE
nixos: add empty /etc/machine-id

### DIFF
--- a/packages/nixos/system.nix
+++ b/packages/nixos/system.nix
@@ -91,6 +91,10 @@
     mutable = false;
   };
 
+  # If /etc is read-only, we need to provide the machine-id file as a mount point for systemd.
+  # https://www.freedesktop.org/software/systemd/man/256/machine-id.html#Initialization
+  environment.etc."machine-id".text = "";
+
   # simple replacement for update-users-groups.pl
   systemd.sysusers.enable = true;
 


### PR DESCRIPTION
Our `/etc` is immutable, but we don't have a machine-id file. This seems to confuse systemd, causing the following errors to be logged (see dmesg container):

```
[    2.686639] systemd[1]: System cannot boot: Missing /etc/machine-id and /etc is mounted read-only.
[    2.686826] systemd[1]: Booting up is supported only when:
[    2.686931] systemd[1]: 1) /etc/machine-id exists and is populated.
[    2.687072] systemd[1]: 2) /etc/machine-id exists and is empty.
[    2.687239] systemd[1]: 3) /etc/machine-id is missing and /etc is writable.
```

I'm not sure what the practical implications are - maybe it's just not an issue because nothing in our image relies on first-boot semantics. The message "System cannot boot" is clearly exaggerated ... 