### PR TITLE
service-mesh: allow egress without ingress

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -556,7 +556,8 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		smEgressConfigAnnotationKey:  "emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080",
 	})
 	voteBot.WithAnnotations(map[string]string{
-		smEgressConfigAnnotationKey: "web#127.137.0.3:8081#web-svc:443",
+		smIngressConfigAnnotationKey: "DISABLED",
+		smEgressConfigAnnotationKey:  "web#127.137.0.3:8081#web-svc:443",
 	})
 
 	return resources

--- a/service-mesh/main.go
+++ b/service-mesh/main.go
@@ -71,8 +71,10 @@ func run() (retErr error) {
 		return err
 	}
 
-	if err := IngressIPTableRules(pconfig.ingress); err != nil {
-		return fmt.Errorf("failed to set up iptables rules: %w", err)
+	if !pconfig.ingressDisabled {
+		if err := IngressIPTableRules(pconfig.ingress); err != nil {
+			return fmt.Errorf("failed to set up iptables rules: %w", err)
+		}
 	}
 
 	// Remove the default deny rule AFTER we set up the configured iptables rules.


### PR DESCRIPTION
The service mesh used to always set up a secure ingress configuration even if the annotation was not set, preventing the exclusive use of egress. This PR allows setting up egress without ingress by setting the special ingress annotation value `DISABLED`.

For testing, we're configuring the vote-bot with a disabled ingress and confirm that there is no `TPROXY` redirection.