### PR TITLE
ci: do not fail imagepuller-benchmark due to time delta

### DIFF
--- a/imagepuller/client/client.go
+++ b/imagepuller/client/client.go
@@ -15,7 +15,7 @@ import (
 
 // Request makes an imagepulling request to the imagepuller ttrpc server.
 func Request(image, mount string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	var d net.Dialer

--- a/tools/imagepuller-benchmark/main.go
+++ b/tools/imagepuller-benchmark/main.go
@@ -326,7 +326,7 @@ func compareResourceUsage(baselineFile string, data map[string]resourceUsage, th
 		checkDelta := func(label string, oldVal, newVal int) {
 			diff := newVal - oldVal
 			if diff > delta { // we do not care about reductions in values
-				allErrs = append(allErrs, fmt.Errorf("%s usage increased by %d for %q (was %d, now %d)", label, diff, name, oldVal, newVal))
+				fmt.Printf("WARN: %s usage increased by %d for %q (was %d, now %d)\n", label, diff, name, oldVal, newVal)
 			}
 		}
 


### PR DESCRIPTION
Opted for printing a warning instead of removing everything time-related.