### PR TITLE
ci: upgrade to stateful sync server

### DIFF
--- a/.github/workflows/bm_maintenance.yml
+++ b/.github/workflows/bm_maintenance.yml
@@ -117,8 +117,9 @@ jobs:
       - name: Update sync fifo for GPU platform
         if: ${{ matrix.platform.name == 'K3s-QEMU-SNP-GPU' }}
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/4eaded61e6943af308b0236ee88b8766b6f52e86/server/deployment.yml
-          kubectl wait --for=condition=available --timeout=5m deployment/sync
+          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/cf49dc9664f70a1b00e3febb427b9e817f8da68b/server/deployment.yml
+          kubectl rollout status statefulset/sync --timeout=5m
+          kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' --timeout=5m svc/sync
           nix run .#scripts.renew-sync-fifo
       - name: Update namespace cleanup cronjob
         id: update

--- a/.github/workflows/cluster_recreate.yml
+++ b/.github/workflows/cluster_recreate.yml
@@ -39,15 +39,9 @@ jobs:
           nix run .#scripts.create-coco-aks -- --name="$azure_resource_group"
       - name: Deploy sync server
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/f069648d8d08951b503559bab367036290d1f50a/server/deployment.yml
-          kubectl wait --for=condition=available --timeout=5m deployment/sync
-      - name: Get sync server IP
-        run: |
-          kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' --timeout=5m svc/sync
-          SYNC_IP=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-          echo "SYNC_IP=$SYNC_IP" | tee -a "$GITHUB_ENV"
+          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/cf49dc9664f70a1b00e3febb427b9e817f8da68b/server/deployment.yml
+          kubectl rollout status statefulset/sync --timeout=5m
       - name: Create fifo
         run: |
-          fifoUUID=$(curl -fsSL "http://$SYNC_IP:8080/fifo/new" | jq -r '.uuid')
-          echo "Fifo UUID: $fifoUUID"
-          kubectl create configmap sync-server-fifo "--from-literal=uuid=$fifoUUID"
+          kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' --timeout=5m svc/sync
+          nix run .#scripts.renew-sync-fifo

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -332,14 +332,13 @@
     '';
   };
 
-  # Temporary workaround until the sync server is stateful.
   renew-sync-fifo = writeShellApplication {
     name = "renew-sync-fifo";
     runtimeInputs = with pkgs; [ kubectl ];
     text = ''
       kubectl delete configmap -n default sync-server-fifo || true
       syncIP=$(kubectl get svc sync -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
-      fifoUUID=$(curl -fsSL "$syncIP:8080/fifo/new" | jq -r '.uuid')
+      fifoUUID=$(curl -fsSL "$syncIP:8080/fifo/new?allow_overrides=true" | jq -r '.uuid')
       kubectl create configmap -n default sync-server-fifo --from-literal=uuid="$fifoUUID"
     '';
   };


### PR DESCRIPTION
This changes the sync-server to the newer stateful version. Also, the `cluster-recreate` workflow can just call the `renew-sync-fifo` script to create a fifo.