### PR TITLE
snp: add support for attestation report v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,8 @@ go 1.24.0
 
 toolchain go1.24.2
 
-// The upstream package has some stepping issues with Genoa:
-// https://github.com/google/go-sev-guest/issues/115
-// https://github.com/google/go-sev-guest/issues/103
-// Includes cherry-pick of unmerged PR to fix platform info validation:
-// https://github.com/google/go-sev-guest/pull/161
-replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f
+// Upstream is poorly maintained, use edgelesssys fork instead.
+replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20250811150530-d85b756e97f2
 
 require (
 	filippo.io/keygen v0.0.0-20250626140535-790df0a991a0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f h1:oHNe8GacgdRfDccQeGSokAmuCEGh7xqz0By4/d0PRUc=
-github.com/edgelesssys/go-sev-guest v0.0.0-20250411143710-1bf02cf1129f/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250811150530-d85b756e97f2 h1:QjSQQJ1anR2UN5L0YXpl0WIOIMkhlycAwF1DS+DpULA=
+github.com/edgelesssys/go-sev-guest v0.0.0-20250811150530-d85b756e97f2/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -246,7 +246,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-8bSqdIdhs7n3NY2cNghbKOsUvE2HZgzjwd88F79mr+E=";
+  vendorHash = "sha256-5V0n+vfFqMq+nw3xHYP6gNQPzbRL1ZzZLbZb2aOdX7A=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
This supports the new SEV ABI Version 1.58 and ensures compatibility of contrast with SEV firmware >=1.55.45.