### PR TITLE
treewide: disallow unknown fields for embedded

### DIFF
--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -4,6 +4,7 @@
 package manifest
 
 import (
+	"bytes"
 	"crypto/x509"
 	_ "embed"
 	"encoding/json"
@@ -27,8 +28,10 @@ type EmbeddedReferenceValues map[string]ReferenceValues
 
 // GetEmbeddedReferenceValues returns the reference values embedded in the binary.
 func GetEmbeddedReferenceValues() (EmbeddedReferenceValues, error) {
+	decoder := json.NewDecoder(bytes.NewReader(embeddedReferenceValuesJSON))
+	decoder.DisallowUnknownFields()
 	var mapping EmbeddedReferenceValues
-	if err := json.Unmarshal(embeddedReferenceValuesJSON, &mapping); err != nil {
+	if err := decoder.Decode(&mapping); err != nil {
 		return nil, fmt.Errorf("unmarshal embedded reference values mapping: %w", err)
 	}
 	return mapping, nil

--- a/nodeinstaller/internal/kataconfig/config.go
+++ b/nodeinstaller/internal/kataconfig/config.go
@@ -4,6 +4,7 @@
 package kataconfig
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -172,8 +173,10 @@ type snpIDBlockMap map[string]map[string]SnpIDBlock
 
 // SnpIDBlockForPlatform returns the embedded SNP ID block and ID auth for the given platform and product.
 func SnpIDBlockForPlatform(platform platforms.Platform, productName sevsnp.SevProduct_SevProductName) (SnpIDBlock, error) {
-	blocks := make(snpIDBlockMap)
-	if err := json.Unmarshal([]byte(snpIDBlocks), &blocks); err != nil {
+	var blocks snpIDBlockMap
+	decoder := json.NewDecoder(bytes.NewReader([]byte(snpIDBlocks)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&blocks); err != nil {
 		return SnpIDBlock{}, fmt.Errorf("unmarshaling embedded SNP ID blocks: %w", err)
 	}
 	blockForPlatform, ok := blocks[strings.ToLower(platform.String())]


### PR DESCRIPTION
We should be aware if we embed structs with unsupported fields.