### PR TITLE
node-installer: target configuration via configMap; remove K3s and RKE2 platforms

### DIFF
--- a/.github/actions/release_artifacts/action.yml
+++ b/.github/actions/release_artifacts/action.yml
@@ -138,13 +138,9 @@ runs:
       run: |
         platforms=(
           "aks-clh-snp"
-          "k3s-qemu-snp-gpu"
-          "k3s-qemu-snp"
-          "k3s-qemu-tdx"
           "metal-qemu-snp-gpu"
           "metal-qemu-snp"
           "metal-qemu-tdx"
-          "rke2-qemu-tdx"
         )
         for platform in "${platforms[@]}"; do
           nix shell .#contrast --command resourcegen \

--- a/.github/actions/release_artifacts/action.yml
+++ b/.github/actions/release_artifacts/action.yml
@@ -122,6 +122,7 @@ runs:
         workspace/emojivoto-demo.yml
         workspace/mysql-demo.yml
         workspace/vault-demo.yml
+        workspace/node-installer-target-config-k3s.yml
         EOM
         EOF
     - name: Create coordinator resource definitions
@@ -160,6 +161,12 @@ runs:
         nix shell .#contrast --command resourcegen \
           --image-replacements ./image-replacements.txt \
           --add-load-balancers vault > workspace/vault-demo.yml
+    - name: Create node installer target configs
+      shell: bash
+      run: |
+        nix shell .#contrast --command resourcegen \
+          --node-installer-target-conf-type k3s \
+          node-installer-target-conf > workspace/node-installer-target-config-k3s.yml
     - name: Build CLI
       shell: bash
       run: |

--- a/.github/workflows/bm_maintenance.yml
+++ b/.github/workflows/bm_maintenance.yml
@@ -67,9 +67,9 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     needs: build-image
     outputs:
-      snp: ${{ steps.update.outputs.K3s-QEMU-SNP }}
-      tdx: ${{ steps.update.outputs.K3s-QEMU-TDX }}
-      snp-gpu: ${{ steps.update.outputs.K3s-QEMU-SNP-GPU }}
+      snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
+      tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
+      snp-gpu: ${{ steps.update.outputs.Metal-QEMU-SNP-GPU }}
     permissions:
       contents: read
     strategy:
@@ -78,13 +78,13 @@ jobs:
           - name: AKS-CLH-SNP
             runner: ubuntu-24.04
             self-hosted: false
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
             self-hosted: true
       fail-fast: false
@@ -115,7 +115,7 @@ jobs:
         run: |
           just get-credentials
       - name: Update sync fifo for GPU platform
-        if: ${{ matrix.platform.name == 'K3s-QEMU-SNP-GPU' }}
+        if: ${{ matrix.platform.name == 'Metal-QEMU-SNP-GPU' }}
         run: |
           kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/cf49dc9664f70a1b00e3febb427b9e817f8da68b/server/deployment.yml
           kubectl rollout status statefulset/sync --timeout=5m
@@ -135,17 +135,17 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     needs: build-image
     outputs:
-      snp: ${{ steps.update.outputs.K3s-QEMU-SNP }}
-      tdx: ${{ steps.update.outputs.K3s-QEMU-TDX }}
-      snp-gpu: ${{ steps.update.outputs.K3s-QEMU-SNP-GPU }}
+      snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
+      tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
+      snp-gpu: ${{ steps.update.outputs.Metal-QEMU-SNP-GPU }}
     strategy:
       matrix:
         platform:
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
       fail-fast: false
     permissions:
@@ -177,17 +177,17 @@ jobs:
     needs: build-image
     if: inputs.containerd || github.event.schedule == '0 2 * * 4' # only run on Fridays or if containerd is enabled
     outputs:
-      snp: ${{ steps.update.outputs.K3s-QEMU-SNP }}
-      tdx: ${{ steps.update.outputs.K3s-QEMU-TDX }}
-      snp-gpu: ${{ steps.update.outputs.K3s-QEMU-SNP-GPU }}
+      snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
+      tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
+      snp-gpu: ${{ steps.update.outputs.Metal-QEMU-SNP-GPU }}
     strategy:
       matrix:
         platform:
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
       fail-fast: false
     permissions:
@@ -218,17 +218,17 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     needs: build-image
     outputs:
-      snp: ${{ steps.update.outputs.K3s-QEMU-SNP }}
-      tdx: ${{ steps.update.outputs.K3s-QEMU-TDX }}
-      snp-gpu: ${{ steps.update.outputs.K3s-QEMU-SNP-GPU }}
+      snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
+      tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
+      snp-gpu: ${{ steps.update.outputs.Metal-QEMU-SNP-GPU }}
     strategy:
       matrix:
         platform:
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
       fail-fast: false
     permissions:
@@ -309,14 +309,14 @@ jobs:
           fi
 
           if [[ "${#snp[@]}" -gt 0 ]]; then
-            entries+=("{\"title\": \"K3s-QEMU-SNP\", \"value\": \"$(str="${snp[*]}"; echo "${str// /, }")\"}")
+            entries+=("{\"title\": \"Metal-QEMU-SNP\", \"value\": \"$(str="${snp[*]}"; echo "${str// /, }")\"}")
           fi
           if [[ "${#tdx[@]}" -gt 0 ]]; then
-            entries+=("{\"title\": \"K3s-QEMU-TDX\", \"value\": \"$(str="${tdx[*]}"; echo "${str// /, }")\"}")
+            entries+=("{\"title\": \"Metal-QEMU-TDX\", \"value\": \"$(str="${tdx[*]}"; echo "${str// /, }")\"}")
           fi
 
           if [[ "${#snp_gpu[@]}" -gt 0 ]]; then
-            entries+=("{\"title\": \"K3s-QEMU-SNP-GPU\", \"value\": \"$(str="${snp_gpu[*]}"; echo "${str// /, }")\"}")
+            entries+=("{\"title\": \"Metal-QEMU-SNP-GPU\", \"value\": \"$(str="${snp_gpu[*]}"; echo "${str// /, }")\"}")
           fi
 
           if [[ "${#entries[@]}" -eq 0 ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,7 @@ jobs:
       packages: write
     env:
       PLATFORM: ${{ inputs.platform }}
+      NODE_INSTALLER_TARGET_CONF_TYPE: 'k3s'
       TEST_NAME: ${{ inputs.test-name }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -95,6 +96,7 @@ jobs:
             --image-replacements workspace/just.containerlookup \
             --namespace-file workspace/e2e.namespace \
             --platform "${PLATFORM}" \
+            --node-installer-target-conf-type "${NODE_INSTALLER_TARGET_CONF_TYPE}" \
             --namespace-suffix="-ci"
       - name: Download logs
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           just get-credentials
       - name: Set sync environment
-        if: (!inputs.self-hosted || inputs.platform == 'K3s-QEMU-SNP-GPU')
+        if: (!inputs.self-hosted || inputs.platform == 'Metal-QEMU-SNP-GPU')
         run: |
           sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
           echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a "$GITHUB_ENV"

--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -31,9 +31,9 @@ on:
         type: choice
         options:
           - AKS-CLH-SNP
-          - K3s-QEMU-SNP
-          - K3s-QEMU-SNP-GPU
-          - K3s-QEMU-TDX
+          - Metal-QEMU-SNP
+          - Metal-QEMU-SNP-GPU
+          - Metal-QEMU-TDX
       skip-undeploy:
         description: "Skip undeploy"
         required: false
@@ -58,15 +58,15 @@ jobs:
               echo "runner=ubuntu-24.04" >> "$GITHUB_OUTPUT"
               echo "self-hosted=false" >> "$GITHUB_OUTPUT"
             ;;
-            "K3s-QEMU-SNP")
+            "Metal-QEMU-SNP")
               echo "runner=SNP" >> "$GITHUB_OUTPUT"
               echo "self-hosted=true" >> "$GITHUB_OUTPUT"
             ;;
-            "K3s-QEMU-SNP-GPU")
+            "Metal-QEMU-SNP-GPU")
               echo "runner=SNP-GPU" >> "$GITHUB_OUTPUT"
               echo "self-hosted=true" >> "$GITHUB_OUTPUT"
             ;;
-            "K3s-QEMU-TDX")
+            "Metal-QEMU-TDX")
               echo "runner=TDX" >> "$GITHUB_OUTPUT"
               echo "self-hosted=true" >> "$GITHUB_OUTPUT"
             ;;

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -25,13 +25,13 @@ jobs:
           - name: AKS-CLH-SNP
             runner: ubuntu-24.04
             self-hosted: false
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
             self-hosted: true
         test-name:
@@ -47,7 +47,7 @@ jobs:
           # keep-sorted end
         include:
           - platform:
-              name: K3s-QEMU-SNP-GPU
+              name: Metal-QEMU-SNP-GPU
               runner: SNP-GPU
               self-hosted: true
             test-name: gpu

--- a/.github/workflows/e2e_on_pull_request.yml
+++ b/.github/workflows/e2e_on_pull_request.yml
@@ -29,15 +29,15 @@ jobs:
             runner: ubuntu-24.04
             self-hosted: false
             test: openssl
-          - platform: K3s-QEMU-SNP
+          - platform: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
             test: openssl
-          - platform: K3s-QEMU-SNP-GPU
+          - platform: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
             self-hosted: true
             test: gpu
-          - platform: K3s-QEMU-TDX
+          - platform: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
             test: openssl

--- a/.github/workflows/e2e_regression.yml
+++ b/.github/workflows/e2e_regression.yml
@@ -32,10 +32,10 @@ jobs:
           - name: AKS-CLH-SNP
             runner: ubuntu-24.04
             self-hosted: false
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
         test-name: [getdents, genpolicy, genpolicy-unsupported, regression]

--- a/.github/workflows/e2e_service_mesh.yml
+++ b/.github/workflows/e2e_service_mesh.yml
@@ -14,10 +14,10 @@ jobs:
           - name: AKS-CLH-SNP
             runner: ubuntu-24.04
             self-hosted: false
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,13 +295,13 @@ jobs:
           - name: AKS-CLH-SNP
             runner: ubuntu-24.04
             self-hosted: false
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
             self-hosted: true
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
       fail-fast: false

--- a/.github/workflows/update_bm_tcb_specs.yml
+++ b/.github/workflows/update_bm_tcb_specs.yml
@@ -18,17 +18,17 @@ jobs:
     name: "Update bm tcb specs ${{ matrix.platform.name }}"
     runs-on: ${{ matrix.platform.runner }}
     outputs:
-      snp: ${{ steps.update.outputs.K3s-QEMU-SNP }}
-      tdx: ${{ steps.update.outputs.K3s-QEMU-TDX }}
-      snp-gpu: ${{ steps.update.outputs.K3s-QEMU-SNP-GPU }}
+      snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
+      tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
+      snp-gpu: ${{ steps.update.outputs.Metal-QEMU-SNP-GPU }}
     strategy:
       matrix:
         platform:
-          - name: K3s-QEMU-SNP
+          - name: Metal-QEMU-SNP
             runner: SNP
-          - name: K3s-QEMU-TDX
+          - name: Metal-QEMU-TDX
             runner: TDX
-          - name: K3s-QEMU-SNP-GPU
+          - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
       fail-fast: false
     permissions:
@@ -62,9 +62,9 @@ jobs:
           SNP_GPU: ${{ needs.update-bm-specs.outputs.snp-gpu }}
         run: |
           platforms=()
-          [[ "${SNP}" == "success" ]] && platforms+=("K3s-QEMU-SNP")
-          [[ "${TDX}" == "success" ]] && platforms+=("K3s-QEMU-TDX")
-          [[ "${SNP_GPU}" == "success" ]] && platforms+=("K3s-QEMU-SNP-GPU")
+          [[ "${SNP}" == "success" ]] && platforms+=("Metal-QEMU-SNP")
+          [[ "${TDX}" == "success" ]] && platforms+=("Metal-QEMU-TDX")
+          [[ "${SNP_GPU}" == "success" ]] && platforms+=("Metal-QEMU-SNP-GPU")
           echo "json=[{\"title\": \"Platforms\", \"value\": \"${platforms[*]}\"}]" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/post_to_teams
         with:

--- a/cli/genpolicy/config.go
+++ b/cli/genpolicy/config.go
@@ -43,9 +43,7 @@ func NewConfig(platform platforms.Platform) *Config {
 			Settings: aksSettings,
 			Bin:      aksGenpolicyBin,
 		}
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP,
-		platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX,
-		platforms.MetalQEMUSNPGPU:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
 		return &Config{
 			Rules:    kataRules,
 			Settings: kataSettings,

--- a/cli/main.go
+++ b/cli/main.go
@@ -96,9 +96,7 @@ func buildVersionString() (string, error) {
 		switch platform {
 		case platforms.AKSCloudHypervisorSNP:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.MicrosoftGenpolicyVersion)
-		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP,
-			platforms.K3sQEMUTDX, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX,
-			platforms.MetalQEMUSNPGPU:
+		case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
 			fmt.Fprintf(versionsWriter, "\tgenpolicy version:\t%s\n", constants.KataGenpolicyVersion)
 		}
 	}

--- a/dev-docs/e2e/bare-metal-runner.md
+++ b/dev-docs/e2e/bare-metal-runner.md
@@ -112,7 +112,9 @@ Install Longhorn into K3s
 ```bash
 helm repo add longhorn https://charts.longhorn.io
 helm repo update
-helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace \
+helm install longhorn longhorn/longhorn \
+  --namespace longhorn-system \
+  --create-namespace \
   --set defaultSettings.storageReservedPercentageForDefaultDisk=5 \
   --set persistence.defaultClassReplicaCount=1
 ```

--- a/docs/docs/getting-started/deployment.md
+++ b/docs/docs/getting-started/deployment.md
@@ -246,14 +246,14 @@ Next, install the Contrast runtime in your cluster which will be used when setti
 kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-aks-clh-snp.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-snp.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-snp.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-tdx.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-tdx.yml
 ```
 </TabItem>
 </Tabs>
@@ -281,9 +281,9 @@ The command also generates a `manifest.json` file, which contains the trusted re
 contrast generate --reference-values aks-clh-snp resources/
 ```
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 ```sh
-contrast generate --reference-values k3s-qemu-snp resources/
+contrast generate --reference-values metal-qemu-snp resources/
 ```
 :::note[Missing TCB values]
 On bare-metal SEV-SNP, `contrast generate` is unable to fill in the `MinimumTCB` values of the created manifest.json as they can vary between platforms.
@@ -291,9 +291,9 @@ They will have to be filled in manually.
 If you don't know the correct values use `{"BootloaderVersion":255,"TEEVersion":255,"SNPVersion":255,"MicrocodeVersion":255}` and observe the real values in the error messages in the following steps. This should only be done in a secure environment. Note that the values will differ between CPU models.
 :::
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 ```sh
-contrast generate --reference-values k3s-qemu-tdx resources/
+contrast generate --reference-values metal-qemu-tdx resources/
 ```
 :::note[Missing TCB values]
 On bare-metal TDX, `contrast generate` is unable to fill in the `MinimumTeeTcbSvn` and `MrSeam` TCB values of the created manifest.json as they can vary between platforms.

--- a/docs/docs/howto/cluster-setup/bare-metal.md
+++ b/docs/docs/howto/cluster-setup/bare-metal.md
@@ -62,12 +62,25 @@ fs.inotify.max_user_instances = 8192
 
 Apply this change by running `systemctl restart systemd-sysctl` and verify it using `sysctl fs.inotify.max_user_instances`.
 
-## K3s setup
+## Kubernetes cluster setup
+
+Contrast can be deployed with different Kubernetes distributions.
+
+### K3s
+
+[K3s](https://k3s.io/) is a lightweight Kubernetes distribution that's easy to set up.
 
 1. Follow the [K3s setup instructions](https://docs.k3s.io/) to create a cluster.
    Contrast is currently tested with K3s version `v1.31.5+k3s1`.
-2. Install a block storage provider such as [Longhorn](https://longhorn.io/docs/latest/deploy/install/install-with-kubectl/) and mark it as the default storage class.
-3. Ensure that a load balancer controller is installed. For development and testing purposes, the built-in [ServiceLB](https://docs.k3s.io/networking/networking-services#service-load-balancer) should suffice.
+2. Install a block storage provider such as [Longhorn](https://longhorn.io/docs/1.9.1/deploy/install/install-with-helm/) and mark it as the default storage class.
+3. Ensure that a load balancer controller is installed.
+   For development and testing purposes, the built-in [ServiceLB](https://docs.k3s.io/networking/networking-services#service-load-balancer) should suffice.
+
+Then, install the ConfigMap to configure the Contrast node-installer for use with K3s:
+
+```sh
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/node-installer-target-config-k3s.yml
+```
 
 ## Preparing a cluster for GPU usage
 

--- a/docs/docs/howto/encrypted-storage.md
+++ b/docs/docs/howto/encrypted-storage.md
@@ -58,14 +58,14 @@ It can be shared between Contrast deployments.
 kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-aks-clh-snp.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-snp.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-snp.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-tdx.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-tdx.yml
 ```
 </TabItem>
 </Tabs>
@@ -91,9 +91,9 @@ of your deployment will be created:
 contrast generate --reference-values aks-clh-snp resources/
 ```
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 ```sh
-contrast generate --reference-values k3s-qemu-snp resources/
+contrast generate --reference-values metal-qemu-snp resources/
 ```
 :::note[Missing TCB values]
 On bare-metal SEV-SNP, `contrast generate` is unable to fill in the `MinimumTCB` values as they can vary between platforms.
@@ -101,9 +101,9 @@ They will have to be filled in manually.
 If you don't know the correct values use `{"BootloaderVersion":255,"TEEVersion":255,"SNPVersion":255,"MicrocodeVersion":255}` and observe the real values in the error messages in the following steps. This should only be done in a secure environment. Note that the values will differ between CPU models.
 :::
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 ```sh
-contrast generate --reference-values k3s-qemu-tdx resources/
+contrast generate --reference-values metal-qemu-tdx resources/
 ```
 :::note[Missing TCB values]
 On bare-metal TDX, `contrast generate` is unable to fill in the `MinimumTeeTcbSvn` and `MrSeam` TCB values as they can vary between platforms.

--- a/docs/docs/howto/workload-deployment/generate-annotations.md
+++ b/docs/docs/howto/workload-deployment/generate-annotations.md
@@ -32,10 +32,10 @@ contrast generate --reference-values aks-clh-snp resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-snp resources/
+contrast generate --reference-values metal-qemu-snp resources/
 ```
 
 On bare-metal SEV-SNP, `contrast generate` is unable to fill in the `MinimumTCB` values as they can vary between platforms and CPU models.
@@ -70,10 +70,10 @@ This must be done on a trusted machine, with a secure and trusted connection to 
 :::
 
 </TabItem>
-<TabItem value="k3s-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
+<TabItem value="metal-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-snp-gpu resources/
+contrast generate --reference-values metal-qemu-snp-gpu resources/
 ```
 
 On bare-metal SEV-SNP, `contrast generate` is unable to fill in the `MinimumTCB` values as they can vary between platforms and CPU models.
@@ -108,10 +108,10 @@ This must be done on a trusted machine, with a secure and trusted connection to 
 :::
 
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-tdx resources/
+contrast generate --reference-values metal-qemu-tdx resources/
 ```
 
 On bare-metal TDX, `contrast generate` is unable to fill in the `MrSeam` value as it depends on your platform configuration.
@@ -169,24 +169,24 @@ contrast generate --reference-values aks-clh-snp --skip-initializer resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-snp --skip-initializer resources/
+contrast generate --reference-values metal-qemu-snp --skip-initializer resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
+<TabItem value="metal-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-snp-gpu --skip-initializer resources/
+contrast generate --reference-values metal-qemu-snp-gpu --skip-initializer resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-tdx --skip-initializer resources/
+contrast generate --reference-values metal-qemu-tdx --skip-initializer resources/
 ```
 
 </TabItem>
@@ -244,24 +244,24 @@ contrast generate --reference-values aks-clh-snp --skip-service-mesh resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-snp --skip-service-mesh resources/
+contrast generate --reference-values metal-qemu-snp --skip-service-mesh resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
+<TabItem value="metal-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-snp-gpu --skip-service-mesh resources/
+contrast generate --reference-values metal-qemu-snp-gpu --skip-service-mesh resources/
 ```
 
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 
 ```sh
-contrast generate --reference-values k3s-qemu-tdx --skip-service-mesh resources/
+contrast generate --reference-values metal-qemu-tdx --skip-service-mesh resources/
 ```
 </TabItem>
 </Tabs>

--- a/docs/docs/howto/workload-deployment/runtime-deployment.md
+++ b/docs/docs/howto/workload-deployment/runtime-deployment.md
@@ -14,7 +14,7 @@ Required for all Contrast deployments.
 ## How-to
 
 Contrast depends on a [custom Kubernetes `RuntimeClass` (`contrast-cc`)](../../architecture/components/runtime.md), which needs to be installed in the cluster prior to the Coordinator or any confidential workloads.
-This consists of a `RuntimeClass` resource and a `DaemonSet` that performs installation on worker nodes.
+This consists of a `RuntimeClass` resource and the node installer `DaemonSet` that performs installation on worker nodes.
 This step is only required once for each version of the runtime.
 It can be shared between Contrast deployments.
 Also, different Contrast runtime versions can be installed in the same cluster.

--- a/docs/docs/howto/workload-deployment/runtime-deployment.md
+++ b/docs/docs/howto/workload-deployment/runtime-deployment.md
@@ -25,19 +25,19 @@ Also, different Contrast runtime versions can be installed in the same cluster.
 kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-aks-clh-snp.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-snp" label="Bare metal (SEV-SNP)">
+<TabItem value="metal-qemu-snp" label="Bare metal (SEV-SNP)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-snp.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-snp.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
+<TabItem value="metal-qemu-snp-gpu" label="Bare metal (SEV-SNP, with GPU support)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-snp-gpu.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-snp-gpu.yml
 ```
 </TabItem>
-<TabItem value="k3s-qemu-tdx" label="Bare metal (TDX)">
+<TabItem value="metal-qemu-tdx" label="Bare metal (TDX)">
 ```sh
-kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-k3s-qemu-tdx.yml
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/runtime-metal-qemu-tdx.yml
 ```
 </TabItem>
 </Tabs>

--- a/e2e/atls/atls_test.go
+++ b/e2e/atls/atls_test.go
@@ -39,11 +39,7 @@ func TestSNPValidators(t *testing.T) {
 	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
 	require.NoError(t, err)
 
-	if platform != platforms.AKSCloudHypervisorSNP &&
-		platform != platforms.K3sQEMUSNP &&
-		platform != platforms.K3sQEMUSNPGPU &&
-		platform != platforms.MetalQEMUSNPGPU &&
-		platform != platforms.MetalQEMUSNP {
+	if !platforms.IsSNP(platform) {
 		t.Skip("Skipping test, test can only be run on SEV-SNP-based platforms")
 	}
 

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -238,7 +238,7 @@ func (ct *ContrastTest) RunPatchManifest(patchFn PatchManifestFunc) error {
 func addInvalidReferenceValues(platform platforms.Platform) PatchManifestFunc {
 	return func(m manifest.Manifest) manifest.Manifest {
 		switch platform {
-		case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.AKSCloudHypervisorSNP:
+		case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU, platforms.AKSCloudHypervisorSNP:
 			// Duplicate the reference values to test multiple validators by having at least 2.
 			m.ReferenceValues.SNP = append(m.ReferenceValues.SNP, m.ReferenceValues.SNP[len(m.ReferenceValues.SNP)-1])
 
@@ -249,7 +249,7 @@ func addInvalidReferenceValues(platform platforms.Platform) PatchManifestFunc {
 				SNPVersion:        toPtr(manifest.SVN(255)),
 				MicrocodeVersion:  toPtr(manifest.SVN(255)),
 			}
-		case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+		case platforms.MetalQEMUTDX:
 			// Duplicate the reference values to test multiple validators by having at least 2.
 			m.ReferenceValues.TDX = append(m.ReferenceValues.TDX, m.ReferenceValues.TDX[len(m.ReferenceValues.TDX)-1])
 
@@ -279,7 +279,7 @@ func PatchReferenceValues(ctx context.Context, k *kubeclient.Kubeclient, platfor
 	}
 	return func(m manifest.Manifest) manifest.Manifest {
 		switch platform {
-		case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU:
+		case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU:
 			// Overwrite the minimumTCB values with the ones loaded from the path tcbSpecificationFile.
 			var snpReferenceValues []manifest.SNPReferenceValues
 			for _, manifestSNP := range m.ReferenceValues.SNP {
@@ -293,7 +293,7 @@ func PatchReferenceValues(ctx context.Context, k *kubeclient.Kubeclient, platfor
 			}
 			m.ReferenceValues.SNP = snpReferenceValues
 
-		case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+		case platforms.MetalQEMUTDX:
 
 			// Overwrite the field MrSeam with the ones loaded from the path tcbSpecificationFile.
 			var tdxReferenceValues []manifest.TDXReferenceValues
@@ -480,9 +480,7 @@ func (ct *ContrastTest) FactorPlatformTimeout(timeout time.Duration) time.Durati
 	switch ct.Platform {
 	case platforms.AKSCloudHypervisorSNP: // AKS defined is the baseline
 		return timeout
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.K3sQEMUSNP,
-		platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX,
-		platforms.MetalQEMUSNPGPU:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
 		return 2 * timeout
 	default:
 		panic(fmt.Sprintf("FactorPlatformTimeout not configured for platform %q", ct.Platform))

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -213,6 +213,20 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 	}, nil
 }
 
+// NodeInstallerTargetConfig returns a ConfigMap for the passed target.
+func NodeInstallerTargetConfig(target, namespace string) (*applycorev1.ConfigMapApplyConfiguration, error) {
+	switch target {
+	case "k3s":
+		return applycorev1.ConfigMap("contrast-node-installer-target-config", namespace).
+			WithData(map[string]string{
+				"containerd-config-path": "var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl",
+				"systemd-unit-name":      "k3s.service,k3s-agent.service",
+			}), nil
+	default:
+		return nil, fmt.Errorf("unsupported target %q", target)
+	}
+}
+
 // PortForwarderConfig wraps a PodApplyConfiguration for a port forwarder.
 type PortForwarderConfig struct {
 	*applycorev1.PodApplyConfiguration

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -96,22 +96,16 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 	var nodeInstallerImageURL string
 	var containers []*applycorev1.ContainerApplyConfiguration
 	var snapshotterVolumes []*applycorev1.VolumeApplyConfiguration
-	switch platform {
-	case platforms.AKSCloudHypervisorSNP:
+	switch {
+	case platform == platforms.AKSCloudHypervisorSNP:
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-microsoft:latest"
 		containers = append(containers, tardevSnapshotter)
 		snapshotterVolumes = tardevSnapshotterVolumes
-	case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
-		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
-		if platform == platforms.MetalQEMUSNPGPU {
-			nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata-gpu:latest"
-		}
+	case platforms.IsQEMU(platform) && platforms.IsGPU(platform):
+		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata-gpu:latest"
 		containers = append(containers, noSnapshotter)
-	case platforms.K3sQEMUTDX, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.RKE2QEMUTDX:
+	case platforms.IsQEMU(platform):
 		nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata:latest"
-		if platform == platforms.K3sQEMUSNPGPU {
-			nodeInstallerImageURL = "ghcr.io/edgelesssys/contrast/node-installer-kata-gpu:latest"
-		}
 		containers = append(containers, noSnapshotter)
 	default:
 		return nil, fmt.Errorf("unsupported platform %q", platform)

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -146,6 +146,9 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 							VolumeMount().
 								WithName("var-run-dbus-socket").
 								WithMountPath("/var/run/dbus/system_bus_socket"),
+							VolumeMount().
+								WithName("target-config").
+								WithMountPath("/target-config"),
 						).
 						WithCommand("/bin/node-installer", platform.String()),
 					).
@@ -165,6 +168,12 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 							WithHostPath(HostPathVolumeSource().
 								WithPath("/var/run/dbus/system_bus_socket").
 								WithType(corev1.HostPathSocket),
+							),
+						Volume().
+							WithName("target-config").
+							WithConfigMap(ConfigMapVolumeSource().
+								WithName("contrast-node-installer-target-config").
+								WithOptional(true),
 							),
 					)...,
 					),

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -16,12 +16,13 @@ import (
 func main() {
 	imageReplacementsPath := flag.String("image-replacements", "", "Path to the image replacements file")
 	namespace := flag.String("namespace", "", "Namespace for namespaced resources")
+	rawPlatform := flag.String("platform", "", "Deployment platform to generate the runtime configuration for")
 	addLoadBalancers := flag.Bool("add-load-balancers", false, "Add load balancers to selected services")
 	addNamespaceObject := flag.Bool("add-namespace-object", false, "Add namespace object with the given namespace")
 	addPortForwarders := flag.Bool("add-port-forwarders", false, "Add port forwarder pods for all services")
 	addLogging := flag.Bool("add-logging", false, "Add logging configuration, based on CONTRAST_LOG_LEVEL and CONTRAST_LOG_SUBSYSTEMS environment variables")
-	rawPlatform := flag.String("platform", "", "Deployment platform to generate the runtime configuration for")
 	addDmesg := flag.Bool("add-dmesg", false, "Add dmesg container")
+	nodeInstallerTargetConfType := flag.String("node-installer-target-conf-type", "", "Type of node installer target configuration to generate (k3s,...)")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags] <set>...\n", os.Args[0])
 		flag.PrintDefaults()
@@ -46,6 +47,12 @@ func main() {
 				log.Fatalf("Error parsing platform: %v", err)
 			}
 			subResources, err = kuberesource.Runtime(platform)
+		case "node-installer-target-conf":
+			if *nodeInstallerTargetConfType == "" {
+				log.Fatalf("--node-installer-target-conf-type must be set")
+			}
+			subResources = make([]any, 1)
+			subResources[0], err = kuberesource.NodeInstallerTargetConfig(*nodeInstallerTargetConfType, *namespace)
 		case "openssl":
 			subResources = kuberesource.PatchRuntimeHandlers(kuberesource.OpenSSL(), "contrast-cc")
 		case "emojivoto":

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -242,6 +242,21 @@ func (h *HostPathVolumeSourceConfig) Inner() *applycorev1.HostPathVolumeSourceAp
 	return h.HostPathVolumeSourceApplyConfiguration
 }
 
+// ConfigMapVolumeSourceConfig wraps applycorev1.ConfigMapVolumeSourceApplyConfiguration.
+type ConfigMapVolumeSourceConfig struct {
+	*applycorev1.ConfigMapVolumeSourceApplyConfiguration
+}
+
+// ConfigMapVolumeSource creates a new ConfigMapVolumeSourceConfig.
+func ConfigMapVolumeSource() *ConfigMapVolumeSourceConfig {
+	return &ConfigMapVolumeSourceConfig{applycorev1.ConfigMapVolumeSource()}
+}
+
+// Inner returns the inner applycorev1.ConfigMapVolumeSourceApplyConfiguration.
+func (c *ConfigMapVolumeSourceConfig) Inner() *applycorev1.ConfigMapVolumeSourceApplyConfiguration {
+	return c.ConfigMapVolumeSourceApplyConfiguration
+}
+
 // ContainerPortConfig wraps applycorev1.ContainerPortApplyConfiguration.
 type ContainerPortConfig struct {
 	*applycorev1.ContainerPortApplyConfiguration

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -18,25 +18,17 @@ const (
 	Unknown Platform = iota
 	// AKSCloudHypervisorSNP represents a deployment with Cloud-Hypervisor on SEV-SNP AKS.
 	AKSCloudHypervisorSNP
-	// K3sQEMUTDX represents a deployment with QEMU on bare-metal TDX K3s.
-	K3sQEMUTDX
-	// K3sQEMUSNP represents a deployment with QEMU on bare-metal SNP K3s.
-	K3sQEMUSNP
-	// RKE2QEMUTDX represents a deployment with QEMU on bare-metal TDX RKE2.
-	RKE2QEMUTDX
 	// MetalQEMUSNP is the generic platform for bare-metal SNP deployments.
 	MetalQEMUSNP
 	// MetalQEMUTDX is the generic platform for bare-metal TDX deployments.
 	MetalQEMUTDX
-	// K3sQEMUSNPGPU represents a deployment with QEMU on bare-metal SNP K3s with GPU passthrough.
-	K3sQEMUSNPGPU
 	// MetalQEMUSNPGPU is the generic platform for bare-metal SNP deployments with GPU passthrough.
 	MetalQEMUSNPGPU
 )
 
 // All returns a list of all available platforms.
 func All() []Platform {
-	return []Platform{AKSCloudHypervisorSNP, K3sQEMUTDX, K3sQEMUSNP, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUTDX, K3sQEMUSNPGPU, MetalQEMUSNPGPU}
+	return []Platform{AKSCloudHypervisorSNP, MetalQEMUSNP, MetalQEMUTDX, MetalQEMUSNPGPU}
 }
 
 // AllStrings returns a list of all available platforms as strings.
@@ -53,14 +45,6 @@ func (p Platform) String() string {
 	switch p {
 	case AKSCloudHypervisorSNP:
 		return "AKS-CLH-SNP"
-	case K3sQEMUTDX:
-		return "K3s-QEMU-TDX"
-	case K3sQEMUSNP:
-		return "K3s-QEMU-SNP"
-	case K3sQEMUSNPGPU:
-		return "K3s-QEMU-SNP-GPU"
-	case RKE2QEMUTDX:
-		return "RKE2-QEMU-TDX"
 	case MetalQEMUSNP:
 		return "Metal-QEMU-SNP"
 	case MetalQEMUSNPGPU:
@@ -109,14 +93,6 @@ func FromString(s string) (Platform, error) {
 	switch strings.ToLower(s) {
 	case "aks-clh-snp":
 		return AKSCloudHypervisorSNP, nil
-	case "k3s-qemu-tdx":
-		return K3sQEMUTDX, nil
-	case "k3s-qemu-snp":
-		return K3sQEMUSNP, nil
-	case "k3s-qemu-snp-gpu":
-		return K3sQEMUSNPGPU, nil
-	case "rke2-qemu-tdx":
-		return RKE2QEMUTDX, nil
 	case "metal-qemu-snp":
 		return MetalQEMUSNP, nil
 	case "metal-qemu-snp-gpu":
@@ -133,7 +109,7 @@ func DefaultMemoryInMegaBytes(p Platform) int {
 	switch p {
 	case AKSCloudHypervisorSNP:
 		return 256
-	case K3sQEMUSNPGPU, MetalQEMUSNPGPU:
+	case MetalQEMUSNPGPU:
 		// Guest components contribute around 600MiB with GPU enabled.
 		return 1024
 	default:
@@ -147,7 +123,7 @@ func DefaultMemoryInMegaBytes(p Platform) int {
 // IsSNP returns true if the platform is a SEV-SNP platform.
 func IsSNP(p Platform) bool {
 	switch p {
-	case AKSCloudHypervisorSNP, K3sQEMUSNP, K3sQEMUSNPGPU, MetalQEMUSNP, MetalQEMUSNPGPU:
+	case AKSCloudHypervisorSNP, MetalQEMUSNP, MetalQEMUSNPGPU:
 		return true
 	default:
 		return false
@@ -157,7 +133,7 @@ func IsSNP(p Platform) bool {
 // IsTDX returns true if the platform is a TDX platform.
 func IsTDX(p Platform) bool {
 	switch p {
-	case K3sQEMUTDX, RKE2QEMUTDX, MetalQEMUTDX:
+	case MetalQEMUTDX:
 		return true
 	default:
 		return false
@@ -167,7 +143,7 @@ func IsTDX(p Platform) bool {
 // IsGPU returns true if the platform supports GPUs.
 func IsGPU(p Platform) bool {
 	switch p {
-	case K3sQEMUSNPGPU, MetalQEMUSNPGPU:
+	case MetalQEMUSNPGPU:
 		return true
 	default:
 		return false
@@ -177,7 +153,7 @@ func IsGPU(p Platform) bool {
 // IsQEMU returns true if the platform uses QEMU as the hypervisor.
 func IsQEMU(p Platform) bool {
 	switch p {
-	case K3sQEMUTDX, K3sQEMUSNP, K3sQEMUSNPGPU, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUSNPGPU, MetalQEMUTDX:
+	case MetalQEMUSNP, MetalQEMUSNPGPU, MetalQEMUTDX:
 		return true
 	default:
 		return false

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -163,3 +163,33 @@ func IsTDX(p Platform) bool {
 		return false
 	}
 }
+
+// IsGPU returns true if the platform supports GPUs.
+func IsGPU(p Platform) bool {
+	switch p {
+	case K3sQEMUSNPGPU, MetalQEMUSNPGPU:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsQEMU returns true if the platform uses QEMU as the hypervisor.
+func IsQEMU(p Platform) bool {
+	switch p {
+	case K3sQEMUTDX, K3sQEMUSNP, K3sQEMUSNPGPU, RKE2QEMUTDX, MetalQEMUSNP, MetalQEMUSNPGPU, MetalQEMUTDX:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsCloudHypervisor returns true if the platform uses Cloud-Hypervisor as the hypervisor.
+func IsCloudHypervisor(p Platform) bool {
+	switch p {
+	case AKSCloudHypervisorSNP:
+		return true
+	default:
+		return false
+	}
+}

--- a/justfile
+++ b/justfile
@@ -63,6 +63,7 @@ e2e target=default_deploy_target platform=default_platform: soft-clean coordinat
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
             --namespace-file ./{{ workspace_dir }}/just.namespace \
             --platform {{ platform }} \
+            --node-installer-target-conf-type ${node_installer_target_conf_type} \
             --namespace-suffix=${namespace_suffix-}
 
 # Generate policies, apply Kubernetes manifests.

--- a/justfile
+++ b/justfile
@@ -69,7 +69,7 @@ e2e target=default_deploy_target platform=default_platform: soft-clean coordinat
 deploy target=default_deploy_target cli=default_cli platform=default_platform: (runtime target platform) (apply "runtime") (populate target platform) (generate cli platform) (apply target)
 
 # Populate the workspace with a runtime class deployment
-runtime target=default_deploy_target platform=default_platform:
+runtime target=default_deploy_target platform=default_platform node_installer_target_conf_type="k3s":
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ./{{ workspace_dir }}/runtime
@@ -77,8 +77,9 @@ runtime target=default_deploy_target platform=default_platform:
       --image-replacements ./{{ workspace_dir }}/just.containerlookup \
       --namespace {{ target }}${namespace_suffix-} \
       --add-namespace-object \
+      --node-installer-target-conf-type ${node_installer_target_conf_type} \
       --platform {{ platform }} \
-      runtime > ./{{ workspace_dir }}/runtime/runtime.yml
+      node-installer-target-conf runtime > ./{{ workspace_dir }}/runtime/runtime.yml
 
 # Populate the workspace with a Kubernetes deployment
 populate target=default_deploy_target platform=default_platform:
@@ -412,6 +413,8 @@ container_registry=""
 azure_resource_group=""
 # Platform to deploy on
 default_platform="AKS-CLH-SNP"
+# Node installer target config map to deploy.
+node_installer_target_conf_type="k3s"
 
 #
 # No need to change anything below this line.

--- a/nodeinstaller/internal/containerdconfig/config.go
+++ b/nodeinstaller/internal/containerdconfig/config.go
@@ -40,17 +40,16 @@ func RuntimeFragment(baseDir, snapshotter string, platform platforms.Platform) (
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-clh-snp.toml"),
 		}
 		cfg.Snapshotter = snapshotter
-	case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUTDX:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-tdx.toml"),
 		}
-	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU,
-		platforms.MetalQEMUSNPGPU:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-snp.toml"),
 		}
 		// For GPU support, we need to pass through the CDI annotations.
-		if platform == platforms.K3sQEMUSNPGPU || platform == platforms.MetalQEMUSNPGPU {
+		if platforms.IsGPU(platform) {
 			cfg.PodAnnotations = append(cfg.PodAnnotations, "cdi.k8s.io/*")
 		}
 	default:

--- a/nodeinstaller/internal/kataconfig/config.go
+++ b/nodeinstaller/internal/kataconfig/config.go
@@ -81,7 +81,7 @@ func KataRuntimeConfig(
 		config.Hypervisor["clh"]["shared_fs"] = "none"
 		config.Hypervisor["clh"]["snp_guest_policy"] = 196608
 		config.Runtime["static_sandbox_resource_mgmt"] = true
-	case platforms.MetalQEMUTDX, platforms.K3sQEMUTDX, platforms.RKE2QEMUTDX:
+	case platforms.MetalQEMUTDX:
 		if err := toml.Unmarshal([]byte(kataBareMetalQEMUTDXBaseConfig), &config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
@@ -109,8 +109,7 @@ func KataRuntimeConfig(
 
 		// TODO: Check again why we need this and how we can avoid it.
 		config.Hypervisor["qemu"]["block_device_aio"] = "threads"
-	case platforms.MetalQEMUSNP, platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU,
-		platforms.MetalQEMUSNPGPU:
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU:
 		if err := toml.Unmarshal([]byte(kataBareMetalQEMUSNPBaseConfig), &config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
@@ -142,7 +141,7 @@ func KataRuntimeConfig(
 		config.Hypervisor["qemu"]["enable_annotations"] = []string{}
 
 		// GPU-specific settings
-		if platform == platforms.K3sQEMUSNPGPU || platform == platforms.MetalQEMUSNPGPU {
+		if platforms.IsGPU(platform) {
 			config.Hypervisor["qemu"]["guest_hook_path"] = "/usr/share/oci/hooks"
 			config.Hypervisor["qemu"]["cold_plug_vfio"] = "root-port"
 			// GPU images tend to be larger, so give a better default timeout that

--- a/nodeinstaller/internal/kataconfig/config_test.go
+++ b/nodeinstaller/internal/kataconfig/config_test.go
@@ -17,11 +17,11 @@ var (
 	//go:embed testdata/expected-configuration-clh-snp.toml
 	expectedConfAKSCLHSNP []byte
 	//go:embed testdata/expected-configuration-qemu-snp.toml
-	expectedConfBareMetalQEMUSNP []byte
+	expectedConfMetalQEMUSNP []byte
 	//go:embed testdata/expected-configuration-qemu-tdx.toml
-	expectedConfBareMetalQEMUTDX []byte
+	expectedConfMetalQEMUTDX []byte
 	//go:embed testdata/expected-configuration-qemu-snp-gpu.toml
-	expectedConfBareMetalQEMUSNPGPU []byte
+	expectedConfMetalQEMUSNPGPU []byte
 )
 
 func TestKataRuntimeConfig(t *testing.T) {
@@ -33,17 +33,17 @@ func TestKataRuntimeConfig(t *testing.T) {
 			changeSnpFields: false,
 			want:            string(expectedConfAKSCLHSNP),
 		},
-		platforms.K3sQEMUSNP: {
+		platforms.MetalQEMUSNP: {
 			changeSnpFields: true,
-			want:            string(expectedConfBareMetalQEMUSNP),
+			want:            string(expectedConfMetalQEMUSNP),
 		},
-		platforms.K3sQEMUSNPGPU: {
+		platforms.MetalQEMUSNPGPU: {
 			changeSnpFields: true,
-			want:            string(expectedConfBareMetalQEMUSNPGPU),
+			want:            string(expectedConfMetalQEMUSNPGPU),
 		},
-		platforms.K3sQEMUTDX: {
+		platforms.MetalQEMUTDX: {
 			changeSnpFields: false,
-			want:            string(expectedConfBareMetalQEMUTDX),
+			want:            string(expectedConfMetalQEMUTDX),
 		},
 	}
 	for platform, tc := range testCases {
@@ -70,9 +70,7 @@ func TestKataRuntimeConfig(t *testing.T) {
 			assert.Contains(string(configBytes), "[Agent.kata]")
 			assert.Contains(string(configBytes), "[Runtime]")
 			switch platform {
-			case platforms.K3sQEMUSNP, platforms.K3sQEMUSNPGPU, platforms.K3sQEMUTDX,
-				platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.RKE2QEMUTDX,
-				platforms.MetalQEMUSNPGPU:
+			case platforms.MetalQEMUSNP, platforms.MetalQEMUTDX, platforms.MetalQEMUSNPGPU:
 				assert.Contains(string(configBytes), "[Hypervisor.qemu]")
 			case platforms.AKSCloudHypervisorSNP:
 				assert.Contains(string(configBytes), "[Hypervisor.clh]")

--- a/nodeinstaller/internal/kataconfig/update-testdata/main.go
+++ b/nodeinstaller/internal/kataconfig/update-testdata/main.go
@@ -31,17 +31,17 @@ func main() {
 			config:   "clh-snp",
 			testdata: "clh-snp",
 		},
-		platforms.K3sQEMUSNP: {
+		platforms.MetalQEMUSNP: {
 			upstream: "qemu-snp",
 			config:   "qemu-snp",
 			testdata: "qemu-snp",
 		},
-		platforms.K3sQEMUTDX: {
+		platforms.MetalQEMUTDX: {
 			upstream: "qemu-tdx",
 			config:   "qemu-tdx",
 			testdata: "qemu-tdx",
 		},
-		platforms.K3sQEMUSNPGPU: {
+		platforms.MetalQEMUSNPGPU: {
 			upstream: "qemu-snp",
 			config:   "qemu-snp",
 			testdata: "qemu-snp-gpu",

--- a/nodeinstaller/internal/targetconfig/targetconfig.go
+++ b/nodeinstaller/internal/targetconfig/targetconfig.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package targetconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/spf13/afero"
+)
+
+// TargetConfig holds the configuration for the target system where the node-installer is running.
+type TargetConfig struct {
+	containerdConfigPath string
+	restartSystemdUnit   bool
+	systemdUnitNames     []string
+	kataConfigPath       string
+
+	hostMount string
+	fs        *afero.Afero
+}
+
+// NewTargetConfig creates a targetConfig with default values.
+func NewTargetConfig(hostMount, runtimeBase string, pl platforms.Platform) (*TargetConfig, error) {
+	conf := &TargetConfig{
+		containerdConfigPath: "etc/containerd/config.toml",
+		restartSystemdUnit:   true,
+		systemdUnitNames:     []string{"containerd.service"},
+		hostMount:            hostMount,
+		fs:                   &afero.Afero{Fs: afero.NewOsFs()},
+	}
+	switch {
+	case platforms.IsCloudHypervisor(pl) && platforms.IsSNP(pl):
+		conf.kataConfigPath = filepath.Join(runtimeBase, "etc", "configuration-clh-snp.toml")
+	case platforms.IsQEMU(pl) && platforms.IsSNP(pl):
+		conf.kataConfigPath = filepath.Join(runtimeBase, "etc", "configuration-qemu-snp.toml")
+	case platforms.IsQEMU(pl) && platforms.IsTDX(pl):
+		conf.kataConfigPath = filepath.Join(runtimeBase, "etc", "configuration-qemu-tdx.toml")
+	default:
+		return nil, fmt.Errorf("unsupported platform %q", pl)
+	}
+	return conf, nil
+}
+
+// LoadOverridesFromDir loads target configuration overrides from the specified directory.
+func (c *TargetConfig) LoadOverridesFromDir(
+	targetConfigDir string,
+) error {
+	if _, err := c.fs.Stat(targetConfigDir); errors.Is(err, fs.ErrNotExist) {
+		log.Printf("Target config directory %q does not exist, using default configuration.\n", targetConfigDir)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("checking target config directory %q: %w", targetConfigDir, err)
+	}
+	if err := c.fs.Walk(targetConfigDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		data, err := c.fs.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading file %q: %w", path, err)
+		}
+		dataStr := string(bytes.TrimSpace(data))
+		if dataStr == "" {
+			return fmt.Errorf("%s cannot be empty", info.Name())
+		}
+		switch info.Name() {
+		case "containerd-config-path":
+			c.containerdConfigPath = dataStr
+		case "restart-systemd-unit":
+			restart, err := strconv.ParseBool(dataStr)
+			if err != nil {
+				return fmt.Errorf("parsing restart-containerd value %q: %w", dataStr, err)
+			}
+			c.restartSystemdUnit = restart
+		case "systemd-unit-name":
+			c.systemdUnitNames = strings.FieldsFunc(dataStr, func(r rune) bool {
+				return slices.Contains([]string{",", " ", "\n"}, string(r))
+			})
+		case "kata-config-path":
+			c.kataConfigPath = dataStr
+		default:
+			return fmt.Errorf("unexpected file %q in target config dir %q", info.Name(), targetConfigDir)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("walking directory %q: %w", targetConfigDir, err)
+	}
+	return nil
+}
+
+// ContainerdConfigPath returns the path to the containerd configuration file.
+func (c *TargetConfig) ContainerdConfigPath() string {
+	return filepath.Join(c.hostMount, c.containerdConfigPath)
+}
+
+// RestartSystemdUnit returns whether the systemd unit should be restarted.
+func (c *TargetConfig) RestartSystemdUnit() bool {
+	return c.restartSystemdUnit
+}
+
+// SystemdUnitNames returns the names of the systemd units to restart.
+func (c *TargetConfig) SystemdUnitNames() []string {
+	return c.systemdUnitNames
+}
+
+// KataConfigPath returns the path to the Kata Containers configuration file.
+func (c *TargetConfig) KataConfigPath() string {
+	return filepath.Join(c.hostMount, c.kataConfigPath)
+}

--- a/nodeinstaller/internal/targetconfig/targetconfig_test.go
+++ b/nodeinstaller/internal/targetconfig/targetconfig_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package targetconfig
+
+import (
+	"testing"
+
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTargetConfig(t *testing.T) {
+	testCases := map[string]struct {
+		hostMount   string
+		runtimeBase string
+		platform    platforms.Platform
+		wantErr     bool
+		wantConfig  *TargetConfig
+	}{
+		"valid config for metal qemu snp": {
+			hostMount:   "/host",
+			runtimeBase: "/opt/edgeless/qemu",
+			platform:    platforms.MetalQEMUSNP,
+			wantErr:     false,
+			wantConfig: &TargetConfig{
+				containerdConfigPath: "etc/containerd/config.toml",
+				restartSystemdUnit:   true,
+				systemdUnitNames:     []string{"containerd.service"},
+				kataConfigPath:       "/opt/edgeless/qemu/etc/configuration-qemu-snp.toml",
+				hostMount:            "/host",
+			},
+		},
+		"valid config for metal qemu tdx": {
+			hostMount:   "/host",
+			runtimeBase: "/opt/edgeless/qemu",
+			platform:    platforms.MetalQEMUTDX,
+			wantErr:     false,
+			wantConfig: &TargetConfig{
+				containerdConfigPath: "etc/containerd/config.toml",
+				restartSystemdUnit:   true,
+				systemdUnitNames:     []string{"containerd.service"},
+				kataConfigPath:       "/opt/edgeless/qemu/etc/configuration-qemu-tdx.toml",
+				hostMount:            "/host",
+			},
+		},
+		"invalid platform": {
+			hostMount:   "/host",
+			runtimeBase: "/opt/edgeless/unknown",
+			platform:    platforms.Unknown,
+			wantErr:     true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			gotConfig, err := NewTargetConfig(tc.hostMount, tc.runtimeBase, tc.platform)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			gotConfig.fs = nil
+			assert.Equal(tc.wantConfig, gotConfig)
+		})
+	}
+}
+
+func TestLoadOverridesFromDir(t *testing.T) {
+	testCases := map[string]struct {
+		fsLayout   map[string]string
+		setupConf  *TargetConfig
+		targetDir  string
+		wantErr    bool
+		wantConfig *TargetConfig
+	}{
+		"valid overrides": {
+			fsLayout: map[string]string{
+				"some/dir/containerd-config-path": "custom/config.toml",
+				"some/dir/kata-config-path":       "custom/kata.toml",
+				"some/dir/restart-systemd-unit":   "false",
+				"some/dir/systemd-unit-name":      "custom.service",
+			},
+			setupConf: &TargetConfig{},
+			targetDir: "some/dir",
+			wantErr:   false,
+			wantConfig: &TargetConfig{
+				containerdConfigPath: "custom/config.toml",
+				restartSystemdUnit:   false,
+				systemdUnitNames:     []string{"custom.service"},
+				kataConfigPath:       "custom/kata.toml",
+			},
+		},
+		"partial overrides": {
+			fsLayout: map[string]string{
+				"some/dir/containerd-config-path": "custom/config.toml",
+				"some/dir/restart-systemd-unit":   "true",
+			},
+			setupConf: &TargetConfig{
+				containerdConfigPath: "default/config.toml",
+				restartSystemdUnit:   true,
+				systemdUnitNames:     []string{"default.service"},
+				kataConfigPath:       "default/kata.toml",
+			},
+			targetDir: "some/dir",
+			wantErr:   false,
+			wantConfig: &TargetConfig{
+				containerdConfigPath: "custom/config.toml",
+				restartSystemdUnit:   true,
+				systemdUnitNames:     []string{"default.service"},
+				kataConfigPath:       "default/kata.toml",
+			},
+		},
+		"no override present": {
+			fsLayout: map[string]string{},
+			setupConf: &TargetConfig{
+				containerdConfigPath: "default/config.toml",
+				restartSystemdUnit:   true,
+				systemdUnitNames:     []string{"default.service"},
+				kataConfigPath:       "default/kata.toml",
+			},
+			targetDir: "some/dir",
+			wantErr:   false,
+			wantConfig: &TargetConfig{
+				containerdConfigPath: "default/config.toml",
+				restartSystemdUnit:   true,
+				systemdUnitNames:     []string{"default.service"},
+				kataConfigPath:       "default/kata.toml",
+			},
+		},
+		"unit names with multiple separators": {
+			fsLayout: map[string]string{
+				"some/dir/systemd-unit-name": "unit1, unit2 unit3\nunit4",
+			},
+			setupConf: &TargetConfig{
+				systemdUnitNames: []string{"default.service"},
+			},
+			targetDir: "some/dir",
+			wantErr:   false,
+			wantConfig: &TargetConfig{
+				systemdUnitNames: []string{"unit1", "unit2", "unit3", "unit4"},
+			},
+		},
+		"containerd-config-path file empty": {
+			fsLayout: map[string]string{
+				"some/dir/containerd-config-path": "",
+			},
+			setupConf: &TargetConfig{},
+			targetDir: "some/dir",
+			wantErr:   true,
+		},
+		"kata-config-path file empty": {
+			fsLayout: map[string]string{
+				"some/dir/kata-config-path": "",
+			},
+			setupConf: &TargetConfig{},
+			targetDir: "some/dir",
+			wantErr:   true,
+		},
+		"restart-systemd-unit file empty": {
+			fsLayout: map[string]string{
+				"some/dir/restart-systemd-unit": "",
+			},
+			setupConf: &TargetConfig{},
+			targetDir: "some/dir",
+			wantErr:   true,
+		},
+		"systemd-unit-name file empty": {
+			fsLayout: map[string]string{
+				"some/dir/systemd-unit-name": "",
+			},
+			setupConf: &TargetConfig{},
+			targetDir: "some/dir",
+			wantErr:   true,
+		},
+		"unexpected file in target config dir": {
+			fsLayout: map[string]string{
+				"some/dir/unexpected-file": "unexpected content",
+			},
+			setupConf: &TargetConfig{},
+			targetDir: "some/dir",
+			wantErr:   true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			fs := afero.NewMemMapFs()
+			for path, content := range tc.fsLayout {
+				require.NoError(afero.WriteFile(fs, path, []byte(content), 0o644))
+			}
+
+			tc.setupConf.fs = &afero.Afero{Fs: fs}
+			err := tc.setupConf.LoadOverridesFromDir(tc.targetDir)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			tc.setupConf.fs = nil // Ignore the fs in the comparison
+			assert.Equal(tc.wantConfig, tc.setupConf)
+		})
+	}
+}

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -35,22 +35,19 @@ func main() {
 	fmt.Fprintln(os.Stderr, "Report issues at https://github.com/edgelesssys/contrast/issues")
 
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: node-installer <platform>")
-		os.Exit(1)
+		log.Fatal("Usage: node-installer <platform>")
 	}
 
 	platform, err := platforms.FromString(os.Args[1])
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 
 	fetcher := asset.NewDefaultFetcher()
 	if err := run(context.Background(), fetcher, platform); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
-	fmt.Println("Installation completed successfully.")
+	log.Println("Installation completed successfully.")
 }
 
 func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform) error {
@@ -71,7 +68,7 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform)
 	if err := config.Validate(); err != nil {
 		return fmt.Errorf("validating config: %w", err)
 	}
-	fmt.Printf("Using config: %+v\n", config)
+	log.Printf("Using config: %+v\n", config)
 
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
 	if err != nil {
@@ -122,7 +119,7 @@ func installFiles(
 		// Replace @@runtimeName@@ in the target path with the actual base directory.
 		targetPath := strings.ReplaceAll(file.Path, kataconfig.RuntimeNamePlaceholder, runtimeHandlerName)
 
-		fmt.Printf("Fetching %q to %q\n", file.URL, targetPath)
+		log.Printf("Fetching %q to %q\n", file.URL, targetPath)
 
 		if err := os.MkdirAll(filepath.Dir(filepath.Join(hostMount, targetPath)), 0o777); err != nil {
 			return fmt.Errorf("creating directory %q: %w", filepath.Dir(targetPath), err)
@@ -184,8 +181,8 @@ func containerdRuntimeConfig(basePath, configPath string, platform platforms.Pla
 func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform platforms.Platform, debugRuntime bool) error {
 	existingRaw, existing, err := parseExistingContainerdConfig(configPath)
 	if err != nil {
-		fmt.Printf("Failed to parse existing containerd config: %v\n", err)
-		fmt.Println("Creating a new containerd base config.")
+		log.Printf("Failed to parse existing containerd config: %v\n", err)
+		log.Println("Creating a new containerd base config.")
 		existing = containerdconfig.Base()
 	}
 
@@ -225,7 +222,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 	}
 
 	if bytes.Equal(existingRaw, rawConfig) {
-		fmt.Println("Containerd config already up-to-date. No changes needed.")
+		log.Println("Containerd config already up-to-date. No changes needed.")
 		return nil
 	}
 
@@ -236,7 +233,7 @@ func patchContainerdConfig(runtimeHandler, basePath, configPath string, platform
 		}
 	}
 
-	fmt.Printf("Patching containerd config at %s\n", configPath)
+	log.Printf("Patching containerd config at %s\n", configPath)
 	tmpFile, err := os.CreateTemp(filepath.Dir(configPath), "containerd-config-*.toml")
 	if err != nil {
 		return fmt.Errorf("creating temporary file: %w", err)
@@ -308,10 +305,10 @@ func restartHostContainerd(ctx context.Context, containerdConfigPath string, ser
 		return fmt.Errorf("retrieving service (%s) start time: %w", service, err)
 	}
 
-	fmt.Printf("Service (%s) start time: %s\n", service, startTime.Format(time.RFC3339Nano))
-	fmt.Printf("Containerd config mtime:          %s\n", configMtime.Format(time.RFC3339Nano))
+	log.Printf("Service (%s) start time: %s\n", service, startTime.Format(time.RFC3339Nano))
+	log.Printf("Containerd config mtime:          %s\n", configMtime.Format(time.RFC3339Nano))
 	if startTime.After(configMtime) {
-		fmt.Printf("Service (%s) already running with the newest config\n", service)
+		log.Printf("Service (%s) already running with the newest config\n", service)
 		return nil
 	}
 
@@ -323,7 +320,7 @@ func restartHostContainerd(ctx context.Context, containerdConfigPath string, ser
 	if err != nil {
 		return fmt.Errorf("restarting service (%s): %w: %s", service, err, out)
 	}
-	fmt.Printf("Service (%s) restarted\n", service)
+	log.Printf("Service (%s) restarted\n", service)
 	return nil
 }
 

--- a/nodeinstaller/node-installer_test.go
+++ b/nodeinstaller/node-installer_test.go
@@ -19,11 +19,11 @@ var (
 	//go:embed testdata/expected-aks-clh-snp.toml
 	expectedConfAKSCLHSNP []byte
 	//go:embed testdata/expected-bare-metal-qemu-tdx.toml
-	expectedConfBareMetalQEMUTDX []byte
+	expectedConfMetalQEMUTDX []byte
 	//go:embed testdata/expected-bare-metal-qemu-snp.toml
-	expectedConfBareMetalQEMUSNP []byte
+	expectedConfMetalQEMUSNP []byte
 	//go:embed testdata/expected-bare-metal-qemu-snp-gpu.toml
-	expectedConfBareMetalQEMUSNPGPU []byte
+	expectedConfMetalQEMUSNPGPU []byte
 )
 
 func TestPatchContainerdConfig(t *testing.T) {
@@ -36,17 +36,17 @@ func TestPatchContainerdConfig(t *testing.T) {
 			platform: platforms.AKSCloudHypervisorSNP,
 			expected: expectedConfAKSCLHSNP,
 		},
-		"K3sQEMUTDX": {
-			platform: platforms.K3sQEMUTDX,
-			expected: expectedConfBareMetalQEMUTDX,
+		"MetalQEMUTDX": {
+			platform: platforms.MetalQEMUTDX,
+			expected: expectedConfMetalQEMUTDX,
 		},
-		"K3sQEMUSNP": {
-			platform: platforms.K3sQEMUSNP,
-			expected: expectedConfBareMetalQEMUSNP,
+		"MetalQEMUSNP": {
+			platform: platforms.MetalQEMUSNP,
+			expected: expectedConfMetalQEMUSNP,
 		},
-		"K3sQEMUSNPGPU": {
-			platform: platforms.K3sQEMUSNPGPU,
-			expected: expectedConfBareMetalQEMUSNPGPU,
+		"MetalQEMUSNPGPU": {
+			platform: platforms.MetalQEMUSNPGPU,
+			expected: expectedConfMetalQEMUSNPGPU,
 		},
 		"Unknown": {
 			platform: platforms.Unknown,

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -60,12 +60,8 @@ let
 
       aks-clh-snp-handler = runtimeHandler "aks-clh-snp" microsoft.contrast-node-installer-image.runtimeHash;
       metal-qemu-tdx-handler = runtimeHandler "metal-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
-      k3s-qemu-tdx-handler = runtimeHandler "k3s-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
-      rke2-qemu-tdx-handler = runtimeHandler "rke2-qemu-tdx" kata.contrast-node-installer-image.runtimeHash;
       metal-qemu-snp-handler = runtimeHandler "metal-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
       metal-qemu-snp-gpu-handler = runtimeHandler "metal-qemu-snp-gpu" kata.contrast-node-installer-image.runtimeHash;
-      k3s-qemu-snp-handler = runtimeHandler "k3s-qemu-snp" kata.contrast-node-installer-image.runtimeHash;
-      k3s-qemu-snp-gpu-handler = runtimeHandler "k3s-qemu-snp-gpu" kata.contrast-node-installer-image.runtimeHash;
       aksRefVals = {
         snp = [
           {
@@ -147,12 +143,8 @@ let
       builtins.toJSON {
         "${aks-clh-snp-handler}" = aksRefVals;
         "${metal-qemu-tdx-handler}" = tdxRefVals;
-        "${k3s-qemu-tdx-handler}" = tdxRefVals;
-        "${rke2-qemu-tdx-handler}" = tdxRefVals;
         "${metal-qemu-snp-handler}" = snpRefVals;
         "${metal-qemu-snp-gpu-handler}" = snpGpuRefVals;
-        "${k3s-qemu-snp-handler}" = snpRefVals;
-        "${k3s-qemu-snp-gpu-handler}" = snpGpuRefVals;
       }
     );
 
@@ -182,8 +174,6 @@ let
     builtins.toJSON {
       metal-qemu-snp = snpIdBlocksFor kata.contrast-node-installer-image.os-image;
       metal-qemu-snp-gpu = snpIdBlocksFor kata.contrast-node-installer-image.gpu.os-image;
-      k3s-qemu-snp = snpIdBlocksFor kata.contrast-node-installer-image.os-image;
-      k3s-qemu-snp-gpu = snpIdBlocksFor kata.contrast-node-installer-image.gpu.os-image;
       aks-clh-snp.Milan =
         let
           launch-digest =

--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -135,8 +135,16 @@ let
               passthru.exists =
                 if (platform == "metal-qemu-tdx" || platform == "metal-qemu-snp") then
                   (versionGreaterEqual version "v1.2.1")
-                else if (platform == "metal-qemu-snp-gpu" || platform == "k3s-qemu-snp-gpu") then
+                else if (platform == "metal-qemu-snp-gpu") then
                   (versionGreaterEqual version "v1.4.0")
+                else if (platform == "k3s-qemu-snp-gpu") then
+                  (versionGreaterEqual version "v1.4.0")
+                  # platform removed in release v1.12.0
+                  && (versionLessThan version "v1.12.0")
+                else if (lib.hasPrefix "k3s-qemu" platform) then
+                  (versionGreaterEqual version "v1.1.0")
+                  # platform removed in release v1.12.0
+                  && (versionLessThan version "v1.12.0")
                 else
                   (versionGreaterEqual version "v1.1.0");
             }


### PR DESCRIPTION
This adds a new way to configure the Contrast node installer via ConfigMap. The ConfigMap describes the target system the node installer is installing to and configures things like the containerd config path and the systemd unit name that needs to be restarted on changes to the containerd config. The node installer ships with default vaules, so the ConfigMap is only needed if things differ from those default paths.

One environment where we see these differences from common Kubernetes/containerd setups is K3s. Up to now, Contrast supported K3s as a separate platform. This change removes those platforms and introduces a node installer target ConfigMap for K3s instead.

**[breaking] The following platforms are removed:**

- `K3s-QEMU-SNP`
- `K3s-QEMU-SNP-GPU`
- `K3s-QEMU-TDX`
- `RKE2-QEMU-TDX`

If you previously used one of these platforms you can migrate by

1. Switching to a `Metal-*` platform:
    - `K3s-QEMU-SNP` -> `Metal-QEMU-SNP`
    - `K3s-QEMU-SNP-GPU` -> `Metal-QEMU-SNP-GPU`
    - `K3s-QEMU-TDX` -> `Metal-QEMU-TDX`
2. Installing the node installer config map for K3s, as described in https://docs.edgeless.systems/contrast/howto/cluster-setup/bare-metal#kubernetes-cluster-setup

Note that RKE2 isn't supported anymore as is wasn't properly tested.