### PR TITLE
cli/verifier: add `NoSharedFSMount` verifier

### DIFF
--- a/cli/verifier/no_shared_fs_mount.go
+++ b/cli/verifier/no_shared_fs_mount.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package verifier
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+const errorMessageTemplate = "volumeMount %q refers to an unsupported %s; supported types are ConfigMap, DownwardAPI, EmptyDir, Ephemeral, Projected and Secret"
+
+// NoSharedFSMount verifies that no filesystems are shared with the root.
+type NoSharedFSMount struct{}
+
+// Verify verifies that no filesystems are shared with the root.
+func (v *NoSharedFSMount) Verify(toVerify any) error {
+	var findings error
+
+	// get all volume mounts that are referenced in containers
+	isNonCC := false
+	kuberesource.MapPodSpec(toVerify, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
+		if spec.RuntimeClassName == nil || !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc") {
+			// this isn't a confidential pod so we don't need to check further
+			isNonCC = true
+			return spec
+		}
+		// verify all volume mounts of all containers in pod
+		for _, container := range spec.Containers {
+			for _, mount := range container.VolumeMounts {
+				volumeReferenced := false
+				for _, volume := range spec.Volumes {
+					if *mount.Name != *volume.Name {
+						continue
+					}
+					volumeReferenced = true
+
+					if isSupportedVolume(volume) {
+						continue
+					}
+
+					// a volume with invalid type is referenced
+					findings = errors.Join(findings, fmt.Errorf(errorMessageTemplate, *mount.Name, "volume type"))
+				}
+				if !volumeReferenced {
+					findings = errors.Join(findings, fmt.Errorf(errorMessageTemplate, *mount.Name, "volume claim template"))
+				}
+			}
+		}
+		return spec
+	})
+	if isNonCC {
+		// we don't care about non-confidential pods
+		return nil
+	}
+
+	return findings
+}
+
+func isSupportedVolume(volume applycorev1.VolumeApplyConfiguration) bool {
+	if volume.ConfigMap != nil {
+		return true
+	}
+	if volume.DownwardAPI != nil {
+		return true
+	}
+	if volume.EmptyDir != nil {
+		return true
+	}
+	if volume.Ephemeral != nil {
+		return true
+	}
+	if volume.Projected != nil {
+		return true
+	}
+	if volume.Secret != nil {
+		return true
+	}
+	return false
+}

--- a/cli/verifier/no_shared_fs_mount_test.go
+++ b/cli/verifier/no_shared_fs_mount_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package verifier_test
+
+import (
+	"testing"
+
+	"github.com/edgelesssys/contrast/cli/verifier"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/stretchr/testify/require"
+)
+
+const podWithEmptyVolume = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  runtimeClassName: contrast-cc
+  volumes:
+    - name: asdf
+      emptyDir: {}
+  containers:
+    - name: test
+      image: bash
+      volumeMounts:
+        - name: asdf
+          mountPath: /tmp
+`
+
+const podWithUnreferencedHostPath = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  runtimeClassName: contrast-cc
+  volumes:
+    - name: unreferenced
+      hostPath:
+        path: /
+  containers:
+    - name: test
+      image: bash
+`
+
+const podWithHostPath = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  runtimeClassName: contrast-cc
+  volumes:
+    - name: asdf
+      hostPath:
+        path: /
+  containers:
+    - name: test
+      image: bash
+      volumeMounts:
+        - name: asdf
+          mountPath: /tmp
+`
+
+const podWithVolumeMountNoVolume = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  runtimeClassName: contrast-cc
+  containers:
+    - name: test
+      image: bash
+      volumeMounts:
+        - name: asdf
+          mountPath: /tmp
+`
+
+const statefulSetWithPodReferencingClaim = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test
+spec:
+  serviceName: "nginx"
+  template:
+    spec:
+      runtimeClassName: contrast-cc
+      containers:
+      - name: nginx
+        image: registry.k8s.io/nginx-slim:0.24
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      resources:
+        requests:
+          storage: 1Gi
+`
+
+const nonCCPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  volumes:
+    - name: asdf
+      emptyDir: {}
+  containers:
+    - name: test
+      image: bash
+      volumeMounts:
+        - name: asdf
+          mountPath: /tmp
+`
+
+const nonCCPodWithHostPath = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  volumes:
+    - name: asdf
+      hostPath:
+        path: /
+  containers:
+    - name: test
+      image: bash
+      volumeMounts:
+        - name: asdf
+          mountPath: /tmp
+`
+
+func TestVerifyNoSharedFSMount(t *testing.T) {
+	testCases := map[string]struct {
+		k8sObjectYAML string
+		wantErr       bool
+	}{
+		"unproblematic yaml": {
+			k8sObjectYAML: podWithEmptyVolume,
+		},
+		"yaml with unreferenced problematic volume": {
+			k8sObjectYAML: podWithUnreferencedHostPath,
+		},
+		"yaml with problematic volume": {
+			k8sObjectYAML: podWithHostPath,
+			wantErr:       true,
+		},
+		"yaml with volume mount but no volume": {
+			k8sObjectYAML: podWithVolumeMountNoVolume,
+			wantErr:       true,
+		},
+		"stateful set with pod referencing claim": {
+			k8sObjectYAML: statefulSetWithPodReferencingClaim,
+			wantErr:       true,
+		},
+		"non cc pod with good volume": {
+			k8sObjectYAML: nonCCPod,
+		},
+		"non cc pod with bad volume": {
+			k8sObjectYAML: nonCCPodWithHostPath,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			toVerifySlice, err := kuberesource.UnmarshalApplyConfigurations([]byte(tc.k8sObjectYAML))
+			require.NoError(err)
+
+			verifier := verifier.NoSharedFSMount{}
+
+			for _, toVerify := range toVerifySlice {
+				err := verifier.Verify(toVerify)
+				if tc.wantErr {
+					require.Error(err)
+				} else {
+					require.NoError(err)
+				}
+			}
+		})
+	}
+}

--- a/cli/verifier/verifiers.go
+++ b/cli/verifier/verifiers.go
@@ -3,24 +3,22 @@
 
 package verifier
 
-import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-)
-
 // AllVerifiers returns all verifiers for k8s objects.
 func AllVerifiers() []Verifier {
-	return []Verifier{}
+	return []Verifier{
+		&NoSharedFSMount{},
+	}
 }
 
-// VerificationFunc is a function that verifies a given unstructured object and returns an error if verification fails.
-type VerificationFunc func(toVerify *unstructured.Unstructured) error
+// VerificationFunc is a function that verifies a given apply configuration and returns an error if verification fails.
+type VerificationFunc func(toVerify any) error
 
-// Verify verifies a given k8s object.
-func (f VerificationFunc) Verify(toVerify *unstructured.Unstructured) error {
+// Verify verifies a given k8s object. `toVerify` should be an apply configuration.
+func (f VerificationFunc) Verify(toVerify any) error {
 	return f(toVerify)
 }
 
-// Verifier verifies a given k8s object.
+// Verifier verifies a given k8s object. `toVerify` should be an apply configuration.
 type Verifier interface {
-	Verify(toVerify *unstructured.Unstructured) error
+	Verify(toVerify any) error
 }


### PR DESCRIPTION
This adds a verifier to be run before `genpolicy` that forbids the following:
1. `volumeMount`s that don't reference a volume of type `configMap`, `downwardAPI`, `emptyDir`, `ephemeral`, `projected` or `secret`
2. `volumeClaimTemplate`s that are not of `volumeMode: Block`