### PR TITLE
kuberesource: change annotation position to pod template

### DIFF
--- a/docs/docs/architecture/components/service-mesh.md
+++ b/docs/docs/architecture/components/service-mesh.md
@@ -73,11 +73,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
-  annotations:
-    contrast.edgeless.systems/servicemesh-ingress: "web#8080#false##metrics#7890#true"
 spec:
   replicas: 1
   template:
+    metadata:
+      annotations:
+        contrast.edgeless.systems/servicemesh-ingress: "web#8080#false##metrics#7890#true"
     spec:
       runtimeClassName: contrast-cc
       containers:
@@ -156,11 +157,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
-  annotations:
-    contrast.edgeless.systems/servicemesh-egress: "billing#127.137.0.1:8081#billing-svc:8080##cart#127.137.0.2:8081#cart-svc:8080"
 spec:
   replicas: 1
   template:
+    metadata:
+      annotations:
+        contrast.edgeless.systems/servicemesh-egress: "billing#127.137.0.1:8081#billing-svc:8080##cart#127.137.0.2:8081#cart-svc:8080"
     spec:
       runtimeClassName: contrast-cc
       containers:

--- a/docs/docs/architecture/k8s-yaml-elements.md
+++ b/docs/docs/architecture/k8s-yaml-elements.md
@@ -1,0 +1,18 @@
+# Overview of Contrast elements in Kubernetes YAML
+
+This document provides an overview of the Contrast elements that can be used in Kubernetes YAML files, particularly the Contrast specific annotations that can be applied to workloads.
+
+## Overview of Contrast annotations
+
+Before running the `contrast generate` command, you can customize its behavior by using various annotations, like skipping the Initializer injection or settings up the Service Mesh.
+These annotations can be added to the workload's Pod (Pod Template) metadata.
+The following table gives an overview of the available annotations and their purpose.
+
+| Annotation                                                   | Description                                                                                                                           |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `contrast.edgeless.systems/skip-initializer`                 | [Skip the Initializer injection for this workload.](../howto/workload-deployment/generate-annotations.md#skip-initializer-annotation) |
+| `contrast.edgeless.systems/servicemesh-ingress`              | [Setup the Service Mesh ingress for this workload.](components/service-mesh.md#configuring-the-proxy)                                 |
+| `contrast.edgeless.systems/servicemesh-egress`               | [Setup the Service Mesh egress for this workload.](components/service-mesh.md#configuring-the-proxy)                                  |
+| `contrast.edgeless.systems/servicemesh-admin-interface-port` | [Enable the Envoy admin interface for the Service Mesh on the specified port.](components/service-mesh.md#configuring-the-proxy)      |
+| `contrast.edgeless.systems/secure-pv`                        | [Enable secure storage for the workload by setting up a LUKS-encrypted volume.](secrets.md#secure-persistence)                        |
+| `contrast.edgeless.systems/workload-secret-id`               | [Specify the `workloadSecretID` to use for this workload.](secrets.md#workload-secrets)                                               |

--- a/docs/docs/architecture/secrets.md
+++ b/docs/docs/architecture/secrets.md
@@ -51,10 +51,10 @@ Remember that persistent volumes from the cloud provider are untrusted.
 Applications can set up trusted storage on top of an untrusted block device using the `contrast.edgeless.systems/secure-pv` annotation.
 This annotation enables `contrast generate` to configure the Initializer to set up a LUKS-encrypted volume at the specified device and mount it to a specified volume.
 The LUKS encryption utilizes the workload secret introduced above.
-Configure any workload resource with the following annotation:
+Configure any pod or pod template spec with the following annotation:
 
 ```yaml
-metadata:
+metadata: # v1.Pod, v1.PodTemplateSpec
   annotations:
     contrast.edgeless.systems/secure-pv: "device-name:mount-name"
 ```
@@ -68,11 +68,12 @@ Workload containers can then use the volume as a secure storage location:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  annotations:
-    contrast.edgeless.systems/secure-pv: "device:secure"
   name: my-statefulset
 spec:
   template:
+    metadata:
+      annotations:
+        contrast.edgeless.systems/secure-pv: "device:secure"
     spec:
       containers:
         - name: my-container

--- a/docs/docs/getting-started/deployment.md
+++ b/docs/docs/getting-started/deployment.md
@@ -204,34 +204,34 @@ This configuration exempts port 8080 from mTLS verification: clients can connect
 Altogether, we can configure the service mesh by adding the following annotations:
 
 ```diff title="resources/emojivoto-demo.yaml"
-@@ -1,6 +1,8 @@
- apiVersion: apps/v1
- kind: Deployment
- metadata:
-+  annotations:
-+    contrast.edgeless.systems/servicemesh-ingress: ""
-   labels:
-     app.kubernetes.io/name: emoji
-     app.kubernetes.io/part-of: emojivoto
-@@ -102,6 +104,8 @@
- apiVersion: apps/v1
- kind: Deployment
- metadata:
-+  annotations:
-+    contrast.edgeless.systems/servicemesh-ingress: ""
-   labels:
-     app.kubernetes.io/name: voting
-     app.kubernetes.io/part-of: emojivoto
-@@ -168,6 +172,9 @@
- apiVersion: apps/v1
- kind: Deployment
- metadata:
-+  annotations:
-+    contrast.edgeless.systems/servicemesh-egress: emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080
-+    contrast.edgeless.systems/servicemesh-ingress: web#8080#false
-   labels:
-     app.kubernetes.io/name: web
-     app.kubernetes.io/part-of: emojivoto
+@@ -14,6 +14,8 @@ spec:
+       version: v11
+   template:
+     metadata:
++      annotations:
++        contrast.edgeless.systems/servicemesh-ingress: ""
+       labels:
+         app.kubernetes.io/name: emoji-svc
+         version: v11
+@@ -115,6 +117,8 @@ spec:
+       version: v11
+   template:
+     metadata:
++      annotations:
++        contrast.edgeless.systems/servicemesh-ingress: ""
+       labels:
+         app.kubernetes.io/name: voting-svc
+         version: v11
+@@ -181,6 +185,9 @@ spec:
+       version: v11
+   template:
+     metadata:
++      annotations:
++        contrast.edgeless.systems/servicemesh-egress: emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080
++        contrast.edgeless.systems/servicemesh-ingress: web#8080#false
+       labels:
+         app.kubernetes.io/name: web-svc
+         version: v11
 ```
 
 These are all the changes you need to make to your deployment files.

--- a/docs/docs/howto/vault.md
+++ b/docs/docs/howto/vault.md
@@ -39,8 +39,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: vault
-  annotations:
-    contrast.edgeless.systems/secure-pv: state:share
+spec:
+  template:
+    metadata:
+      annotations:
+        contrast.edgeless.systems/secure-pv: state:share
 ```
 
 The Contrast Initializer, running as an init container, uses the workload secret located at `/contrast/secrets/workload-secret-seed` to generate an encryption key and initialize the block device `state` as a LUKS-encrypted partition.
@@ -60,6 +63,7 @@ spec:
   template:
     metadata:
       annotations:
+        contrast.edgeless.systems/secure-pv: state:share
         contrast.edgeless.systems/workload-secret-id: vault_unsealing
 ```
 

--- a/docs/docs/howto/workload-deployment/TLS-configuration.md
+++ b/docs/docs/howto/workload-deployment/TLS-configuration.md
@@ -32,10 +32,10 @@ The following example is for an application with these properties:
 - All other endpoints require client authentication.
 - The app connects to a Kubernetes service `backend.default:4001`, which requires client authentication.
 
-Add the following annotations to your workload:
+Add the following annotations to your pod or the pod template spec of your controller:
 
 ```yaml
-metadata: # apps/v1.Deployment, apps/v1.DaemonSet, ...
+metadata: # v1.Pod, v1.PodTemplateSpec
   annotations:
     contrast.edgeless.systems/servicemesh-ingress: "main#8001#false##metrics#8080#true"
     contrast.edgeless.systems/servicemesh-egress: "backend#127.0.0.2:4001#backend.default:4001"

--- a/docs/docs/howto/workload-deployment/generate-annotations.md
+++ b/docs/docs/howto/workload-deployment/generate-annotations.md
@@ -198,7 +198,7 @@ If you want to disable the Initializer injection for a specific workload with
 the `contrast-cc` runtime class, you can do so by adding an annotation to the workload.
 
 ```yaml
-metadata: # apps/v1.Deployment, apps/v1.DaemonSet, ...
+metadata: # v1.Pod, v1.PodTemplateSpec
   annotations:
     contrast.edgeless.systems/skip-initializer: "true"
 ```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -238,6 +238,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          label: "K8s YAML elements",
+          id: "architecture/k8s-yaml-elements",
+        },
+        {
+          type: "doc",
           label: "Features & limitations",
           id: "architecture/features-limitations",
         },

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -458,62 +458,30 @@ func MapPodSpecWithMeta(
 	if resource == nil {
 		return nil
 	}
+	var podAccessor PodSpecAccessor
 	switch r := resource.(type) {
 	case *applybatchv1.CronJobApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.JobTemplate != nil &&
-			r.Spec.JobTemplate.Spec != nil &&
-			r.Spec.JobTemplate.Spec.Template != nil &&
-			r.Spec.JobTemplate.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.JobTemplate.Spec.Template.Spec != nil {
-			r.Spec.JobTemplate.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.JobTemplate.Spec.Template.Spec = f(r.Spec.JobTemplate.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.JobTemplate.Spec.Template.Spec)
-		}
+		podAccessor = (&CronJobConfig{r}).PodTemplate()
 	case *applyappsv1.DaemonSetApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.Template != nil &&
-			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.Template.Spec != nil {
-			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
-		}
+		podAccessor = (&DaemonSetConfig{r}).PodTemplate()
 	case *applyappsv1.DeploymentApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.Template != nil &&
-			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.Template.Spec != nil {
-			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
-		}
+		podAccessor = (&DeploymentConfig{r}).PodTemplate()
 	case *applybatchv1.JobApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.Template != nil &&
-			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.Template.Spec != nil {
-			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
-		}
+		podAccessor = (&JobConfig{r}).PodTemplate()
 	case *applycorev1.PodApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec)
-		}
+		podAccessor = &PodConfig{r}
 	case *applyappsv1.ReplicaSetApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.Template != nil &&
-			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.Template.Spec != nil {
-			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
-		}
+		podAccessor = (&ReplicaSetConfig{r}).PodTemplate()
 	case *applycorev1.ReplicationControllerApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.Template != nil &&
-			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.Template.Spec != nil {
-			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
-		}
+		podAccessor = (&ReplicationControllerConfig{r}).PodTemplate()
 	case *applyappsv1.StatefulSetApplyConfiguration:
-		if r.Spec != nil &&
-			r.Spec.Template != nil &&
-			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-			r.Spec.Template.Spec != nil {
-			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+		podAccessor = (&StatefulSetConfig{r}).PodTemplate()
+	}
+	if podAccessor != nil {
+		meta := podAccessor.GetObjectMeta()
+		spec := podAccessor.GetPodSpec()
+		if meta != nil && spec != nil {
+			f(meta, spec)
 		}
 	}
 	return resource

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -27,6 +27,7 @@ const (
 	smEgressConfigAnnotationKey   = "contrast.edgeless.systems/servicemesh-egress"
 	smAdminInterfaceAnnotationKey = "contrast.edgeless.systems/servicemesh-admin-interface-port"
 	securePVAnnotationKey         = "contrast.edgeless.systems/secure-pv"
+	workloadSecretIDAnnotationKey = "contrast.edgeless.systems/workload-secret-id"
 )
 
 // AddInitializer adds an initializer and its shared volume to the resource.
@@ -284,18 +285,17 @@ func AddDmesg(resources []any) []any {
 		WithSecurityContext(SecurityContext().
 			WithPrivileged(true).SecurityContextApplyConfiguration)
 
-	addDmesg := func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration,
-	) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
+	addDmesg := func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
 		if spec.RuntimeClassName == nil || !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc") {
-			return meta, spec
+			return spec
 		}
 		spec.Containers = append(spec.Containers, *dmesgContainer)
-		return meta, spec
+		return spec
 	}
 
 	var out []any
 	for _, resource := range resources {
-		out = append(out, MapPodSpecWithMeta(resource, addDmesg))
+		out = append(out, MapPodSpec(resource, addDmesg))
 	}
 
 	return out
@@ -460,34 +460,34 @@ func MapPodSpecWithMeta(
 	}
 	switch r := resource.(type) {
 	case *applybatchv1.CronJobApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.JobTemplate != nil &&
 			r.Spec.JobTemplate.Spec != nil &&
 			r.Spec.JobTemplate.Spec.Template != nil &&
+			r.Spec.JobTemplate.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.JobTemplate.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.JobTemplate.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.JobTemplate.Spec.Template.Spec)
+			r.Spec.JobTemplate.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.JobTemplate.Spec.Template.Spec = f(r.Spec.JobTemplate.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.JobTemplate.Spec.Template.Spec)
 		}
 	case *applyappsv1.DaemonSetApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.Template != nil &&
+			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
 		}
 	case *applyappsv1.DeploymentApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.Template != nil &&
+			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
 		}
 	case *applybatchv1.JobApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.Template != nil &&
+			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
 		}
 	case *applycorev1.PodApplyConfiguration:
 		if r.ObjectMetaApplyConfiguration != nil &&
@@ -495,25 +495,25 @@ func MapPodSpecWithMeta(
 			r.ObjectMetaApplyConfiguration, r.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec)
 		}
 	case *applyappsv1.ReplicaSetApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.Template != nil &&
+			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
 		}
 	case *applycorev1.ReplicationControllerApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.Template != nil &&
+			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
 		}
 	case *applyappsv1.StatefulSetApplyConfiguration:
-		if r.ObjectMetaApplyConfiguration != nil &&
-			r.Spec != nil &&
+		if r.Spec != nil &&
 			r.Spec.Template != nil &&
+			r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 			r.Spec.Template.Spec != nil {
-			r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
+			r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec = f(r.Spec.Template.ObjectMetaApplyConfiguration, r.Spec.Template.Spec)
 		}
 	}
 	return resource

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -172,9 +172,9 @@ func TestAddInitializer(t *testing.T) {
 		{
 			name: "cryptsetup default",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc").
@@ -189,9 +189,9 @@ func TestAddInitializer(t *testing.T) {
 		{
 			name: "cryptsetup bad annotation",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{securePVAnnotationKey: "test"}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{securePVAnnotationKey: "test"}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc"),
@@ -201,9 +201,9 @@ func TestAddInitializer(t *testing.T) {
 		{
 			name: "cryptsetup no device",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc"),
@@ -213,9 +213,9 @@ func TestAddInitializer(t *testing.T) {
 		{
 			name: "cryptsetup volume is not an block device",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc").
@@ -310,9 +310,9 @@ func TestAddServiceMesh(t *testing.T) {
 		{
 			name: "default",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc"),
@@ -334,9 +334,9 @@ func TestAddServiceMesh(t *testing.T) {
 		{
 			name: "service mesh replaced",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithInitContainers(ServiceMeshProxy()).
@@ -347,9 +347,9 @@ func TestAddServiceMesh(t *testing.T) {
 		{
 			name: "volume reused",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc").
@@ -363,9 +363,9 @@ func TestAddServiceMesh(t *testing.T) {
 		{
 			name: "volume is not an EmptyDir",
 			d: applyappsv1.Deployment("test", "default").
-				WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
+						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc").

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -8,11 +8,39 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
+	applybatchv1 "k8s.io/client-go/applyconfigurations/batch/v1"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	applynodev1 "k8s.io/client-go/applyconfigurations/node/v1"
 	applyrbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 )
+
+// PodSpecAccessor is an interface for Kubernetes resources that have a PodSpec with corresponding ObjectMeta.
+type PodSpecAccessor interface {
+	GetObjectMeta() *applymetav1.ObjectMetaApplyConfiguration
+	GetPodSpec() *applycorev1.PodSpecApplyConfiguration
+}
+
+// PodTemplate wraps applycorev1.PodTemplateSpecApplyConfiguration.
+type PodTemplate struct {
+	*applycorev1.PodTemplateSpecApplyConfiguration
+}
+
+// GetObjectMeta returns the ObjectMeta of the Pod template.
+func (t *PodTemplate) GetObjectMeta() *applymetav1.ObjectMetaApplyConfiguration {
+	if t.PodTemplateSpecApplyConfiguration != nil && t.ObjectMetaApplyConfiguration != nil {
+		return t.ObjectMetaApplyConfiguration
+	}
+	return &applymetav1.ObjectMetaApplyConfiguration{}
+}
+
+// GetPodSpec returns the PodSpec of the Pod template.
+func (t *PodTemplate) GetPodSpec() *applycorev1.PodSpecApplyConfiguration {
+	if t.PodTemplateSpecApplyConfiguration != nil && t.Spec != nil {
+		return t.Spec
+	}
+	return &applycorev1.PodSpecApplyConfiguration{}
+}
 
 // DeploymentConfig wraps applyappsv1.DeploymentApplyConfiguration.
 type DeploymentConfig struct {
@@ -26,6 +54,14 @@ func Deployment(name, namespace string) *DeploymentConfig {
 		d.Namespace = nil
 	}
 	return &DeploymentConfig{d}
+}
+
+// PodTemplate returns the PodTemplate of the Deployment.
+func (c *DeploymentConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil && c.Spec.Template != nil {
+		return &PodTemplate{c.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
 }
 
 // DeploymentSpecConfig wraps applyappsv1.DeploymentSpecApplyConfiguration.
@@ -52,6 +88,14 @@ func DaemonSet(name, namespace string) *DaemonSetConfig {
 	return &DaemonSetConfig{d}
 }
 
+// PodTemplate returns the PodTemplate of the DaemonSet.
+func (c *DaemonSetConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil && c.Spec.Template != nil {
+		return &PodTemplate{c.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
+}
+
 // DaemonSetSpecConfig wraps applyappsv1.DaemonSetSpecApplyConfiguration.
 type DaemonSetSpecConfig struct {
 	*applyappsv1.DaemonSetSpecApplyConfiguration
@@ -76,6 +120,14 @@ func StatefulSet(name, namespace string) *StatefulSetConfig {
 	return &StatefulSetConfig{s}
 }
 
+// PodTemplate returns the PodTemplate of the StatefulSet.
+func (c *StatefulSetConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil && c.Spec.Template != nil {
+		return &PodTemplate{c.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
+}
+
 // StatefulSetSpecConfig wraps applyappsv1.StatefulSetSpecApplyConfiguration.
 type StatefulSetSpecConfig struct {
 	*applyappsv1.StatefulSetSpecApplyConfiguration
@@ -98,6 +150,77 @@ func Pod(name, namespace string) *PodConfig {
 		p.Namespace = nil
 	}
 	return &PodConfig{p}
+}
+
+// GetObjectMeta returns the ObjectMeta of the Pod.
+func (c *PodConfig) GetObjectMeta() *applymetav1.ObjectMetaApplyConfiguration {
+	if c.PodApplyConfiguration != nil && c.ObjectMetaApplyConfiguration != nil {
+		return c.ObjectMetaApplyConfiguration
+	}
+	return &applymetav1.ObjectMetaApplyConfiguration{}
+}
+
+// GetPodSpec returns the PodSpec of the Pod.
+func (c *PodConfig) GetPodSpec() *applycorev1.PodSpecApplyConfiguration {
+	if c.PodApplyConfiguration != nil && c.Spec != nil {
+		return c.Spec
+	}
+	return &applycorev1.PodSpecApplyConfiguration{}
+}
+
+// CronJobConfig wraps applybatchv1.CronJobApplyConfiguration.
+type CronJobConfig struct {
+	*applybatchv1.CronJobApplyConfiguration
+}
+
+// PodTemplate returns the PodTemplate of the CronJob.
+func (c *CronJobConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil &&
+		c.Spec.JobTemplate != nil &&
+		c.Spec.JobTemplate.Spec != nil &&
+		c.Spec.JobTemplate.Spec.Template != nil {
+		return &PodTemplate{c.Spec.JobTemplate.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
+}
+
+// JobConfig wraps applybatchv1.CronJobApplyConfiguration.
+type JobConfig struct {
+	*applybatchv1.JobApplyConfiguration
+}
+
+// PodTemplate returns the PodTemplate of the Job.
+func (c *JobConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil && c.Spec.Template != nil {
+		return &PodTemplate{c.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
+}
+
+// ReplicaSetConfig wraps applyappsv1.ReplicaSetApplyConfiguration.
+type ReplicaSetConfig struct {
+	*applyappsv1.ReplicaSetApplyConfiguration
+}
+
+// PodTemplate returns the PodTemplate of the ReplicaSet.
+func (c *ReplicaSetConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil && c.Spec.Template != nil {
+		return &PodTemplate{c.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
+}
+
+// ReplicationControllerConfig wraps applycorev1.ReplicationControllerApplyConfiguration.
+type ReplicationControllerConfig struct {
+	*applycorev1.ReplicationControllerApplyConfiguration
+}
+
+// PodTemplate returns the PodTemplate of the ReplicationController.
+func (c *ReplicationControllerConfig) PodTemplate() *PodTemplate {
+	if c.Spec != nil && c.Spec.Template != nil {
+		return &PodTemplate{c.Spec.Template}
+	}
+	return &PodTemplate{&applycorev1.PodTemplateSpecApplyConfiguration{}}
 }
 
 // LabelSelectorConfig wraps applymetav1.LabelSelectorApplyConfiguration.


### PR DESCRIPTION
Previously, we had two places where Contrast annotations could go:
- On the top level resource meta, e.g., service mesh and secure PV annotations.
- On the pod template meta, e.g., pod role, workload secret ID.

With this change, all Contrast annotations are specified in the pod template meta. All annotations are documented in a table in the docs.

This affects all workloads that define one of the following annotations:
- `contrast.edgeless.systems/skip-initializer`
- `contrast.edgeless.systems/servicemesh-ingress`
- `contrast.edgeless.systems/servicemesh-egress`
- `contrast.edgeless.systems/servicemesh-admin-interface-port`
- `contrast.edgeless.systems/secure-pv`

Running `contrast generate` on these workloads will ignore the annotations. To migrate, move the annotations from the top-level resource meta to the Pod Template Meta. The resulting YAML will be generated as before.