### PR TITLE
meshapi: add pod ip to mesh cert SANs

### DIFF
--- a/coordinator/internal/meshapi/meshapi.go
+++ b/coordinator/internal/meshapi/meshapi.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"log/slog"
+	"net"
 
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 	"github.com/edgelesssys/contrast/internal/manifest"
@@ -73,6 +74,10 @@ func (i *Server) NewMeshCert(ctx context.Context, _ *meshapi.NewMeshCertRequest)
 		return nil, status.Errorf(codes.PermissionDenied, "policy hash %s not found in manifest", hostData)
 	}
 	dnsNames := entry.SANs
+
+	if host, _, err := net.SplitHostPort(p.Addr.String()); err == nil {
+		dnsNames = append(dnsNames, host)
+	}
 
 	peerPubKey, err := x509.ParsePKIXPublicKey(peerPubKeyBytes)
 	if err != nil {

--- a/coordinator/internal/meshapi/meshapi_test.go
+++ b/coordinator/internal/meshapi/meshapi_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"log/slog"
+	"net"
 	"testing"
 
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
@@ -62,6 +63,7 @@ func TestNewMeshCert(t *testing.T) {
 		State: stateguard.NewStateForTest(se, m, nil, ca),
 	}
 	ctx := peer.NewContext(t.Context(), &peer.Peer{
+		Addr:     &net.TCPAddr{IP: net.IP{1, 2, 3, 4}},
 		AuthInfo: info,
 	})
 
@@ -75,6 +77,8 @@ func TestNewMeshCert(t *testing.T) {
 	certChain := certFromPEM(t, resp.CertChain)
 	require.Len(certChain, 2)
 	cert, intermediateCert := certChain[0], certChain[1]
+	require.Contains(cert.DNSNames, "test")
+	require.Contains(cert.IPAddresses, net.IP{1, 2, 3, 4})
 	assert.False(cert.IsCA)
 	assert.True(intermediateCert.IsCA)
 	assert.Equal(cert.AuthorityKeyId, intermediateCert.SubjectKeyId)


### PR DESCRIPTION
This adds the pod IP as a SAN to the mesh certificate of the pod, in addition to the already existing DNS name specified in the manifest.