### PR TITLE
ci/cleanup: don't depend on platform specifics

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -567,14 +567,23 @@
     name = "cleanup-containerd";
     runtimeInputs = with pkgs; [ containerd ];
     text = ''
+      declare address
+      if [[ -S "/host/run/k3s/containerd/containerd.sock" ]]; then
+        address="/host/run/k3s/containerd/containerd.sock"
+      elif [[ -S "/host/run/containerd/containerd.sock" ]]; then
+        address="/host/run/containerd/containerd.sock"
+      else
+        echo "No containerd socket found at /run/containerd/containerd.sock or /run/k3s/containerd/containerd.sock"
+        exit 1
+      fi
       while read -r image; do
-        ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io image rm --sync "$image"
+        ctr --address "$address" --namespace k8s.io image rm --sync "$image"
       done < <(
-        ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io image list |
+        ctr --address "$address" --namespace k8s.io image list |
           tail -n +2 |
           cut -d' ' -f1
       )
-      ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io content prune references
+      ctr --address "$address" --namespace k8s.io content prune references
     '';
   };
 

--- a/tools/bm-maintenance/cleanup-containerd.yml
+++ b/tools/bm-maintenance/cleanup-containerd.yml
@@ -19,11 +19,11 @@ spec:
           imagePullPolicy: Always
           command: ["cleanup-containerd"]
           volumeMounts:
-            - name: containerd-run
-              mountPath: /run/k3s/containerd/
+            - name: host-mount
+              mountPath: /host
       volumes:
-        - name: containerd-run
+        - name: host-mount
           hostPath:
-            path: /run/k3s/containerd/
+            path: /
             type: Directory
       restartPolicy: OnFailure

--- a/tools/bm-maintenance/cleanup.yml
+++ b/tools/bm-maintenance/cleanup.yml
@@ -58,8 +58,6 @@ spec:
           env:
             - name: HOST_MOUNT
               value: /host
-            - name: CONFIG
-              value: /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
             - name: SNAPSHOTTER
               value: nydus
           volumeMounts:


### PR DESCRIPTION
Automatically detect paths for containerd socket and config file.