### PR TITLE
[release/v1.12] overlays/cryptsetup: 2.8.0 -> 2.8.1

### DIFF
--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -90,4 +90,16 @@ final: prev:
           openssl = final.openssl_3;
         };
       };
+
+  cryptsetup = prev.cryptsetup.overrideAttrs (
+    finalAttrs: _prevAttrs: {
+      version = "2.8.1";
+      src = final.fetchurl {
+        url =
+          "mirror://kernel/linux/utils/cryptsetup/v${final.lib.versions.majorMinor finalAttrs.version}/"
+          + "${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+        hash = "sha256-LDN563ZZfcq1CRFEmwE+JpfEv/zHFtu/DZsOj7u0b7Q=";
+      };
+    }
+  );
 }


### PR DESCRIPTION
Backport of #1712 to `release/v1.12`.

Original description:

---

https://gitlab.com/cryptsetup/cryptsetup/-/raw/main/docs/v2.8.1-ReleaseNotes