### PR TITLE
cli/verifier: check servicemesh-egress annotation isn't empty

### DIFF
--- a/cli/verifier/servicemesh_egress.go
+++ b/cli/verifier/servicemesh_egress.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package verifier
+
+import (
+	"errors"
+
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+// ServiceMeshEgressNotEmpty verifies that the `contrast.edgeless.systems/servicemesh-egress` annotation
+// isn't empty if it exists.
+type ServiceMeshEgressNotEmpty struct{}
+
+// Verify verifies that the `contrast.edgeless.systems/servicemesh-egress` annotation
+// isn't empty if it exists.
+func (v *ServiceMeshEgressNotEmpty) Verify(toVerify any) error {
+	var findings error
+
+	kuberesource.MapPodSpecWithMeta(toVerify, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
+		for k, v := range meta.Annotations {
+			if k != "contrast.edgeless.systems/servicemesh-egress" {
+				continue
+			}
+			if v == "" {
+				findings = errors.Join(findings, errors.New("empty annotation content in \"contrast.edgeless.systems/servicemesh-egress\", which is likely to be an error"))
+			}
+		}
+
+		return meta, spec
+	})
+
+	return findings
+}

--- a/cli/verifier/servicemesh_egress_test.go
+++ b/cli/verifier/servicemesh_egress_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package verifier_test
+
+import (
+	"testing"
+
+	"github.com/edgelesssys/contrast/cli/verifier"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/stretchr/testify/require"
+)
+
+const deploymentNoAnnotations = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  template:
+    spec:
+      runtimeClassName: contrast-cc
+      containers:
+        - name: currency-conversion
+          image: ghcr.io/edgelesssys/conversion:v1.2.3@...
+`
+
+const deploymentWithEmptyEgressAnnotationInSpec = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        contrast.edgeless.systems/servicemesh-egress: ""
+    spec:
+      runtimeClassName: contrast-cc
+      containers:
+        - name: currency-conversion
+          image: ghcr.io/edgelesssys/conversion:v1.2.3@...
+`
+
+const deploymentWithGoodEgressAnnotationInSpec = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        contrast.edgeless.systems/servicemesh-egress: "asdf"
+    spec:
+      runtimeClassName: contrast-cc
+      containers:
+        - name: currency-conversion
+          image: ghcr.io/edgelesssys/conversion:v1.2.3@...
+`
+
+func TestServiceMeshEgress(t *testing.T) {
+	testCases := map[string]struct {
+		k8sYaml string
+		wantErr bool
+	}{
+		"no annotations": {
+			k8sYaml: deploymentNoAnnotations,
+		},
+		"bad spec": {
+			k8sYaml: deploymentWithEmptyEgressAnnotationInSpec,
+			wantErr: true,
+		},
+		"good spec": {
+			k8sYaml: deploymentWithGoodEgressAnnotationInSpec,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			toVerifySlice, err := kuberesource.UnmarshalApplyConfigurations([]byte(tc.k8sYaml))
+			require.NoError(err)
+
+			verifier := verifier.ServiceMeshEgressNotEmpty{}
+
+			for _, toVerify := range toVerifySlice {
+				err := verifier.Verify(toVerify)
+				if tc.wantErr {
+					require.Error(err)
+				} else {
+					require.NoError(err)
+				}
+			}
+		})
+	}
+}

--- a/cli/verifier/verifiers.go
+++ b/cli/verifier/verifiers.go
@@ -7,6 +7,7 @@ package verifier
 func AllVerifiersBeforeGenerate() []Verifier {
 	return []Verifier{
 		&ImageRefValid{},
+		&ServiceMeshEgressNotEmpty{},
 	}
 }
 


### PR DESCRIPTION
This PR adds a verifier that checks that the `contrast.edgeless.systems/servicemesh-egress` annotation is not empty.

Previously, setting the annotation to the empty string would disable egress but trigger ingress to be activated, which is likely not the intended behavior. The correct way to prevent egress rules setup is to not add the egress annotation.