### PR TITLE
service-mesh: use envoy-bin package

### DIFF
--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -109,7 +109,7 @@ let
       tag = "v${pkgs.service-mesh.version}";
       copyToRoot = with pkgs; [
         busybox
-        envoy
+        envoy-bin
         iptables-legacy
       ];
       config = {


### PR DESCRIPTION
Reducing burden to recompile on our side, also this gets faster/more regular security updates.