### PR TITLE
ci: fix post to teams action

### DIFF
--- a/.github/actions/post_to_teams/action.yml
+++ b/.github/actions/post_to_teams/action.yml
@@ -32,23 +32,23 @@ runs:
         cp .github/actions/post_to_teams/teams_card_template.json template.json
 
         # add the title
-        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[0].text = "${INPUTS_TITLE}"' ./template.json
+        yq -oj -iP ".attachments[0].content.body[0].columns[1].items[0].text = \"${INPUTS_TITLE}\"" ./template.json
 
         # add the message
-        yq -oj -iP '.attachments[0].content.body[1].text = "${INPUTS_MESSAGE}"' ./template.json
+        yq -oj -iP ".attachments[0].content.body[1].text = \"${INPUTS_MESSAGE}\"" ./template.json
 
         # add the run url to the clickable button
-        yq -oj -iP '.attachments[0].content.actions[0].url = "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"' ./template.json
+        yq -oj -iP ".attachments[0].content.actions[0].url = \"${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}\"" ./template.json
 
         # update the fact set
-        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[1].facts[0].value = "${{github.run_id}}"' ./template.json
-        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[1].facts[1].value = "${GITHUB_REF_NAME}"' ./template.json
+        yq -oj -iP ".attachments[0].content.body[0].columns[1].items[1].facts[0].value = \"${{github.run_id}}\"" ./template.json
+        yq -oj -iP ".attachments[0].content.body[0].columns[1].items[1].facts[1].value = \"${GITHUB_REF_NAME}\"" ./template.json
 
         # add additional fields
-        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[1].facts += ${INPUTS_ADDITIONALFIELDS}' ./template.json
+        yq -oj -iP ".attachments[0].content.body[0].columns[1].items[1].facts += ${INPUTS_ADDITIONALFIELDS}" ./template.json
 
         # add additional buttons
-        yq -oj -iP '.attachments[0].content.actions += ${INPUTS_ADDITIONALACTIONS}' ./template.json
+        yq -oj -iP ".attachments[0].content.actions += ${INPUTS_ADDITIONALACTIONS}" ./template.json
 
         payload="$(cat ./template.json)"
         curl \


### PR DESCRIPTION
Correctly expand shell variables in yq query, so the action does not fail.