### PR TITLE
cli/verifiers: before and after verifiers

### DIFF
--- a/cli/verifier/verifiers.go
+++ b/cli/verifier/verifiers.go
@@ -3,8 +3,13 @@
 
 package verifier
 
-// AllVerifiers returns all verifiers for k8s objects.
-func AllVerifiers() []Verifier {
+// AllVerifiersBeforeGenerate returns all verifiers for k8s objects that should be run before generate.
+func AllVerifiersBeforeGenerate() []Verifier {
+	return []Verifier{}
+}
+
+// AllVerifiersAfterGenerate returns all verifiers for k8s objects that should be run after generate.
+func AllVerifiersAfterGenerate() []Verifier {
 	return []Verifier{
 		&NoSharedFSMount{},
 	}


### PR DESCRIPTION
Splits verifiers into the ones running before and the ones running after generate. Fixes the vault e2e test.

https://github.com/edgelesssys/contrast/actions/runs/17263866219