### PR TITLE
[release/v1.12] initializer: don't log NewMeshCert response

### DIFF
--- a/initializer/main.go
+++ b/initializer/main.go
@@ -128,7 +128,7 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 	for {
 		resp, err = requestCert()
 		if err == nil {
-			log.Info("Requesting cert", "response", resp)
+			log.Info("Successfully requested cert from Coordinator")
 			break
 		}
 		log.Warn("Requesting cert", "err", err)


### PR DESCRIPTION
Backport of #1735 to `release/v1.12`.

Original description:

---

