### PR TITLE
e2e: add missing GPU error to known dmesg lines

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -310,11 +310,12 @@ func TestOpenSSL(t *testing.T) {
 			"[Firmware Bug]: Failed to parse event in TPM Final Events Log",
 			"ACPI BIOS Error (bug): Failure creating named object [\\_GPE._HID], AE_ALREADY_EXISTS (20240827/dswload2-326)",
 			"ACPI Error: AE_ALREADY_EXISTS, During name lookup/catalog (20240827/psobject-220)",
+			"NVRM: No NVIDIA GPU found", // openssl test does not use a GPU
 		}
-		for _, line := range strings.Split(strings.TrimSpace(dmesgOutput), "\n") {
-			require.True(slices.ContainsFunc(knownErrors, func(knownError string) bool {
+		for line := range strings.SplitSeq(strings.TrimSpace(dmesgOutput), "\n") {
+			assert.True(t, slices.ContainsFunc(knownErrors, func(knownError string) bool {
 				return strings.Contains(line, knownError)
-			}), "dmesg line does not contain known error: %s", line)
+			}), "unexpected dmesg error: %q", line)
 		}
 	})
 }


### PR DESCRIPTION
Resolves the issue encountered in https://github.com/edgelesssys/contrast/actions/runs/17285924414/job/49063068272#step:10:214, where we run the e2e test with the GPU runtime but don't have a GPU added to the pod under test.