### PR TITLE
kata.kata-runtime: pass imagepuller error to kata

### DIFF
--- a/packages/by-name/kata/kata-runtime/0021-agent-use-custom-implementation-for-image-pulling.patch
+++ b/packages/by-name/kata/kata-runtime/0021-agent-use-custom-implementation-for-image-pulling.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] agent: use custom implementation for image pulling
 
 Signed-off-by: Charlotte Hartmann Paludo <git@charlotteharludo.com>
 ---
- src/agent/src/confidential_data_hub/mod.rs | 33 ++++++++++++++++------
- 1 file changed, 25 insertions(+), 8 deletions(-)
+ src/agent/src/confidential_data_hub/mod.rs | 30 ++++++++++++++++------
+ 1 file changed, 22 insertions(+), 8 deletions(-)
 
 diff --git a/src/agent/src/confidential_data_hub/mod.rs b/src/agent/src/confidential_data_hub/mod.rs
-index 7099251d31f4577e9979c8128f79ee9d0e811952..b47edf7a641420fa6bbcb4ca10e47463cb9ec730 100644
+index 7099251d31f4577e9979c8128f79ee9d0e811952..9f528185535191dae06ed95b942c12f1032c7396 100644
 --- a/src/agent/src/confidential_data_hub/mod.rs
 +++ b/src/agent/src/confidential_data_hub/mod.rs
 @@ -8,7 +8,7 @@
@@ -21,7 +21,7 @@ index 7099251d31f4577e9979c8128f79ee9d0e811952..b47edf7a641420fa6bbcb4ca10e47463
  use anyhow::{bail, Context, Result};
  use derivative::Derivative;
  use protocols::{
-@@ -182,18 +182,35 @@ pub async fn pull_image(image: &str, bundle_path: PathBuf) -> Result<String> {
+@@ -182,18 +182,32 @@ pub async fn pull_image(image: &str, bundle_path: PathBuf) -> Result<String> {
      fs::create_dir_all(&bundle_path)?;
      info!(sl(), "pull image {image:?}, bundle path {bundle_path:?}");
  
@@ -32,10 +32,7 @@ index 7099251d31f4577e9979c8128f79ee9d0e811952..b47edf7a641420fa6bbcb4ca10e47463
 -    cdh_client
 -        .pull_image(image, bundle_path.to_string_lossy().as_ref())
 -        .await?;
-+    match pull_image_contrast(image, bundle_path.to_string_lossy().as_ref()).await {
-+        Err(e) => warn!(sl(), "Encountered an error while pulling the image: {e}"),
-+        Ok(()) => {}
-+    };
++    pull_image_contrast(image, bundle_path.to_string_lossy().as_ref()).await?;
  
      let image_bundle_path = scoped_join(&bundle_path, "rootfs")?;
      Ok(image_bundle_path.as_path().display().to_string())


### PR DESCRIPTION
Previously, when an error occurred during image pulling or unpacking, the relevant error message was not forwarded to the kata-agent and not readable from the pod's logs. Instead, the next step in container initialization failed with an unhelpful error message.

This PR fixes this, and failures in image pulling/unpacking should now be logged using more helpful and failure-specific messages.