### PR TITLE
e2e: skip empty dmesg lines

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -312,7 +312,12 @@ func TestOpenSSL(t *testing.T) {
 			"ACPI Error: AE_ALREADY_EXISTS, During name lookup/catalog (20240827/psobject-220)",
 			"NVRM: No NVIDIA GPU found", // openssl test does not use a GPU
 		}
-		for line := range strings.SplitSeq(strings.TrimSpace(dmesgOutput), "\n") {
+		for line := range strings.SplitSeq(dmesgOutput, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			t.Logf("Analyzing dmesg log line %q", line)
 			assert.True(t, slices.ContainsFunc(knownErrors, func(knownError string) bool {
 				return strings.Contains(line, knownError)
 			}), "unexpected dmesg error: %q", line)


### PR DESCRIPTION
It's not quite clear where they are coming from, but we encountered empty lines in scheduled e2e tests. This change skips empty lines and logs the remaining lines so that they can be observed in test logs, even if they were expected.

https://github.com/edgelesssys/contrast/actions/runs/17352579175/job/49261161878#step:10:216

```
     openssl_test.go:316: 
        	Error Trace:	github.com/edgelesssys/contrast/e2e/openssl/openssl_test.go:316
        	            				strings/iter.go:61
        	            				github.com/edgelesssys/contrast/e2e/openssl/openssl_test.go:315
        	Error:      	Should be true
        	Test:       	TestOpenSSL/dmesg_contains_no_errors
        	Messages:   	unexpected dmesg error: ""
```