### PR TITLE
contrast-releases: fix runtime existence

### DIFF
--- a/packages/contrast-releases.nix
+++ b/packages/contrast-releases.nix
@@ -139,12 +139,16 @@ let
                   (versionGreaterEqual version "v1.4.0")
                 else if (platform == "k3s-qemu-snp-gpu") then
                   (versionGreaterEqual version "v1.4.0")
-                  # platform removed in release v1.12.0
-                  && (versionLessThan version "v1.12.0")
-                else if (lib.hasPrefix "k3s-qemu" platform) then
+                  # platform removed in release v1.13.0
+                  && (versionLessThan version "v1.13.0")
+                else if
+                  (lib.hasPrefix "k3s-qemu" platform)
+                  || (lib.hasPrefix "rke2-qemu" platform)
+                  || (platform == "aks-clh-snp")
+                then
                   (versionGreaterEqual version "v1.1.0")
-                  # platform removed in release v1.12.0
-                  && (versionLessThan version "v1.12.0")
+                  # platform removed in release v1.13.0
+                  && (versionLessThan version "v1.13.0")
                 else
                   (versionGreaterEqual version "v1.1.0");
             }


### PR DESCRIPTION
- removed version was wrong for k3s runtimes
- missed removal of rke2
- missed removal of aks