### PR TITLE
kuberesource: default target config to kube-system namespace

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -421,14 +421,14 @@ func (ct *ContrastTest) installRuntime(t *testing.T) {
 
 	resources, err := kuberesource.Runtime(ct.Platform)
 	require.NoError(err)
-	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
-	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
-
 	if ct.NodeInstallerTargetConfType != "" && ct.NodeInstallerTargetConfType != "none" {
-		nodeInstallerTargetConf, err := kuberesource.NodeInstallerTargetConfig(ct.NodeInstallerTargetConfType, ct.Namespace)
+		nodeInstallerTargetConf, err := kuberesource.NodeInstallerTargetConfig(ct.NodeInstallerTargetConfType)
 		require.NoError(err)
 		resources = append(resources, nodeInstallerTargetConf)
 	}
+
+	resources = kuberesource.PatchImages(resources, ct.ImageReplacements)
+	resources = kuberesource.PatchNamespaces(resources, ct.Namespace)
 
 	unstructuredResources, err := kuberesource.ResourcesToUnstructured(resources)
 	require.NoError(err)

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -482,6 +482,8 @@ func PatchNamespaces(resources []any, namespace string) []any {
 			r.Namespace = nsPtr
 		case *applyrbacv1.RoleApplyConfiguration:
 			r.Namespace = nsPtr
+		case *applycorev1.ConfigMapApplyConfiguration:
+			r.Namespace = nsPtr
 		case *applyrbacv1.RoleBindingApplyConfiguration:
 			r.Namespace = nsPtr
 			for i := range len(r.Subjects) {

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -168,10 +168,11 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 }
 
 // NodeInstallerTargetConfig returns a ConfigMap for the passed target.
-func NodeInstallerTargetConfig(target, namespace string) (*applycorev1.ConfigMapApplyConfiguration, error) {
+func NodeInstallerTargetConfig(target string) (*applycorev1.ConfigMapApplyConfiguration, error) {
+	ns := "kube-system"
 	switch target {
 	case "k3s":
-		return applycorev1.ConfigMap("contrast-node-installer-target-config", namespace).
+		return applycorev1.ConfigMap("contrast-node-installer-target-config", ns).
 			WithData(map[string]string{
 				"containerd-config-path": "var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl",
 				"systemd-unit-name":      "k3s.service,k3s-agent.service",

--- a/internal/kuberesource/resourcegen/main.go
+++ b/internal/kuberesource/resourcegen/main.go
@@ -52,7 +52,7 @@ func main() {
 				log.Fatalf("--node-installer-target-conf-type must be set")
 			}
 			subResources = make([]any, 1)
-			subResources[0], err = kuberesource.NodeInstallerTargetConfig(*nodeInstallerTargetConfType, *namespace)
+			subResources[0], err = kuberesource.NodeInstallerTargetConfig(*nodeInstallerTargetConfType)
 		case "openssl":
 			subResources = kuberesource.PatchRuntimeHandlers(kuberesource.OpenSSL(), "contrast-cc")
 		case "emojivoto":


### PR DESCRIPTION
The release artifact used the wrong namespace, so the node-installer couldn't find it. The fix adapts the same namespace handling as with the runtime: default to kube-system, use PatchNamespaces in development/e2e.