### PR TITLE
ci: remove imagestore from e2e regression

### DIFF
--- a/.github/workflows/e2e_regression.yml
+++ b/.github/workflows/e2e_regression.yml
@@ -33,7 +33,7 @@ jobs:
           - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
-        test-name: [genpolicy-unsupported, imagestore, regression]
+        test-name: [genpolicy-unsupported, regression]
       fail-fast: false
     name: "${{ matrix.platform.name }}"
     uses: ./.github/workflows/e2e.yml


### PR DESCRIPTION
Tests can't be in regression and nightly e2e at the same time, otherwise they are executed twice and their names collide in the logs upload on release.

See https://github.com/edgelesssys/contrast/actions/runs/17490862857/job/49680438660