### PR TITLE
ci/bm-maintenance: upgrade sync-server

### DIFF
--- a/.github/workflows/bm_maintenance.yml
+++ b/.github/workflows/bm_maintenance.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Update sync fifo for GPU platform
         if: ${{ matrix.platform.name == 'Metal-QEMU-SNP-GPU' }}
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/83b56a5022bb5c6e796e8b5dfee6ce8dca951435/server/deployment.yml
+          kubectl apply -f https://raw.githubusercontent.com/katexochen/sync/9567164967b5832fb4992088af89dbbd94184043/server/deployment.yml
           kubectl rollout status statefulset/sync --timeout=5m
           kubectl wait --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' --timeout=5m svc/sync
           nix run .#scripts.renew-sync-fifo


### PR DESCRIPTION
This should fix the sporadic failures where an E2E test waits forever in the sync queue.