### PR TITLE
ci: accept 429s, retry more slowly

### DIFF
--- a/tools/lychee/config.toml
+++ b/tools/lychee/config.toml
@@ -7,7 +7,6 @@ cache_exclude_status = [
     "300..600",
 ]
 include_fragments = true
-retry_wait_time = 20
 fallback_extensions = ["md", "html"]
 exclude = [
     '^https://mysql\.com/', # returns 403
@@ -22,3 +21,9 @@ exclude_path = [
 # https://github.com/lycheeverse/lychee/issues/1593
 threads = 1
 max_concurrency = 1
+
+# Make Too Many Requests (429) less likely,
+# and accept as to not block the CI.
+retry_wait_time = 30
+max_retries = 1
+accept = ["200", "429"]


### PR DESCRIPTION
Linkcheck CI constantly fails due to 429s (esp. from hashicorp). Since we are only caching for one day anyways, accepting 429s should be OK.