### PR TITLE
e2e: abort hanging connections early

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -201,7 +201,7 @@ handler() {
 trap handler TERM
 set -x
 for port in ${LISTEN_PORTS}; do
-  socat -d -d TCP-LISTEN:$port,fork TCP:${FORWARD_HOST}:$port &
+  socat -d -d TCP-LISTEN:$port,fork TCP:${FORWARD_HOST}:$port,connect-timeout=2,retry=1 &
 done
 wait
 `

--- a/tools/lychee/config.toml
+++ b/tools/lychee/config.toml
@@ -13,6 +13,7 @@ exclude = [
     '^https://mysql\.com/', # returns 403
     '^http(s)?://localhost',
     '^https://github\.com/edgelesssys/contrast/(settings|deployments)', # not public
+    '^https://.*\.hashicorp\.com', # strict bot protection
 ]
 exclude_path = [
     "dev-docs/frozen",


### PR DESCRIPTION
We often see e2e tests that time out while waiting for a connection proxied by socat. This can happen if the target endpoint was not quite available yet, for example when the routes were not yet established. In its default configuration, socat keeps waiting for the SYN/ACK to arrive, possibly until the kernel gives up on the connection.

What we actually want in this case is to abort the connection attempt and retry it. This needs to be done in socat, because the client can't tell the difference between an established connection that's not sending data and a connection being initiated between socat and the backend. Thus, we configure the connection timeout at 2s, which should be plenty for reachable endpoints in the same cluster, but short enough to avoid a test timeout. Adding a retry on the socat level should also reduce the need for retries at the client/test level.

---

This should help with errors like this:

```
time=2025-09-08T05:05:30.219Z level=ERROR msg="port-forwarded func failed" attempt=0 namespace=testopenssl-9c40ac10-ci pod=port-forwarder-coordinator port=1313 error="running \"verify\": time=2025-09-08T05:05:00.208Z level=DEBUG msg=\"Starting verification\"\ntime=2025-09-08T05:05:00.208Z level=DEBUG msg=\"Using KDS cache dir\" dir=/home/github/.cache/contrast/kds\ntime=2025-09-08T05:05:00.218Z level=DEBUG msg=\"Dialing coordinator\" endpoint=0.0.0.0:44811\ntime=2025-09-08T05:05:00.218Z level=DEBUG msg=\"Getting manifest\"\nError: getting manifests: getting manifests: rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: context deadline exceeded\"\n"
```

Instead of timing out, the error will now be an `EOF` after 2s, which is then retried by the port-forwarder.