### PR TITLE
cli/verifier: add `VersionsMatch`

### DIFF
--- a/cli/verifier/verifiers.go
+++ b/cli/verifier/verifiers.go
@@ -3,6 +3,10 @@
 
 package verifier
 
+import (
+	"github.com/edgelesssys/contrast/internal/constants"
+)
+
 // AllVerifiersBeforeGenerate returns all verifiers for k8s objects that should be run before generate.
 func AllVerifiersBeforeGenerate() []Verifier {
 	return []Verifier{
@@ -20,6 +24,7 @@ func AllVerifiersAfterGenerate() []Verifier {
 	return []Verifier{
 		&NoSharedFSMount{},
 		&ImageRefValid{},
+		&VersionsMatch{Version: constants.Version},
 	}
 }
 

--- a/cli/verifier/versions_match.go
+++ b/cli/verifier/versions_match.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package verifier
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/regclient/regclient/types/ref"
+
+	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+// VersionsMatch verifies that the cli version matches the version of the used resources.
+type VersionsMatch struct {
+	Version string
+}
+
+// Verify verifies that the cli version matches the version of the used resources.
+func (v *VersionsMatch) Verify(toVerify any) error {
+	// ignore this verifier for preview and dev builds.
+	if strings.Contains(v.Version, "dev") || strings.Contains(v.Version, "pre") {
+		return nil
+	}
+
+	var findings error
+
+	kuberesource.MapPodSpecWithMeta(toVerify, func(
+		meta *applymetav1.ObjectMetaApplyConfiguration,
+		spec *applycorev1.PodSpecApplyConfiguration,
+	) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
+		if spec.RuntimeClassName == nil || !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc") {
+			return meta, spec
+		}
+
+		for _, container := range spec.Containers {
+			if !needsImageVersionCheck(*container.Name, meta.Annotations["contrast.edgeless.systems/pod-role"]) {
+				continue
+			}
+			if container.Image == nil || *container.Image == "" {
+				continue
+			}
+
+			r, err := ref.New(*container.Image)
+			if err != nil {
+				findings = errors.Join(findings, fmt.Errorf("could not parse image reference %q: %w", *container.Image, err))
+				continue
+			}
+			if r.Tag == "" {
+				continue
+			}
+
+			if r.Tag != v.Version {
+				findings = errors.Join(findings, fmt.Errorf("version mismatch: you are attempting to use Contrast version %q with a %q resource of version %q",
+					v.Version, *container.Name, r.Tag))
+			}
+		}
+		return meta, spec
+	})
+
+	return findings
+}
+
+func needsImageVersionCheck(containerName string, podRole string) bool {
+	if slices.Contains([]string{"contrast-initializer", "contrast-service-mesh"}, containerName) {
+		return true
+	}
+	if containerName == "coordinator" && podRole == "coordinator" {
+		return true
+	}
+	return false
+}

--- a/cli/verifier/versions_match_test.go
+++ b/cli/verifier/versions_match_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package verifier_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/edgelesssys/contrast/cli/verifier"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	coordinatorWithVersionTemplate = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+  annotations:
+    contrast.edgeless.systems/pod-role: %s
+spec:
+  runtimeClassName: contrast-cc
+  containers:
+    - name: coordinator
+      image: ghcr.io/edgelesssys/contrast/coordinator:%s@sha256:65e7832acb46d952d5c96c824d6f370999b8f3d547b3c2c449e82d8dc4b4816c
+`
+
+	statefulSetWithVersionTemplate = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      runtimeClassName: contrast-cc
+      containers:
+        - name: contrast-initializer
+          image: ghcr.io/edgelesssys/contrast/coordinator:%s@sha256:65e7832acb46d952d5c96c824d6f370999b8f3d547b3c2c449e82d8dc4b4816c
+`
+
+	podWithoutVersion = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  runtimeClassName: contrast-cc
+  containers:
+    - name: contrast-initializer
+      image: ghcr.io/edgelesssys/contrast/coordinator@sha256:65e7832acb46d952d5c96c824d6f370999b8f3d547b3c2c449e82d8dc4b4816c
+`
+)
+
+func TestVerifyVersionsMatch(t *testing.T) {
+	testCases := map[string]struct {
+		k8sObjectYAML []byte
+		version       string
+		wantErr       bool
+	}{
+		"versions match": {
+			k8sObjectYAML: fmt.Appendf(nil, statefulSetWithVersionTemplate, "v1.13.0"),
+			version:       "v1.13.0",
+		},
+		"versions match with pod-role": {
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "coordinator", "v1.13.0"),
+			version:       "v1.13.0",
+		},
+		"cli version newer": {
+			k8sObjectYAML: fmt.Appendf(nil, statefulSetWithVersionTemplate, "v1.12.0"),
+			version:       "v1.13.0",
+			wantErr:       true,
+		},
+		"cli version older": {
+			k8sObjectYAML: fmt.Appendf(nil, statefulSetWithVersionTemplate, "v1.13.0"),
+			version:       "v1.12.0",
+			wantErr:       true,
+		},
+		"cli version mismatch with pod-role": {
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "coordinator", "v1.13.0"),
+			version:       "v1.12.0",
+			wantErr:       true,
+		},
+		"cli version mismatch with differing pod-role unaffected": {
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "not-coordinator", "v1.13.0"),
+			version:       "v1.12.0",
+		},
+		"resource missing version skipped": {
+			k8sObjectYAML: []byte(podWithoutVersion),
+			version:       "v1.13.0",
+		},
+		"resource missing version skipped, dev build": {
+			k8sObjectYAML: []byte(podWithoutVersion),
+			version:       "v0.0.0-dev",
+		},
+		"resource with version, dev build": {
+			k8sObjectYAML: fmt.Appendf(nil, statefulSetWithVersionTemplate, "v1.13.0"),
+			version:       "v0.0.0-dev",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			toVerifySlice, err := kuberesource.UnmarshalApplyConfigurations(tc.k8sObjectYAML)
+			require.NoError(err)
+
+			verifier := verifier.VersionsMatch{Version: tc.version}
+
+			for _, toVerify := range toVerifySlice {
+				err := verifier.Verify(toVerify)
+				if tc.wantErr {
+					require.Error(err)
+				} else {
+					require.NoError(err)
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.66.1
+	github.com/regclient/regclient v0.9.2
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
+github.com/regclient/regclient v0.9.2 h1:5mJYY3NSV7xtBCv+Me3mbfcNJg9u7nrNt/Z6Od7QjVM=
+github.com/regclient/regclient v0.9.2/go.mod h1:QOi29pa84xH+AA56bQwQbzw3RZDwqHrG15KTXGeO+Q8=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -197,7 +197,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-p/Z7f2xeOcI8JYdnqWCi11Z9kHwsc4pZnSA8jBQN0Hg=";
+  vendorHash = "sha256-rSz3n5pyFyIw5GNanrn2eJrgnfLmJBw5gnokskEPSnA=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Version mismatches between the Contrast CLI and the Contrast resources used (specifically, the `coordinator`, `initializer` and `service-mesh-proxy`) can lead to hard-to-debug errors.

Starting with this PR, `contrast generate` will fail if a version mismatch is encountered. The error message will inform you which resource needs updating.