### PR TITLE
e2e: add openssl logging for unexpected success

### DIFF
--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -269,7 +269,10 @@ func TestOpenSSL(t *testing.T) {
 		})
 
 		t.Run("coordinator can't recover mesh CA key", func(t *testing.T) {
-			_, _, err := c.ExecDeployment(ctx, ct.Namespace, opensslBackend, []string{"/bin/sh", "-c", opensslConnectCmd("openssl-frontend:443", meshCAFile)})
+			stdout, stderr, err := c.ExecDeployment(ctx, ct.Namespace, opensslBackend, []string{"/bin/sh", "-c", opensslConnectCmd("openssl-frontend:443", meshCAFile)})
+			if err == nil {
+				t.Logf("openssl with %q after recovery: stdout\n%s\n\nstderr:\n%s", meshCAFile, stdout, stderr)
+			}
 			assert.Error(t, err)
 		})
 


### PR DESCRIPTION
This happened in a CI flake the other day. Although the issue was likely an earlier failing test, it would be good to have the openssl connection logs for debugging this situation.