### PR TITLE
internal/cryptsetup: print full header on verify error

### DIFF
--- a/internal/cryptsetup/cryptsetup.go
+++ b/internal/cryptsetup/cryptsetup.go
@@ -169,7 +169,19 @@ func (d *Device) verifyBinaryHeader() error {
 	return nil
 }
 
-func (d *Device) verifyHeader(header cryptsetupMetadata) error {
+func (d *Device) verifyHeader(header cryptsetupMetadata) (retErr error) {
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		headerJSON, err := json.Marshal(header)
+		if err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("marshaling header for debug output: %w", err))
+			return
+		}
+		retErr = errors.Join(retErr, fmt.Errorf("full header content: %s", string(headerJSON)))
+	}()
+
 	if len(header.KeySlots) != 1 {
 		return fmt.Errorf("expected exactly one keyslot, got %d", len(header.KeySlots))
 	}


### PR DESCRIPTION
```
time=2025-09-26T07:17:05.595Z level=ERROR msg="setting up encrypted mount: opening LUKS device /dev/csi0: verifying LUKS he
ader from /dev/shm/contrast-cryptsetup/luks-header-c15dd8bf: test error to trigger full header printout\nfull header conten
t: {\"keyslots\":{\"0\":{\"type\":\"luks2\",\"key_size\":96,\"af\":{\"type\":\"luks1\",\"stripes\":4000,\"hash\":\"sha256\"
},\"area\":{\"type\":\"raw\",\"offset\":\"32768\",\"size\":\"385024\",\"encryption\":\"aes-xts-plain64\",\"key_size\":64},\
"kdf\":{\"type\":\"argon2id\",\"time\":469,\"memory\":10240,\"cpus\":1,\"salt\":\"GJuO5i46uyQ8cuqcvUtDD1ejn3i71UDUsamgTygX/
vc=\"}}},\"tokens\":{},\"segments\":{\"0\":{\"type\":\"crypt\",\"offset\":\"16777216\",\"size\":\"dynamic\",\"iv_tweak\":\"
0\",\"encryption\":\"aes-xts-plain64\",\"sector_size\":4096,\"integrity\":{\"type\":\"hmac(sha256)\",\"journal_encryption\"
:\"none\",\"journal_integrity\":\"none\",\"key_size\":0}}},\"digests\":{\"0\":{\"type\":\"pbkdf2\",\"keyslots\":[\"0\"],\"s
egments\":[\"0\"],\"hash\":\"sha256\",\"iterations\":333941,\"salt\":\"mZnkw1mdzhcjXCN/BZK3Rm/PcIJo2QCukZnSqeuOPXQ=\",\"dig
est\":\"QfH1G18NklyFgBzYCS5Vb/9ndTQ1fFfiFPOOEE3pWsA=\"}},\"Config\":{\"json_size\":\"12288\",\"keyslots_size\":\"16744448\"
}}"
```