### PR TITLE
initdata: add FromDevice function

### DIFF
--- a/internal/initdata/initdata.go
+++ b/internal/initdata/initdata.go
@@ -9,10 +9,13 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"slices"
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
@@ -81,7 +84,11 @@ func DecodeKataAnnotation(annotation string) (*Initdata, error) {
 		return nil, err
 	}
 
-	decompressed, err := decompress(decoded)
+	return decodeGzipped(decoded)
+}
+
+func decodeGzipped(data []byte) (*Initdata, error) {
+	decompressed, err := decompress(data)
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +133,41 @@ func (i *Initdata) EncodeKataAnnotation() (string, string, error) {
 	}
 
 	return encoded, digest, nil
+}
+
+// FromDevice reads initdata from a block device prepared by the Kata runtime.
+func FromDevice(devicePath string) (*Initdata, error) {
+	f, err := os.Open(devicePath)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 8)
+	_, err = f.ReadAt(buf, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading magic number: %w", err)
+	}
+	const magic = "initdata"
+	if slices.Compare(buf, []byte(magic)) != 0 {
+		return nil, fmt.Errorf("%w: expected %x, got %x", errWrongMagic, magic, buf)
+	}
+	buf = make([]byte, 8)
+	_, err = f.ReadAt(buf, 8)
+	if err != nil {
+		return nil, fmt.Errorf("reading magic number: %w", err)
+	}
+	size := binary.LittleEndian.Uint64(buf)
+	const maxSize = 128*1024*1024*1024
+	if size > maxSize {
+		return nil, fmt.Errorf("%w: expected at most 128MiB, got %d byte", errTooLarge, size)
+	}
+	buf = make([]byte, size)
+
+	_, err = f.ReadAt(buf, 16)
+	if err != nil {
+		return nil, fmt.Errorf("reading initdata blob: %w", err)
+	}
+
+	return decodeGzipped(buf)
 }
 
 func (i *Initdata) digest(digestible []byte) (string, error) {
@@ -180,3 +222,8 @@ func compress(decompressed []byte) ([]byte, error) {
 
 	return compressed.Bytes(), nil
 }
+
+var (
+	errWrongMagic = errors.New("wrong magic number")
+	errTooLarge = errors.New("initdata is too large")
+)

--- a/internal/initdata/initdata_test.go
+++ b/internal/initdata/initdata_test.go
@@ -5,10 +5,15 @@ package initdata
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,4 +189,78 @@ func TestEncodeKataAnnotation(t *testing.T) {
 			assert.Equal(&i, decoded)
 		})
 	}
+}
+
+func TestFromDevice(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	initdata, err := New("sha256", map[string]string{"foo": "bar"})
+	require.NoError(t, err)
+
+	marshalled, err := toml.Marshal(initdata)
+	require.NoError(t, err)
+
+	realContent := prepareInitdataImage(t, marshalled)
+
+	for name, tc := range map[string]struct {
+		deviceContent []byte
+		wantErr       error
+	}{
+		"good": {
+			deviceContent: realContent,
+		},
+		"less-padding": {
+			deviceContent: realContent[:480],
+		},
+		"bad-magic": {
+			deviceContent: []byte("LUKS\xba\xbefoobar"),
+			wantErr:       errWrongMagic,
+		},
+		"short-magic": {
+			deviceContent: []byte("in"),
+			wantErr:       io.EOF,
+		},
+		"short-size": {
+			deviceContent: []byte("initdata\x01\x00"),
+			wantErr:       io.EOF,
+		},
+		"humonguous-allocation": {
+			deviceContent: []byte("initdata\x00\x00\x00\x00\x00\x00\x00\x10"),
+			wantErr:       errTooLarge,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			path := filepath.Join(tmpDir, name)
+			require.NoError(os.WriteFile(path, tc.deviceContent, 0o755))
+
+			parsed, err := FromDevice(path)
+			if tc.wantErr != nil {
+				require.ErrorIs(err, tc.wantErr)
+				return
+			}
+			require.NoError(err)
+
+			require.Equal(initdata, parsed)
+		})
+	}
+}
+
+// prepareInitdataImage is a variant of the eponymous function in Kata, simplified for tests.
+//
+// https://github.com/kata-containers/kata-containers/blob/077aaa6480953de3770b8c3e240dbb0dc44a186e/src/runtime/virtcontainers/hypervisor.go#L1222-L1281
+func prepareInitdataImage(t *testing.T, initdata []byte) []byte {
+	t.Helper()
+	require := require.New(t)
+
+	compressed, err := compress(initdata)
+	require.NoError(err)
+
+	padding := make([]byte, 512-((16+len(compressed))%512))
+	buf := []byte("initdata")
+	buf = binary.LittleEndian.AppendUint64([]byte("initdata"), uint64(len(compressed)))
+	buf = append(buf, compressed...)
+	buf = append(buf, padding...)
+	require.Len(buf, 512)
+	return buf
 }


### PR DESCRIPTION
This port of [Kata agent code](https://github.com/kata-containers/kata-containers/blob/077aaa6480953de3770b8c3e240dbb0dc44a186e/src/agent/src/initdata.rs#L81-L98) will be used in our initdata processor.