### PR TITLE
e2e: more debug logging for openssl_test

### DIFF
--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -363,6 +363,7 @@ func (c *Kubeclient) Restart(ctx context.Context, resource ResourceWaiter, names
 		return err
 	}
 	for _, pod := range pods {
+		c.log.Info("restarting pod", "namespace", namespace, "name", name)
 		err := c.Client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: toPtr(int64(0)),
 		})

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -347,6 +347,9 @@ func TestMain(m *testing.M) {
 
 func opensslConnectCmd(addr, caCert string) string {
 	return fmt.Sprintf(
-		`openssl s_client -connect %s -verify_return_error -x509_strict -CAfile /contrast/tls-config/%s -cert /contrast/tls-config/certChain.pem -key /contrast/tls-config/key.pem </dev/null`,
-		addr, caCert)
+		`set -x
+		cat /contrast/tls-config/%s
+		cat /contrast/tls-config/certChain.pem
+		openssl s_client -connect %s -verify_return_error -x509_strict -CAfile /contrast/tls-config/%s -cert /contrast/tls-config/certChain.pem -key /contrast/tls-config/key.pem </dev/null`,
+		caCert, addr, caCert)
 }


### PR DESCRIPTION
The openssl test is still sporadically failing. From the logs re-introduced in #1801, I see that the server-side certificates seem to match expectations. What I'd like to know now is how the certs passed to the client look like, so I write them to stdout before running the command. `set -x` ensures that we see what's executed and thus understand the output better.

Furthermore, I noticed that pod restarts are not visible in the logs, so I added a log line.