### PR TITLE
cli: fix combined output yaml

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -154,7 +154,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	if flags.outputFile != "" {
-		combinedYAML, err := getCombinedYAML(paths)
+		combinedYAML, err := kuberesource.YAMLBytesFromFiles(paths...)
 		if err != nil {
 			return fmt.Errorf("get combined YAML: %w", err)
 		}
@@ -520,21 +520,6 @@ func copyFile(inPath, outPath string) error {
 		return fmt.Errorf("copy %s: %w", inPath, err)
 	}
 	return nil
-}
-
-func getCombinedYAML(paths []string) ([]byte, error) {
-	var combinedYAML []byte
-	for _, path := range paths {
-		resource, err := kuberesource.YAMLBytesFromFile(path)
-		if err != nil {
-			return nil, err
-		}
-
-		// This expects a "---" separator at the beginning of each YAML file,
-		// as is the case after running "genpolicy".
-		combinedYAML = append(combinedYAML, resource...)
-	}
-	return combinedYAML, nil
 }
 
 func addWorkloadOwnerKeyToManifest(manifst *manifest.Manifest, keyPath string) error {

--- a/cli/genpolicy/genpolicy.go
+++ b/cli/genpolicy/genpolicy.go
@@ -83,7 +83,7 @@ func (r *Runner) Run(ctx context.Context, yamlPath string, cmPath []string, logg
 		return fmt.Errorf("running genpolicy: %w", err)
 	}
 
-	resource, err := kuberesource.YAMLBytesFromFile(yamlPath)
+	resource, err := kuberesource.YAMLBytesFromFiles(yamlPath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}

--- a/internal/kuberesource/reader.go
+++ b/internal/kuberesource/reader.go
@@ -32,15 +32,19 @@ func UnmarshalApplyConfigurations(data []byte) ([]any, error) {
 	return result, nil
 }
 
-// YAMLBytesFromFile reads a k8 YAML file and returns a formatting-preserving encoding.
-func YAMLBytesFromFile(yamlPath string) ([]byte, error) {
-	data, err := os.ReadFile(yamlPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", yamlPath, err)
-	}
-	kubeObjs, err := UnmarshalApplyConfigurations(data)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshaling %s: %w", yamlPath, err)
+// YAMLBytesFromFiles reads one or multiple K8s YAML files and returns them in a formatted byte encoding.
+func YAMLBytesFromFiles(yamlPaths ...string) ([]byte, error) {
+	var kubeObjs []any
+	for _, path := range yamlPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+		objs, err := UnmarshalApplyConfigurations(data)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling %s: %w", path, err)
+		}
+		kubeObjs = append(kubeObjs, objs...)
 	}
 	resource, err := EncodeResources(kubeObjs...)
 	if err != nil {

--- a/internal/kuberesource/reader_writer_test.go
+++ b/internal/kuberesource/reader_writer_test.go
@@ -4,6 +4,8 @@
 package kuberesource
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,6 +61,96 @@ spec:
 			require.NoError(err)
 
 			require.Equal(tc.fixture, string(got))
+		})
+	}
+}
+
+const (
+	podYAML = `apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+`
+	combinedYAML = `apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+`
+)
+
+func TestYAMLBytesFromFiles(t *testing.T) {
+	testCases := []struct {
+		name    string
+		files   map[string]string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single valid file",
+			files: map[string]string{
+				"file1.yaml": podYAML,
+			},
+			want: podYAML,
+		},
+		{
+			name: "multiple valid files",
+			files: map[string]string{
+				"file1.yaml": podYAML,
+				"file2.yaml": podYAML,
+			},
+			want: combinedYAML,
+		},
+		{
+			name: "invalid file",
+			files: map[string]string{
+				"file1.yaml": `invalid-yaml`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "format multiline string",
+			files: map[string]string{
+				"file1.yaml": `apiVersion: v1
+data:
+  foo: "bar\nbaz\n"
+kind: ConfigMap
+`,
+			},
+			want: `apiVersion: v1
+data:
+  foo: |
+    bar
+    baz
+kind: ConfigMap
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			tempDir := t.TempDir()
+
+			var paths []string
+			for fileName, content := range tc.files {
+				path := filepath.Join(tempDir, fileName)
+				require.NoError(os.WriteFile(path, []byte(content), 0o644))
+				paths = append(paths, path)
+			}
+
+			got, err := YAMLBytesFromFiles(paths...)
+			if tc.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+
+			require.Equal(tc.want, string(got))
 		})
 	}
 }


### PR DESCRIPTION
This changes the `YAMLBytesFromFile` function to accept multiple paths, so we can directly use it to generate the combined YAML output during `generate` when the `--output` flag is set. This also fixes the combined output, which was broken after #1798, and adds a unit test for the `YAMLBytesFromFiles` function.