### PR TITLE
node-installer: install static runtime

### DIFF
--- a/packages/by-name/kata/contrast-node-installer-image/package.nix
+++ b/packages/by-name/kata/contrast-node-installer-image/package.nix
@@ -196,11 +196,11 @@ let
   kata-runtime = ociLayerTar {
     files = [
       {
-        source = "${kata.runtime}/bin/kata-runtime";
+        source = "${contrastPkgsStatic.kata.runtime}/bin/kata-runtime";
         destination = "/opt/edgeless/bin/kata-runtime";
       }
       {
-        source = "${kata.runtime}/bin/containerd-shim-kata-v2";
+        source = "${contrastPkgsStatic.kata.runtime}/bin/containerd-shim-kata-v2";
         destination = "/opt/edgeless/bin/containerd-shim-contrast-cc-v2";
       }
     ];


### PR DESCRIPTION
This is a fix for an issue introduced in #1775, where we switched the way we are referencing static packages. Since that point, the node-installer image shipped a dynamically linked runtime, which might not work on clients' host system.