### PR TITLE
tdx: fix --version output of RTMRs

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -86,8 +86,8 @@ func buildVersionString() (string, error) {
 		}
 		for _, tdx := range values.TDX {
 			fmt.Fprintf(versionsWriter, "\t- mrTd:\t%s\n", tdx.MrTd.String())
-			for i, rtmr := range tdx.Rtrms {
-				fmt.Fprintf(versionsWriter, "\t  rtrm[%d]:\t%s\n", i+1, rtmr.String())
+			for i, rtmr := range tdx.Rtmrs {
+				fmt.Fprintf(versionsWriter, "\t  rtmr[%d]:\t%s\n", i+1, rtmr.String())
 			}
 			fmt.Fprintf(versionsWriter, "\t  mrSeam:\t%s\n", tdx.MrSeam.String())
 			fmt.Fprintf(versionsWriter, "\t  tdAttributes:\t%s\n", tdx.TdAttributes.String())

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -208,7 +208,7 @@ func (m *Manifest) TDXValidateOpts(kdsGetter *certcache.CachedHTTPSGetter) ([]TD
 			return nil, fmt.Errorf("failed to convert Xfam from manifest to byte slices: %w", err)
 		}
 		var rtmrs [4][]byte
-		for i, rtmr := range refVal.Rtrms {
+		for i, rtmr := range refVal.Rtmrs {
 			bytes, err := rtmr.Bytes()
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert Rtmr[%d] from manifest to byte slices: %w", i, err)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -53,7 +53,7 @@ func newTestManifestTDX() *Manifest {
 		TDX: []TDXReferenceValues{
 			{
 				MrTd: HexString("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
-				Rtrms: [4]HexString{
+				Rtmrs: [4]HexString{
 					"555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
 					"666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
 					"777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777",
@@ -187,10 +187,10 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		"tdx rtrms empty": {
+		"tdx rtmrs empty": {
 			m: newTestManifestTDX(),
 			mutate: func(m *Manifest) {
-				m.ReferenceValues.TDX[0].Rtrms = [4]HexString{}
+				m.ReferenceValues.TDX[0].Rtmrs = [4]HexString{}
 			},
 			wantErr: true,
 		},

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -214,7 +214,7 @@ func amdTrustedRootCerts(productName ProductName) (map[string][]*trust.AMDRootCe
 // TDXReferenceValues contains reference values for TDX.
 type TDXReferenceValues struct {
 	MrTd         HexString
-	Rtrms        [4]HexString
+	Rtmrs        [4]HexString
 	MrSeam       HexString
 	TdAttributes HexString
 	Xfam         HexString
@@ -235,9 +235,9 @@ func (r TDXReferenceValues) Validate() error {
 	if err := validateHexString(r.Xfam, 8); err != nil {
 		errs = append(errs, newValidationError("Xfam", err))
 	}
-	for i, rtmr := range r.Rtrms {
+	for i, rtmr := range r.Rtmrs {
 		if err := validateHexString(rtmr, 48); err != nil {
-			errs = append(errs, newValidationError(fmt.Sprintf("Rtrms[%d]", i+1), err))
+			errs = append(errs, newValidationError(fmt.Sprintf("RTMR[%d]", i+1), err))
 		}
 	}
 	return errors.Join(errs...)

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -102,7 +102,7 @@ let
             in
             {
               mrTd = builtins.readFile "${launch-digests}/mrtd.hex";
-              rtrms = [
+              rtmrs = [
                 (builtins.readFile "${launch-digests}/rtmr0.hex")
                 (builtins.readFile "${launch-digests}/rtmr1.hex")
                 (builtins.readFile "${launch-digests}/rtmr2.hex")


### PR DESCRIPTION
This PR includes a typo fix in the manifest. If you're processing the reference values in the manifest programmatically, you need to update to the changed key. 

```diff
--- manifest-old.json   1970-01-01 00:00:00.000000000 +0100
+++ manifest-new.json   1970-01-01 00:00:00.000000000 +0100
@@ -13,7 +13,7 @@
     "tdx": [
       {
         "MrTd": "76fc55af4b7a5c78f3775daff1f9623860f95128c6da48256de805090b264482ddc34f9f225a6312df8a42096355b249",
-        "Rtrms": [
+        "Rtmrs": [
           "b5855e4cc492dc1d834e64d46ccdaef39aef777885fa4af5600328d66c4a36b1abaa36b2026ca84b3a2430006bf495b3",
           "542be5581397cfd164d856815ff319c8f1dc44efd8ee7d659738cd444955746f6a29ed72b4499c1fc02b11fa852f986e",
           "622980595999700d7f35cbf709ea2822bb8145064bb0988ba89a017efacdb998db3d9861f6785770cce68cb0ebf81ae0",
```

---

Individual changes in this PR:

* start indices at 1 to align with go-tdx-guest: https://github.com/google/go-tdx-guest/blob/ffb0869e6f4d355dd34ccfdff8e989c94cf7a59b/validate/validate.go#L181
* fix typo: `RTRM -> RTMR`