### PR TITLE
ci: prevent merge by commit message

### DIFF
--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -27,8 +27,22 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: prevent merge
+      - name: prevent merge by label
         if: contains(github.event.pull_request.labels.*.name, 'do not merge')
         run: |
           echo '::error::This PR is labeled as "do not merge", remove the label to make this check pass.'
+          exit 1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 20
+          persist-credentials: false
+      - name: prevent merge by commit message
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if ! git log --pretty=format:"%s" "${BASE_SHA}..${HEAD_SHA}" | grep -iE "^[[]?(dnm|do not merge|draft|no ci|temp)"; then
+            exit 0
+          fi
+          echo '::error::This PR contains commits that should not be merged, see above.'
           exit 1


### PR DESCRIPTION
In addition to the do-not-merge label, this prevents merging commits that start their subject with one of the following phrases:

* `DO NOT MERGE`
* `DNM`
* `draft`

---

Example failure: https://github.com/edgelesssys/contrast/actions/runs/18350842068/job/52270109970?pr=1830