### PR TITLE
docs: quote numerical annotation values to prevent parsing as int

### DIFF
--- a/docs/docs/howto/secure-image-store.md
+++ b/docs/docs/howto/secure-image-store.md
@@ -37,13 +37,15 @@ kubectl apply -f resources/
 
 ### Disabling the image store for a single pod
 
-To disable the secure image store for a specific pod, set the value of the shown annotation to `0`, without a unit:
+To disable the secure image store for a specific pod, set the value of the shown annotation to `"0"`, without a unit:
 
 ```yaml
 metadata: # v1.Pod, v1.PodTemplateSpec
   annotations:
-    contrast.edgeless.systems/image-store-size: 0
+    contrast.edgeless.systems/image-store-size: "0"
 ```
+
+*(The quotation marks around `"0"` are required for the value to be treated as a string.)*
 
 Rerun `contrast generate` and reapply your deployment for the change to take effect:
 


### PR DESCRIPTION
Annotations should be strings, but the unitless `0` is interpreted as int instead, leading to:

```
Error: parsing file "<...>.yml" to run generate on: converting to *v1.PodApplyConfiguration: cannot convert int64 to string
```