### PR TITLE
treewide: move fifo interaction into justfile/scripts

### DIFF
--- a/.github/workflows/asciinema.yml
+++ b/.github/workflows/asciinema.yml
@@ -42,22 +42,16 @@ jobs:
       - name: Get credentials for CI cluster
         run: |
           just get-credentials
-      - name: Get ticket for the CI cluster
+      - name: Request fifo ticket
         run: |
-          syncIP="$(kubectl get svc sync -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-          fifo="$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')"
-          ticket="$(curl -fsSL "${syncIP}:8080/fifo/${fifo}/ticket" | jq -r '.ticket')"
-          echo "SYNC_IP=$syncIP" | tee -a "$GITHUB_ENV"
-          echo "SYNC_FIFO=$fifo" | tee -a "$GITHUB_ENV"
-          echo "SYNC_TICKET=$ticket" | tee -a "$GITHUB_ENV"
-          curl -fsSL "${syncIP}:8080/fifo/${fifo}/wait/$ticket"
+          just request-fifo-ticket
       - name: Update asciinema screencast
         working-directory: tools/asciinema
         run: |
           ./generate-screencasts.sh
-      - name: Mark ticket done
+      - name: Release fifo ticket
         run: |
-          curl -fsSL "${SYNC_IP}:8080/fifo/${SYNC_FIFO}/done/${SYNC_TICKET}"
+          just release-fifo-ticket
       - name: Create PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,13 +72,10 @@ jobs:
         if: (!inputs.self-hosted)
         run: |
           just get-credentials
-      - name: Set sync environment
+      - name: Request fifo ticket
         if: (!inputs.self-hosted || inputs.platform == 'Metal-QEMU-SNP-GPU')
         run: |
-          sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-          echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a "$GITHUB_ENV"
-          sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
-          echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
+          just request-fifo-ticket
       - name: E2E Test
         run: |
           nix build .#scripts.get-logs
@@ -115,5 +112,8 @@ jobs:
             echo "No namespace file found, skipping cleanup." >&2
             exit 0
           fi
-
           kubectl delete ns "$(cat workspace/e2e.namespace)" --timeout 10m
+      - name: Release fifo ticket
+        if: always() && (!inputs.self-hosted || inputs.platform == 'Metal-QEMU-SNP-GPU') && !inputs.skip-undeploy
+        run: |
+          just release-fifo-ticket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,13 +342,10 @@ jobs:
         if: (!matrix.platform.self-hosted)
         run: |
           just get-credentials
-      - name: Set sync environment
-        if: (!matrix.platform.self-hosted)
+      - name: Request fifo ticket
+        if: (!matrix.platform.self-hosted || matrix.platform.name == 'Metal-QEMU-SNP-GPU')
         run: |
-          sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-          echo "SYNC_ENDPOINT=http://$sync_ip:8080" | tee -a "$GITHUB_ENV"
-          sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
-          echo "SYNC_FIFO_UUID=$sync_uuid" | tee -a "$GITHUB_ENV"
+          just request-fifo-ticket
       - name: E2E Test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -358,6 +355,10 @@ jobs:
             --tag "${VERSION}" \
             --platform ${{ matrix.platform.name }} \
             --node-installer-target-conf ${{ matrix.platform.node-installer-target-conf }}
+      - name: Release fifo ticket
+        if: always() && (!matrix.platform.self-hosted || matrix.platform.name == 'Metal-QEMU-SNP-GPU')
+        run: |
+          just release-fifo-ticket
 
   regression:
     name: e2e regression

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/google/go-tdx-guest v0.3.2-0.20250814004405-ffb0869e6f4d
 	github.com/google/logger v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
-	github.com/katexochen/sync v0.0.0-20250909124809-9567164967b5
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/katexochen/sync v0.0.0-20250909124809-9567164967b5 h1:BmNTr2MclR0YL7S0rxFK9FgcydW3b+FMRlPRVN1sPyA=
-github.com/katexochen/sync v0.0.0-20250909124809-9567164967b5/go.mod h1:vQc0LFI7ChxjrhGfgn+rdk0my9hO89Qm/r1ZbJc39iY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/packages/by-name/contrast/package.nix
+++ b/packages/by-name/contrast/package.nix
@@ -199,7 +199,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-sOVeJzQVwBpry8AvpGmwCXsGYvDygcGJRWd56QoYHjo=";
+  vendorHash = "sha256-DmH5YCwACZcS551LmgcrGS9NB3yN6KmihT8nvN1aFvA=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -639,8 +639,11 @@ lib.makeScope pkgs.newScope (scripts: {
       curl
     ];
     text = ''
+      echo "Requesting fifo ticket from sync server" >&2
       sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+      echo "Sync server IP: $sync_ip" >&2
       sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
+      echo "Sync fifo UUID: $sync_uuid" >&2
       path="ticket"
       if [[ "$#" -ge 1 ]]; then
         path="ticket?done_timeout=$1"
@@ -660,11 +663,17 @@ lib.makeScope pkgs.newScope (scripts: {
       curl
     ];
     text = ''
-      sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-      sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
       ticket=$1
-      curl -fsSL "$sync_ip:8080/fifo/$sync_uuid/done/$ticket" || true
-      echo "Released ticket $ticket from fifo $sync_uuid" >&2
+      echo "Releasing fifo ticket $ticket" >&2
+      sync_ip=$(kubectl get svc sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+      echo "Sync server IP: $sync_ip" >&2
+      sync_uuid=$(kubectl get configmap sync-server-fifo -o jsonpath='{.data.uuid}')
+      echo "Sync fifo UUID: $sync_uuid" >&2
+      if ! curl -fsSL "$sync_ip:8080/fifo/$sync_uuid/done/$ticket"; then
+        echo "Failed to release fifo $sync_uuid with ticket $ticket" >&2
+      else
+        echo "Successfully released fifo $sync_uuid with ticket $ticket" >&2
+      fi
     '';
   };
 })


### PR DESCRIPTION
Previously, we had this all around, especially there was code for fifo handling in the e2e Go code. However, the e2e test would release the fifo ticket at the end of the run, before the resources were actually cleaned up (and we collected the logs etc.). So there was a window where the previous run had released the ticket, but the resources were still present, and the next run would start up and didn't get the GPU because it was still in use.
Further, this was even more broken when executing  e2e tests from the justfile (where we didn't use the fifo at all) or when setting the skip-undeploy option in CI (where we would release the ticket and keep the resources around).