### PR TITLE
ci: upload k8s events

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -435,6 +435,7 @@ lib.makeScope pkgs.newScope (scripts: {
         retry kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; cp -r /export /export-no-stream; tar zcvf /exported-logs.tar.gz /export-no-stream; rm -rf /export-no-stream"
         retry kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz
         tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs
+        retry kubectl events -n "$namespace" > ./workspace/logs/export-no-stream/logs/k8s-events.yaml
         ;;
       *)
         echo "Unknown option $1"


### PR DESCRIPTION
Event logs are, as expected, in the zip root. https://github.com/edgelesssys/contrast/actions/runs/18633288776/attempts/1?pr=1851