### PR TITLE
e2e: add fifo label to namespace in contrasttest

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,7 +85,8 @@ jobs:
             --namespace-file workspace/e2e.namespace \
             --platform "${PLATFORM}" \
             --node-installer-target-conf-type "${NODE_INSTALLER_TARGET_CONF_TYPE}" \
-            --namespace-suffix="-ci"
+            --namespace-suffix="-ci" \
+            --sync-ticket-file workspace/just.sync-ticket
       - name: Download logs
         if: always()
         run: |

--- a/justfile
+++ b/justfile
@@ -60,7 +60,8 @@ e2e target=default_deploy_target platform=default_platform: soft-clean coordinat
             --namespace-file ./{{ workspace_dir }}/just.namespace \
             --platform {{ platform }} \
             --node-installer-target-conf-type ${node_installer_target_conf_type} \
-            --namespace-suffix=${namespace_suffix-}
+            --namespace-suffix=${namespace_suffix-} \
+            --sync-ticket-file ./{{ workspace_dir }}/just.sync-ticket
 
 # Generate policies, apply Kubernetes manifests.
 deploy target=default_deploy_target cli=default_cli platform=default_platform: (runtime target platform) (apply "runtime" platform) (populate target platform) (generate cli platform) (apply target platform)


### PR DESCRIPTION
If an E2E test is run via `nix shell .#contrast.e2e --command {{ target }}.test` as in `just e2e` or in GitHub workflows, the namespace for the test is created by `contrasttest`, so we need to add the `contrast.edgeless.systems/sync-ticket` label here. If a test is cleaned up by the maintenance namespace cleanup job after an hour, the fifo ticket is then also released.