### PR TITLE
docs: remove all references to the coco project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 Contrast runs confidential container deployments on Kubernetes at scale.
 
-Contrast is based on the [Kata Containers](https://github.com/kata-containers/kata-containers) and
-[Confidential Containers](https://github.com/confidential-containers) projects.
-Confidential Containers are Kubernetes pods that are executed inside a confidential micro-VM and provide strong hardware-based isolation from the surrounding environment.
+Contrast is based on the [Kata Containers](https://github.com/kata-containers/kata-containers) and provides an implementation of the confidential containers concept.
+Confidential containers are Kubernetes pods that are executed inside a confidential micro-VM and provide strong hardware-based isolation from the surrounding environment.
 This works with unmodified containers in a lift-and-shift approach.
 
 <img src="docs/static/img/concept.svg" alt="Concept" width="80%"/>

--- a/docs/docs/architecture/components/policies.md
+++ b/docs/docs/architecture/components/policies.md
@@ -1,6 +1,6 @@
 # Policies
 
-Kata runtime policies are an integral part of Confidential Containers.
+Kata runtime policies are an integral part of Contrast.
 They prescribe how a Kubernetes pod must be configured to launch successfully in a confidential VM.
 In Contrast, policies act as a workload identifier: only pods with a policy registered in the manifest receive workload certificates and may participate in the confidential deployment.
 Verification of the Contrast Coordinator and its manifest transitively guarantees that all workloads meet the owner's expectations.

--- a/docs/docs/architecture/components/runtime.md
+++ b/docs/docs/architecture/components/runtime.md
@@ -107,28 +107,15 @@ After deploying the installer, it performs the following steps on each node:
 - Reconfigure `containerd` by adding a runtime plugin that corresponds to the `handler` field of the Kubernetes `RuntimeClass`
 - Restart `containerd` to make it aware of the new plugin
 
-## More on Confidential Containers
-
-Contrast uses some building blocks from [Confidential Containers](https://confidentialcontainers.org) (CoCo), a [CNCF Sandbox project](https://www.cncf.io/projects/confidential-containers/) that aims to standardize confidential computing at the pod level.
-The project is under active development and many of the high-level features are still in flux.
-Contrast uses the more stable core primitive provided by CoCo: its Kubernetes runtime.
-
 ## Kubernetes RuntimeClass
 
 Kubernetes can be extended to use more than one container runtime with [`RuntimeClass`](https://kubernetes.io/docs/concepts/containers/runtime-class/) objects.
 The [Container Runtime Interface](https://kubernetes.io/docs/concepts/architecture/cri/) (CRI) implementation, for example containerd, dispatches pod management API calls to the appropriate `RuntimeClass`.
 `RuntimeClass` implementations are usually based on an [OCI runtime](https://github.com/opencontainers/runtime-spec), such as `runc`, `runsc` or `crun`.
-In CoCo's case, the runtime is Kata Containers with added confidential computing capabilities.
-
-## Kata Containers
+Contrast uses the Kata Containers runtime with added confidential computing capabilities.
 
 [Kata Containers](https://katacontainers.io/) is an OCI runtime that runs pods in VMs.
 The pod VM spawns an agent process that accepts management commands from the Kata runtime running on the host.
-There are two options for creating pod VMs: local to the Kubernetes node, or remote VMs created with cloud provider APIs.
-Using local VMs requires either bare-metal servers or VMs with support for nested virtualization.
-Local VMs communicate with the host over a virtual socket.
-For remote VMs, host-to-agent communication is tunnelled through the cloud provider's network.
-
 Kata Containers was originally designed to isolate the guest from the host, but it can also run pods in confidential VMs (CVMs) to shield pods from their underlying infrastructure.
 In confidential mode, the guest agent is configured with an [Open Policy Agent](https://www.openpolicyagent.org/) (OPA) policy to authorize API calls from the host.
 This policy also contains checksums for the expected container images.

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -9,7 +9,7 @@ Contrast consists of the following main components:
 - **Contrast Kubernetes runtime**:
   Contrast provides a custom Kubernetes `RuntimeClass` that defines a runtime handler for `containerd`.
   This handler runs containers inside Confidential Virtual Machines (CVMs).
-  The runtime is based on Kata Containers and the Confidential Containers (CoCo) project.
+  The runtime is based on Kata Containers.
 
 - **Runtime policies**:
   Strictly control host-to-CVM communication on worker nodes and ensure that only approved workloads are allowed to start inside CVMs.

--- a/docs/docs/getting-started/overview.md
+++ b/docs/docs/getting-started/overview.md
@@ -14,7 +14,7 @@ To make your app confidential with Contrast, follow these steps:
    Download and install the Contrast CLI, which is used to manage your deployments and generate necessary configurations.
 
 2. [Install and set up](../howto/cluster-setup/bare-metal.md):
-   Prepare your Kubernetes cluster to support confidential containers.
+   Prepare your infrastructure and Kubernetes cluster for confidential computing use.
 
 3. [Deploy your workload](./deployment):
    Update your application’s deployment to run with Contrast:

--- a/docs/docs/howto/encrypted-storage.md
+++ b/docs/docs/howto/encrypted-storage.md
@@ -120,7 +120,7 @@ Follow [the steps given above](#deployment) to reapply your configuration.
 
 The deployment YAML shipped for this demo is already configured to be used with Contrast.
 A [runtime class](../architecture/components/runtime) `contrast-cc`
-was added to the pods to signal they should be run as Confidential Containers. During the generation process,
+was added to the pods to signal they should be run as confidential containers. During the generation process,
 the Contrast [Initializer](../architecture/components/initializer.md) will be added as an init container to these
 workloads. It will attest the pod to the Coordinator and fetch the workload certificates and the workload secret.
 

--- a/docs/docs/howto/workload-deployment/deployment-file-preparation.md
+++ b/docs/docs/howto/workload-deployment/deployment-file-preparation.md
@@ -1,6 +1,7 @@
 # Prepare deployment files
 
-To run your Kubernetes workloads as Confidential Containers, you'll need to make a few adjustments to your deployment files. This section walks you through the required changes and highlights important security considerations for your application.
+To run your Kubernetes workloads as confidential containers with Contrast, you'll need to make a few adjustments to your deployment files.
+This section walks you through the required changes and highlights important security considerations for your application.
 
 ## Applicability
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -9,9 +9,9 @@ Welcome to the Contrast documentation! Contrast makes your Kubernetes deployment
 
 ![Contrast concept](/img/concept.svg)
 
-Contrast is built upon the open-source [Kata Containers](https://github.com/kata-containers/kata-containers) and [Confidential Containers](https://github.com/confidential-containers) projects.
+Contrast is built upon the open-source [Kata Containers](https://github.com/kata-containers/kata-containers) project.
 
-Confidential Containers are Kubernetes pods executed within confidential micro-VMs, providing strong, hardware-based isolation from the surrounding environment.
+Contrast provides confidential containers: Kubernetes pods that are executed within confidential micro-VMs, providing strong, hardware-based isolation from the surrounding environment.
 You can use your existing containers without modification—enabling easy adoption through a lift-and-shift approach.
 
 :::tip


### PR DESCRIPTION
We are not using things from CoCo project and have diverged in what we do, too. So removing these to for reduced confusion. Leaving some occurrences without title casing to refer to the concept, not the project.