### PR TITLE
just: create workspace dir if not existent

### DIFF
--- a/justfile
+++ b/justfile
@@ -287,6 +287,7 @@ request-fifo-ticket timeout="":
         exit 1
     fi
     ticket=$(nix run .#scripts.get-sync-ticket {{ timeout }})
+    mkdir -p ./{{ workspace_dir }}
     echo $ticket > ./{{ workspace_dir }}/just.sync-ticket
 
 release-fifo-ticket:


### PR DESCRIPTION
This caused the release workflow to fail in https://github.com/edgelesssys/contrast/actions/runs/18742470668/job/53463429754 with

```
Requesting fifo ticket from sync server
Sync server IP: 100.93.188.85
Sync fifo UUID: 60bc7760-ab90-453f-8285-1336ef75688e
Waiting for lock on fifo 60bc7760-ab90-453f-8285-1336ef75688e with ticket 0d952f4e-a431-40e3-a5f4-c6cf4283ed52
Acquired lock on fifo 60bc7760-ab90-453f-8285-1336ef75688e with ticket 0d952f4e-a431-40e3-a5f4-c6cf4283ed52
/tmp/nix-shell.qUqi2U/just-gIlkb5/request-fifo-ticket: line 290: ./workspace/just.sync-ticket: No such file or directory
error: Recipe `request-fifo-ticket` failed with exit code 1
```