### PR TITLE
cli: print AMD product name in version command

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -77,7 +77,8 @@ func buildVersionString() (string, error) {
 			fmt.Fprint(versionsWriter, "\n")
 		}
 		for _, snp := range values.SNP {
-			fmt.Fprintf(versionsWriter, "\t- launch digest:\t%s\n", snp.TrustedMeasurement.String())
+			fmt.Fprintf(versionsWriter, "\t- product name:\t%s\n", snp.ProductName)
+			fmt.Fprintf(versionsWriter, "\t  launch digest:\t%s\n", snp.TrustedMeasurement.String())
 			fmt.Fprint(versionsWriter, "\t  default SNP TCB:\t\n")
 			printOptionalSVN("bootloader", snp.MinimumTCB.BootloaderVersion)
 			printOptionalSVN("tee", snp.MinimumTCB.TEEVersion)


### PR DESCRIPTION
As we embed reference values for different AMD products, we should print the product name that the reference values belong to.