### PR TITLE
docs: update resources that influence policy

### DIFF
--- a/docs/docs/architecture/components/policies.md
+++ b/docs/docs/architecture/components/policies.md
@@ -104,16 +104,8 @@ Contrast policies can be generated for all Kubernetes resource kinds that spawn 
 The following resource kinds influence pod configuration and are also taken into account for policy generation:
 
 <!-- keep-sorted start by_regex=`(\w+)` -->
-- `ClusterRole`
-- `ClusterRoleBinding`
 - `ConfigMap`
-- `LimitRange`
-- `PodDisruptionBudget`
-- `Role`
-- `RoleBinding`
 - `Secret`
-- `Service`
-- `ServiceAccount`
 <!-- keep-sorted end -->
 
-All other resource kinds are unsupported and can't be passed to `contrast generate`.
+All other resource kinds are ignored by `contrast generate` and don't influence the generated policy.

--- a/docs/docs/architecture/features-limitations.md
+++ b/docs/docs/architecture/features-limitations.md
@@ -20,8 +20,6 @@ This section lists planned features and current limitations of Contrast.
 - **Order of events**: The current policy evaluation mechanism on API requests isn't stateful, so it can't ensure a prescribed order of events.
 - **Absence of events**: Policies can't ensure certain events have happened. A container, such as the [service mesh sidecar](components/service-mesh.md), can be omitted entirely. Environment variables may be missing.
 - **Volume integrity checks**: Integrity checks don't cover any volume mounts, such as `ConfigMaps` and `Secrets`.
-- **Supported resource kinds**: There are some resources not yet covered.
-  It's crucial to ensure that only [supported resource kinds](components/policies.md#supported-resource-kinds) are passed to `contrast generate`.
 
 :::note
 The missing guarantee for startup order doesn't affect the security of Contrast's service mesh, see [Service mesh startup enforcement](components/service-mesh.md#service-mesh-startup-enforcement).


### PR DESCRIPTION
The only resources that influence the policy beside pod-generating controllers are ConfigMaps and Secrets. All other resources are ignored by genpolicy (`contrast generate`) and won't affect the policy. With #1842, the Contrast CLI won't fail anymore if those resources are present.