### PR TITLE
docs/readme: remove inkscape link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,9 +36,9 @@ Here is how you can modify and rebuild the attestation graphics.
 
 Requirements:
 
-* [Inkscape](https://inkscape.org/)
+* `inkscape`
 * [goat](https://github.com/blampe/goat)
 
 1. Edit the ASCII art
 2. Render the SVG with goat: `goat -i <graphic>.txt -o <graphic>.svg
-3. Export text to path with inkscape: `inkscape <graphic>.svg -o --export-plain-svg=attestation-pod.svg --export-text-to-path`
+3. Export text to path with: `inkscape <graphic>.svg -o --export-plain-svg=attestation-pod.svg --export-text-to-path`

--- a/tools/vale/styles/config/vocabularies/edgeless/accept.txt
+++ b/tools/vale/styles/config/vocabularies/edgeless/accept.txt
@@ -79,7 +79,6 @@ initdata
 initializers?
 initramfs
 initrd
-Inkscape
 iodepth
 IP
 IPSec


### PR DESCRIPTION
This is often failing in link checking, its a well known tool, people will find it without a link.