### PR TITLE
coordinator: reduce log level of non-critical errors

### DIFF
--- a/coordinator/internal/history/configmapstore.go
+++ b/coordinator/internal/history/configmapstore.go
@@ -181,7 +181,7 @@ func (s *ConfigMapStore) Watch(key string) (<-chan []byte, func(), error) {
 				}
 				switch event.Type {
 				case watch.Error:
-					s.logger.Error("watch error", "key", key, "error", event.Object)
+					s.logger.Warn("watch error", "key", key, "error", event.Object)
 					return
 				case watch.Added, watch.Modified:
 					cm, ok := event.Object.(*corev1.ConfigMap)

--- a/coordinator/internal/stateguard/stateguard.go
+++ b/coordinator/internal/stateguard/stateguard.go
@@ -146,7 +146,7 @@ func (g *Guard) WatchHistory(ctx context.Context) error {
 				return ctx.Err()
 			}
 		}
-		g.logger.Error("WatchLatestTransitions failed, starting a new watcher", "error", err)
+		g.logger.Warn("WatchLatestTransitions failed, starting a new watcher", "error", err)
 		select {
 		case <-g.clock.After(5 * time.Second):
 			g.logger.Info("time for a new watcher")

--- a/coordinator/internal/transitengineapi/transitengineapi.go
+++ b/coordinator/internal/transitengineapi/transitengineapi.go
@@ -284,7 +284,7 @@ func writeJSONResponse(w http.ResponseWriter, payload any) error {
 func writeHTTPError(w http.ResponseWriter, httpErr httpError, logger *slog.Logger) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpErr.code)
-	logger.Error("HTTP error", "error", httpErr)
+	logger.Warn("HTTP error", "error", httpErr)
 
 	_ = json.NewEncoder(w).Encode(httpErr) //nolint:errchkjson
 }


### PR DESCRIPTION
Some errors are expected to happen every once in a while. A good example are the k8s watchers, which are sometimes cancelled by the server, lose connectivity or intermittently fail for some other reason. Since the Coordinator is usually not in a degraded state if it encounters such errors, we should log them at the warning level.