### PR TITLE
initdata: handle imagepuller config

### DIFF
--- a/internal/initdata/initdata.go
+++ b/internal/initdata/initdata.go
@@ -158,7 +158,11 @@ func (i *Initdata) Validate() error {
 }
 
 // FromDevice reads the raw TOML document from a block device prepared by the Kata runtime.
-func FromDevice(devicePath string) (Raw, error) {
+func FromDevice(devicePath, magic string) (Raw, error) {
+	if len(magic) != 8 {
+		return nil, fmt.Errorf("invalid magic id: must be exactly 8 bytes, but %q is %d bytes", magic, len(magic))
+	}
+
 	f, err := os.Open(devicePath)
 	if err != nil {
 		return nil, err
@@ -168,7 +172,6 @@ func FromDevice(devicePath string) (Raw, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading magic number: %w", err)
 	}
-	const magic = "initdata"
 	if slices.Compare(buf, []byte(magic)) != 0 {
 		return nil, fmt.Errorf("%w: expected %x, got %x", errWrongMagic, magic, buf)
 	}

--- a/internal/initdata/initdata_test.go
+++ b/internal/initdata/initdata_test.go
@@ -224,7 +224,7 @@ func TestFromDevice(t *testing.T) {
 			path := filepath.Join(tmpDir, name)
 			require.NoError(os.WriteFile(path, tc.deviceContent, 0o755))
 
-			raw, err := FromDevice(path)
+			raw, err := FromDevice(path, "initdata")
 			if tc.wantErr != nil {
 				require.ErrorIs(err, tc.wantErr)
 				return

--- a/nodeinstaller/internal/kataconfig/config.go
+++ b/nodeinstaller/internal/kataconfig/config.go
@@ -60,6 +60,7 @@ func KataRuntimeConfig(
 		config.Hypervisor["qemu"]["image"] = filepath.Join(baseDir, "share", "kata-containers.img")
 		config.Hypervisor["qemu"]["rootfs_type"] = "erofs"
 		config.Hypervisor["qemu"]["valid_hypervisor_paths"] = []string{filepath.Join(baseDir, "tdx", "bin", "qemu-system-x86_64")}
+		config.Hypervisor["qemu"]["contrast_imagepuller_config"] = filepath.Join(baseDir, "etc", "host-config", "contrast-imagepuller.toml")
 		// Fix and align guest memory calculation.
 		config.Hypervisor["qemu"]["default_memory"] = platforms.DefaultMemoryInMegaBytes(platform)
 		config.Runtime["sandbox_cgroup_only"] = true
@@ -88,6 +89,7 @@ func KataRuntimeConfig(
 		config.Hypervisor["qemu"]["image"] = filepath.Join(baseDir, "share", "kata-containers.img")
 		config.Hypervisor["qemu"]["rootfs_type"] = "erofs"
 		config.Hypervisor["qemu"]["valid_hypervisor_paths"] = []string{filepath.Join(baseDir, "snp", "bin", "qemu-system-x86_64")}
+		config.Hypervisor["qemu"]["contrast_imagepuller_config"] = filepath.Join(baseDir, "etc", "host-config", "contrast-imagepuller.toml")
 		// Fix and align guest memory calculation.
 		config.Hypervisor["qemu"]["default_memory"] = platforms.DefaultMemoryInMegaBytes(platform)
 		config.Runtime["sandbox_cgroup_only"] = true

--- a/nodeinstaller/internal/kataconfig/testdata/expected-configuration-qemu-snp-gpu.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/expected-configuration-qemu-snp-gpu.toml
@@ -4,6 +4,7 @@ block_device_aio = 'threads'
 block_device_driver = 'virtio-scsi'
 cold_plug_vfio = 'root-port'
 confidential_guest = true
+contrast_imagepuller_config = '/etc/host-config/contrast-imagepuller.toml'
 cpu_features = 'pmu=off'
 default_bridges = 1
 default_maxmemory = 0

--- a/nodeinstaller/internal/kataconfig/testdata/expected-configuration-qemu-snp.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/expected-configuration-qemu-snp.toml
@@ -3,6 +3,7 @@
 block_device_aio = 'threads'
 block_device_driver = 'virtio-scsi'
 confidential_guest = true
+contrast_imagepuller_config = '/etc/host-config/contrast-imagepuller.toml'
 cpu_features = 'pmu=off'
 default_bridges = 1
 default_maxmemory = 0

--- a/nodeinstaller/internal/kataconfig/testdata/expected-configuration-qemu-tdx.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/expected-configuration-qemu-tdx.toml
@@ -3,6 +3,7 @@
 block_device_aio = 'threads'
 block_device_driver = 'virtio-scsi'
 confidential_guest = true
+contrast_imagepuller_config = '/etc/host-config/contrast-imagepuller.toml'
 cpu_features = 'pmu=off'
 default_bridges = 1
 default_maxmemory = 0

--- a/packages/by-name/kata/runtime/0020-runtime-pass-imagepuller-config-device-to-vm.patch
+++ b/packages/by-name/kata/runtime/0020-runtime-pass-imagepuller-config-device-to-vm.patch
@@ -1,0 +1,213 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Charlotte Hartmann Paludo <git@charlotteharludo.com>
+Date: Tue, 28 Oct 2025 08:14:40 +0100
+Subject: [PATCH] runtime: pass imagepuller config device to vm
+
+Signed-off-by: Charlotte Hartmann Paludo <git@charlotteharludo.com>
+---
+ src/runtime/pkg/katautils/config.go          |  2 +
+ src/runtime/virtcontainers/hypervisor.go     | 65 ++++++++++++++++++--
+ src/runtime/virtcontainers/qemu.go           | 10 ++-
+ src/runtime/virtcontainers/qemu_arch_base.go |  6 +-
+ src/runtime/virtcontainers/qemu_test.go      |  2 +-
+ 5 files changed, 75 insertions(+), 10 deletions(-)
+
+diff --git a/src/runtime/pkg/katautils/config.go b/src/runtime/pkg/katautils/config.go
+index d8c57e11c041efa597ab0f047546c3b5d1535806..49121ab8752bd7daaa1ced951c1a6d1da42d6078 100644
+--- a/src/runtime/pkg/katautils/config.go
++++ b/src/runtime/pkg/katautils/config.go
+@@ -173,6 +173,7 @@ type hypervisor struct {
+ 	DisableGuestSeLinux            bool                      `toml:"disable_guest_selinux"`
+ 	LegacySerial                   bool                      `toml:"use_legacy_serial"`
+ 	ExtraMonitorSocket             govmmQemu.MonitorProtocol `toml:"extra_monitor_socket"`
++	ImagepullerConfigPath          string                    `toml:"contrast_imagepuller_config"`
+ }
+ 
+ type runtime struct {
+@@ -1003,6 +1004,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
+ 		SnpIdAuth:                h.SnpIdAuth,
+ 		SnpGuestPolicy:           h.SnpGuestPolicy,
+ 		MeasurementAlgo:          h.GetMeasurementAlgo(),
++		ImagepullerConfigPath:    h.ImagepullerConfigPath,
+ 	}, nil
+ }
+ 
+diff --git a/src/runtime/virtcontainers/hypervisor.go b/src/runtime/virtcontainers/hypervisor.go
+index 1bcbb03e6f1a166c092c1a3a9b180b617a7eeb8b..f3f9869bce2ace9375017a61ce0f84210873d678 100644
+--- a/src/runtime/virtcontainers/hypervisor.go
++++ b/src/runtime/virtcontainers/hypervisor.go
+@@ -704,6 +704,13 @@ type HypervisorConfig struct {
+ 	// as a raw block device to guest
+ 	InitdataImage string
+ 
++	// ImagepullerConfigPath is the path to the optional imagepuller config.
++	ImagepullerConfigPath string
++
++	// The imagepuller config image on the host side to be mounted
++	// as a raw block device to the guest
++	ImagepullerConfigImage string
++
+ 	// GPU specific annotations (currently only applicable for Remote Hypervisor)
+ 	//DefaultGPUs specifies the number of GPUs required for the Kata VM
+ 	DefaultGPUs uint32
+@@ -1219,7 +1226,7 @@ func prepareInitdataMount(logger *logrus.Entry, id string, config *HypervisorCon
+ 		return err
+ 	}
+ 
+-	if err := prepareInitdataImage(config.Initdata, initdataImagePath); err != nil {
++	if err := prepareInitdataImage("initdata", []byte(config.Initdata), initdataImagePath); err != nil {
+ 		logger.WithField("initdata", "prepare initdata image").WithError(err).Error("prepare failed")
+ 		return err
+ 	}
+@@ -1228,9 +1235,53 @@ func prepareInitdataMount(logger *logrus.Entry, id string, config *HypervisorCon
+ 	return nil
+ }
+ 
++// prepareImagepullerConfigMount prepares the on-disk imagepuller config initdata image for a VM/sandbox.
++//
++// It reads the InsecureConfig from the config.ImagepullerConfigPath location,
++// creates a working directory at /run/kata-containers/shared/initdata/<id>, builds the image file
++// (data.img) via prepareInitdataImage, and sets config.ImagepullerConfigImage to the
++// resulting absolute path.
++func prepareImagepullerConfigMount(logger *logrus.Entry, id string, config *HypervisorConfig) error {
++	if config.ImagepullerConfigPath == "" {
++		logger.Info("No imagepuller config provided. Skipping prepare imagepuller config device")
++		return nil
++	}
++	if _, err := os.Stat(config.ImagepullerConfigPath); errors.Is(err, os.ErrNotExist) {
++		logger.
++			WithField("imagepuller_config_path", config.ImagepullerConfigPath).
++			Info("Imagepuller config file does not exist. Skipping prepare imagepuller config device")
++		return nil
++	} else if err != nil {
++		return err
++	}
++
++	content, err := os.ReadFile(config.ImagepullerConfigPath)
++	if err != nil {
++		logger.WithField("initdata", "read imagepuller config file").WithError(err).Error("reading config failed")
++		return err
++	}
++
++	logger.Info("Start to prepare imagepuller config")
++	initdataWorkdir := filepath.Join("/run/kata-containers/shared/initdata", id)
++	initdataImagePath := filepath.Join(initdataWorkdir, "imagepuller.img")
++
++	if err := os.MkdirAll(initdataWorkdir, 0o755); err != nil {
++		logger.WithField("initdata", "create imagepuller config image path").WithError(err).Error("mkdir failed")
++		return err
++	}
++
++	if err := prepareInitdataImage("imgpullr", content, initdataImagePath); err != nil {
++		logger.WithField("initdata", "prepare imagepuller config image").WithError(err).Error("prepare failed")
++		return err
++	}
++
++	config.ImagepullerConfigImage = initdataImagePath
++	return nil
++}
++
+ // prepareInitdataImage will create an image with a very simple layout
+ //
+-// There will be multiple sectors. The first 8 bytes are Magic number "initdata".
++// There will be multiple sectors. The first 8 bytes are the provided Magic number.
+ // Then a "length" field of 8 bytes follows (unsigned int64).
+ // Finally the gzipped initdata toml. The image will be padded to an
+ // integer multiple of the sector size for alignment.
+@@ -1239,13 +1290,17 @@ func prepareInitdataMount(logger *logrus.Entry, id string, config *HypervisorCon
+ // 0	  'i' 'n' 'i' 't' 'd' 'a' 't' 'a'  | gzip length in le  |
+ // 16	  gzip(initdata toml) ...
+ // (end of the last sector)  '\0' paddings
+-func prepareInitdataImage(initdata string, imagePath string) error {
++func prepareInitdataImage(magic string, initdata []byte, imagePath string) error {
++	if len(magic) != 8 {
++		return fmt.Errorf("invalid magic id: must be exactly 8 bytes, but %q is %d bytes", magic, len(magic))
++	}
++
+ 	SectorSize := 512
+ 	var buf bytes.Buffer
+ 	gzipper := gzip.NewWriter(&buf)
+ 	defer gzipper.Close()
+ 
+-	gzipper.Write([]byte(initdata))
++	gzipper.Write(initdata)
+ 	err := gzipper.Close()
+ 	if err != nil {
+ 		return fmt.Errorf("failed to compress initdata: %v", err)
+@@ -1266,7 +1321,7 @@ func prepareInitdataImage(initdata string, imagePath string) error {
+ 	}
+ 	defer file.Close()
+ 
+-	_, err = file.Write([]byte("initdata"))
++	_, err = file.Write([]byte(magic))
+ 	if err != nil {
+ 		return fmt.Errorf("failed to write magic number to initdata image: %v", err)
+ 	}
+diff --git a/src/runtime/virtcontainers/qemu.go b/src/runtime/virtcontainers/qemu.go
+index bba70245d2b7e3ff12a9c67e01a6c195d63cd087..0e55fbd8101b82e45777710c97cf55d4dfa8094e 100644
+--- a/src/runtime/virtcontainers/qemu.go
++++ b/src/runtime/virtcontainers/qemu.go
+@@ -551,6 +551,10 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
+ 		return err
+ 	}
+ 
++	if err := prepareImagepullerConfigMount(q.Logger(), q.id, hypervisorConfig); err != nil {
++		return err
++	}
++
+ 	machine, err := q.getQemuMachine()
+ 	if err != nil {
+ 		return err
+@@ -650,7 +654,11 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
+ 	}
+ 
+ 	if len(hypervisorConfig.Initdata) > 0 {
+-		devices = q.arch.buildInitdataDevice(ctx, devices, hypervisorConfig.InitdataImage)
++		devices = q.arch.buildInitdataDevice(ctx, devices, "initdata", hypervisorConfig.InitdataImage)
++	}
++
++	if len(hypervisorConfig.ImagepullerConfigImage) > 0 {
++		devices = q.arch.buildInitdataDevice(ctx, devices, "imagepuller", hypervisorConfig.ImagepullerConfigImage)
+ 	}
+ 
+ 	// some devices configuration may also change kernel params, make sure this is called afterwards
+diff --git a/src/runtime/virtcontainers/qemu_arch_base.go b/src/runtime/virtcontainers/qemu_arch_base.go
+index 2b6ab7ce5b4f138c13ba580ffafc8f52a634a732..f8b0d4ef973c2edd96d539e80964e5c3f0d5d4ab 100644
+--- a/src/runtime/virtcontainers/qemu_arch_base.go
++++ b/src/runtime/virtcontainers/qemu_arch_base.go
+@@ -181,7 +181,7 @@ type qemuArch interface {
+ 	qomGetSlot(qomPath string, qmpCh *qmpChannel) (types.PciSlot, error)
+ 
+ 	// buildInitdataDevice creates an initdata device for the given architecture.
+-	buildInitdataDevice(ctx context.Context, devices []govmmQemu.Device, initdataImage string) []govmmQemu.Device
++	buildInitdataDevice(ctx context.Context, devices []govmmQemu.Device, id, initdataImage string) []govmmQemu.Device
+ }
+ 
+ type qemuArchBase struct {
+@@ -969,11 +969,11 @@ func (q *qemuArchBase) qomGetSlot(qomPath string, qmpCh *qmpChannel) (types.PciS
+ }
+ 
+ // build initdata device
+-func (q *qemuArchBase) buildInitdataDevice(ctx context.Context, devices []govmmQemu.Device, initdataImage string) []govmmQemu.Device {
++func (q *qemuArchBase) buildInitdataDevice(ctx context.Context, devices []govmmQemu.Device, id, initdataImage string) []govmmQemu.Device {
+ 	device := govmmQemu.BlockDevice{
+ 		Driver:    govmmQemu.VirtioBlock,
+ 		Transport: govmmQemu.TransportPCI,
+-		ID:        "initdata",
++		ID:        id,
+ 		File:      initdataImage,
+ 		SCSI:      false,
+ 		WCE:       false,
+diff --git a/src/runtime/virtcontainers/qemu_test.go b/src/runtime/virtcontainers/qemu_test.go
+index 53b0ff716cf3195de26afbce7b3ab7cf792352b1..5643e6e5426e2e86c7dd7f4d59bfc74219e61f4b 100644
+--- a/src/runtime/virtcontainers/qemu_test.go
++++ b/src/runtime/virtcontainers/qemu_test.go
+@@ -790,7 +790,7 @@ func TestPrepareInitdataImage(t *testing.T) {
+ 		t.Run(tt.name, func(t *testing.T) {
+ 			imageDir := t.TempDir()
+ 			imagePath := path.Join(imageDir, "initdata.img")
+-			err := prepareInitdataImage(tt.content, imagePath)
++			err := prepareInitdataImage("initdata", []byte(tt.content), imagePath)
+ 			if err != nil {
+ 				t.Errorf("prepareInitdataImage() error = %v", err)
+ 			}

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -137,6 +137,10 @@ buildGoModule (finalAttrs: {
       # policy errors if set.
       # Upstream PR: https://github.com/kata-containers/kata-containers/pull/11935.
       ./0019-genpolicy-support-fsGroup-setting-in-pod-security-co.patch
+
+      # In addition to the initdata device, we also require the imagepuller's auth config
+      # to be passed to the VM in a similar manner.
+      ./0020-runtime-pass-imagepuller-config-device-to-vm.patch
     ];
   };
 

--- a/packages/nixos/kata.nix
+++ b/packages/nixos/kata.nix
@@ -132,6 +132,10 @@ in
       after = [
         "network.target"
         "imagestore.service"
+        "initdata-processor.service"
+      ];
+      requires = [
+        "initdata-processor.service"
       ];
       wantedBy = [ "kata-agent.service" ];
       serviceConfig = {


### PR DESCRIPTION
If `/etc/host-config/imagepuller.toml` exists in the runtime's dir, the kata runtime will pack it into a device, similar to the initdata device; the initdata-processor will then see the device, read its contents and write the original file back to the `/run/insecure-config/imagepuller.toml` file expected by the imagepuller.