### PR TITLE
nodeinstaller: remove serviceaccount and clusterrole

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -53,10 +53,7 @@ func Runtime(platform platforms.Platform) ([]any, error) {
 
 	return []any{
 		runtimeClassApplyConfig,
-		nodeInstaller.DaemonSetApplyConfiguration,
-		nodeInstaller.ServiceAccountApplyConfiguration,
-		nodeInstaller.ClusterRoleApplyConfiguration,
-		nodeInstaller.ClusterRoleBindingApplyConfiguration,
+		nodeInstaller,
 	}, nil
 }
 


### PR DESCRIPTION
This removes the service account from the node installer daemon set, as well as the associated `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` resources from the runtime YAML.

These resources were added in #1103 for the nydus pull container, which was removed in #1434. Since there is no other use, we can safely remove the resources here.