### PR TITLE
nodeinstaller: write imagepuller config secret to host

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -103,6 +103,9 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 							VolumeMount().
 								WithName("target-config").
 								WithMountPath("/target-config"),
+							VolumeMount().
+								WithName("imagepuller-config").
+								WithMountPath("/imagepuller-config"),
 						).
 						WithCommand("/bin/node-installer", platform.String()),
 					).
@@ -127,6 +130,12 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*NodeInstalle
 							WithName("target-config").
 							WithConfigMap(ConfigMapVolumeSource().
 								WithName("contrast-node-installer-target-config").
+								WithOptional(true),
+							),
+						Volume().
+							WithName("imagepuller-config").
+							WithSecret(SecretVolumeSource().
+								WithSecretName("contrast-node-installer-imagepuller-config").
 								WithOptional(true),
 							),
 					)...,

--- a/internal/kuberesource/wrappers.go
+++ b/internal/kuberesource/wrappers.go
@@ -380,6 +380,21 @@ func (c *ConfigMapVolumeSourceConfig) Inner() *applycorev1.ConfigMapVolumeSource
 	return c.ConfigMapVolumeSourceApplyConfiguration
 }
 
+// SecretVolumeSourceConfig wraps applycorev1.SecretVolumeSourceApplyConfiguration.
+type SecretVolumeSourceConfig struct {
+	*applycorev1.SecretVolumeSourceApplyConfiguration
+}
+
+// SecretVolumeSource creates a new SecretVolumeSourceConfig.
+func SecretVolumeSource() *SecretVolumeSourceConfig {
+	return &SecretVolumeSourceConfig{applycorev1.SecretVolumeSource()}
+}
+
+// Inner returns the inner applycorev1.SecretVolumeSourceApplyConfiguration.
+func (c *SecretVolumeSourceConfig) Inner() *applycorev1.SecretVolumeSourceApplyConfiguration {
+	return c.SecretVolumeSourceApplyConfiguration
+}
+
 // ContainerPortConfig wraps applycorev1.ContainerPortApplyConfiguration.
 type ContainerPortConfig struct {
 	*applycorev1.ContainerPortApplyConfiguration


### PR DESCRIPTION
Wrote this as part of the e2e for the imagepuller auth, but seemed like it should rather be in its own, narrowly defined PR.

## How to test:

1. deploy some workload:
    ```bash
    just
    ```
2. take note of namespace:
    ```bash
    export ns=$(cat workspace/just.namespace)
    ```
3. create a file `contrast-imagepuller.toml` to be used as a secret. For testing, a comment is enough:
    ```toml
    # Hello from the other side!
    ```
4. create the secret in kubernetes:
    ```bash
    kubectl create secret generic contrast-node-installer-imagepuller-config --from-file contrast-imagepuller.toml=contrast-imagepuller.toml -n $ns
    ```
5. restart the nodeinstaller daemonset:
    ```bash
    kubectl rollout restart ds contrast-cc-metal-qemu-snp-be766437-nodeinstaller -n $ns
    ```
6. on the host, find your file in `/opt/edgeless/contrast-cc-metal-qemu-snp-be766437/etc/host-config/contrast-imagepuller.toml`
7. if you rebase on #1882 before all of this, you can also kill/restart a pod and then find `/run/insecure-config/imagepuller.toml` and a mention of its usage in the imagepuller logs.