### PR TITLE
imagepuller: swap out toml libraries (BurntSushi -> pelletier)

### DIFF
--- a/imagepuller/go.mod
+++ b/imagepuller/go.mod
@@ -3,10 +3,10 @@ module github.com/edgelesssys/contrast/imagepuller
 go 1.25.0
 
 require (
-	github.com/BurntSushi/toml v1.5.0
 	github.com/containerd/ttrpc v1.2.7
 	github.com/google/go-containerregistry v0.20.6
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	go.podman.io/storage v1.61.0
@@ -16,6 +16,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.17.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect

--- a/imagepuller/go.sum
+++ b/imagepuller/go.sum
@@ -69,6 +69,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/imagepuller/internal/auth/auth.go
+++ b/imagepuller/internal/auth/auth.go
@@ -13,10 +13,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/edgelesssys/contrast/imagepuller/internal/api"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Config represents the imagepuller's registry authentication configurations.

--- a/packages/by-name/imagepuller/package.nix
+++ b/packages/by-name/imagepuller/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   src = ../../../imagepuller;
 
   proxyVendor = true;
-  vendorHash = "sha256-2h8P5T0uNa1UL7ziiMPp4vyBuujWHIToSImxPtOs46U=";
+  vendorHash = "sha256-USJMRSmeA9bPrARKtm6kE38YfMcoGrR4gpZgRqzgqc8=";
 
   env.CGO_ENABLED = 0;
   dontFixup = true;


### PR DESCRIPTION
Just noticed that #1853 introduced an (unnecessary) new dependency on `BurntSushi/toml`, where everywhere else we seem to be using `pelletier/go-toml`. As far as the  imagepuller usecase goes, this is a drop-in replacement.