### PR TITLE
atls: add timeout for optional endorsement fetching

### DIFF
--- a/internal/grpc/atlscredentials/atlscredentials.go
+++ b/internal/grpc/atlscredentials/atlscredentials.go
@@ -72,7 +72,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		return nil, nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), constants.ATLSServerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ATLSServerHandshakeTimeout)
 	defer cancel()
 
 	conn := tls.Server(rawConn, serverCfg)

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -64,7 +64,7 @@ func (d *Dialer) Dial(_ context.Context, target string) (*grpc.ClientConn, error
 			Backoff: backoff.DefaultConfig,
 			// We need a high initial timeout, because otherwise the client will get stuck in a reconnect loop
 			// where the timeout is too low to get a full handshake done.
-			MinConnectTimeout: constants.ATLSClientTimeout,
+			MinConnectTimeout: constants.ATLSClientConnectTimeout,
 		}),
 	)
 }


### PR DESCRIPTION
In #1261, we tried to make the server side timeouts smaller than the client timeouts for SNP, to get better error reporting and feedback from the server side. We added context handling to the `HTTPSGetter` that is used to fetch the SNP endorsements (VCEK, ASK, ARK and CRL) from the KDS. However, the default timeout to fetch the KDS that we introduced in that PR (2m) was much higher than the `ServerHandshake` timeout (25s).

The endorsement fetching on the issuer side it _optional_, as the validator can still try to fetch endorsements on their side, so issues with endorsement fetching shouldn't be lethal on the issuer side. Therefore this change introduce another timeout within the issuer that is smaller than the `ServerHandshake`, enabling the Issuer to succeed in within the `ServerHandshake` timeout even if the endorsement can't be fetched.

The change further improves the documentation around timeouts and improve naming of some things.