### PR TITLE
ci: collect discrete events, not pretty aggregates

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -435,7 +435,7 @@ lib.makeScope pkgs.newScope (scripts: {
         retry kubectl exec -n "$namespace" "$pod" -- /bin/bash -c "rm -f /exported-logs.tar.gz; cp -r /export /export-no-stream; tar zcvf /exported-logs.tar.gz /export-no-stream; rm -rf /export-no-stream"
         retry kubectl cp -n "$namespace" "$pod:/exported-logs.tar.gz" ./workspace/logs/exported-logs.tar.gz
         tar xzvf ./workspace/logs/exported-logs.tar.gz --directory ./workspace/logs
-        retry kubectl events -n "$namespace" > ./workspace/logs/export-no-stream/logs/k8s-events.yaml
+        retry kubectl events -n "$namespace" -o yaml > ./workspace/logs/export-no-stream/logs/k8s-events.yaml
         ;;
       *)
         echo "Unknown option $1"


### PR DESCRIPTION
The default output of `kubectl events` is aggregated over similar kinds of events. This loses information about the exact timing of an event, which makes the default rendering pretty much useless for debugging. If the output format is yaml, all individual events will be reported back.