### PR TITLE
e2e: log debug info on unexpected openssl success

### DIFF
--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -164,6 +164,7 @@ func (c *Kubeclient) PodsFromOwner(ctx context.Context, namespace, kind, name st
 func (c *Kubeclient) Exec(ctx context.Context, namespace, pod string, argv []string) (
 	stdout string, stderr string, err error,
 ) {
+	c.log.Debug("executing command in pod", "namespace", namespace, "pod", pod, "argv", argv)
 	buf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	request := c.Client.CoreV1().RESTClient().
@@ -197,6 +198,7 @@ func (c *Kubeclient) Exec(ctx context.Context, namespace, pod string, argv []str
 func (c *Kubeclient) ExecContainer(ctx context.Context, namespace, pod, container string, argv []string) (
 	stdout string, stderr string, err error,
 ) {
+	c.log.Debug("executing command in container", "namespace", namespace, "pod", pod, "container", container, "argv", argv)
 	buf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	request := c.Client.CoreV1().RESTClient().
@@ -240,6 +242,7 @@ func (c *Kubeclient) ExecDeployment(ctx context.Context, namespace, deployment s
 	if len(pods) == 0 {
 		return "", "", fmt.Errorf("no pods found for deployment %s/%s", namespace, deployment)
 	}
+	c.log.Debug("executing command in deployment pod", "namespace", namespace, "deployment", deployment)
 	return c.Exec(ctx, namespace, pods[0].Name, argv)
 }
 


### PR DESCRIPTION
This should provide more details on the pods involved, especially their start times. See https://github.com/edgelesssys/contrast/pull/1905#issuecomment-3512522987 for more background.

Test run with unconditional printing: https://github.com/edgelesssys/contrast/actions/runs/19264006485/job/55075316307#step:10:1447