### PR TITLE
lychee: use version from nixpkgs

### DIFF
--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -103,22 +103,4 @@ final: prev:
           openssl = final.openssl_3;
         };
       };
-
-  # The fragment checks in 0.19.1 are broken.
-  # ToDO(katexochen): Check on lychee versions >0.19.1.
-  lychee = prev.lychee.overrideAttrs (
-    finalAttrs: _prevAttrs: {
-      version = "0.18.1";
-      src = final.fetchFromGitHub {
-        owner = "lycheeverse";
-        repo = "lychee";
-        tag = "lychee-v${finalAttrs.version}";
-        hash = "sha256-aT7kVN2KM90M193h4Xng6+v69roW0J4GLd+29BzALhI=";
-      };
-      cargoDeps = final.rustPackages.rustPlatform.fetchCargoVendor {
-        inherit (finalAttrs) src pname version;
-        hash = "sha256-TKKhT4AhV2uzXOHRnKHiZJusNoCWUliKmKvDw+Aeqnc=";
-      };
-    }
-  );
 }

--- a/tools/lychee/config.toml
+++ b/tools/lychee/config.toml
@@ -6,7 +6,9 @@ cache_exclude_status = [
     "104..200",
     "300..600",
 ]
-include_fragments = true
+# Many of our links include fragments that are only resolved by JS, like Github permalinks to
+# source code lines. This breaks fragment lookup logic.
+include_fragments = false
 retry_wait_time = 20
 fallback_extensions = ["md", "html"]
 exclude = [


### PR DESCRIPTION
Our original intent was to wait until fragment checks were fixed. However, it turned out that fragment checks are not going to work for the majority of our links, because they are resolved by client-side javascript and not to be found in the HTML. Thus, turn off fragment checks altogether.

---

This fixes a problem with our overlay - the build in latest nixpkgs does not work with `0.18.1`.