### PR TITLE
docs: use reported TCB in manifest

### DIFF
--- a/docs/docs/getting-started/deployment.md
+++ b/docs/docs/getting-started/deployment.md
@@ -297,7 +297,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 
@@ -335,7 +335,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 

--- a/docs/docs/howto/workload-deployment/generate-annotations.md
+++ b/docs/docs/howto/workload-deployment/generate-annotations.md
@@ -54,7 +54,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 
@@ -92,7 +92,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 

--- a/docs/versioned_docs/version-1.14/getting-started/deployment.md
+++ b/docs/versioned_docs/version-1.14/getting-started/deployment.md
@@ -297,7 +297,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 
@@ -335,7 +335,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 

--- a/docs/versioned_docs/version-1.14/howto/workload-deployment/generate-annotations.md
+++ b/docs/versioned_docs/version-1.14/howto/workload-deployment/generate-annotations.md
@@ -54,7 +54,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 
@@ -92,7 +92,7 @@ Platform TCB: TCB Version:
   FMC:         None
 ```
 
-Use the values from `Platform TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
+Use the values from `Reported TCB` to fill in the `MinimumTCB` values in the generated `manifest.json` file.
 
 :::note[Attention!]
 


### PR DESCRIPTION
In case provisional firmware is deployed, snphost will show a higher platform TCB than reported TCB. As the platform operator can rollback from provisional firmware anytime to the committed firmware version, Contrast relies on the committed firmware version at the time of guest launch (launch TCB) in verification. Reported TCB should point to a committed firmware version and is used to derive the key that signs the report, so we should be using that instead of the actual platform TCB.