### PR TITLE
docs: update how to obtain TDX MrSeam

### DIFF
--- a/docs/docs/getting-started/deployment.md
+++ b/docs/docs/getting-started/deployment.md
@@ -353,15 +353,21 @@ contrast generate --reference-values metal-qemu-tdx resources/
 On bare-metal TDX, `contrast generate` is unable to fill in the `MrSeam` value as it depends on your platform configuration.
 It will have to be filled in manually.
 
-`MrSeam` is the SHA384 hash of the TDX module. You can retrieve it by executing
+`MrSeam` is the SHA384 hash of the TDX module.
+You should retrieve the TDX module via a trustworthy channel from Intel, for example by downloading the TDX module [from Intel's GitHub repository](https://github.com/intel/confidential-computing.tdx.tdx-module/releases) and hashing the module on a trusted machine.
+You can also reproduce the release artifact by following the build instructions linked in the release notes.
+
+You can check the hash of the in-use TDX module by executing
 
 ```sh
 sha384sum /boot/efi/EFI/TDX/TDX-SEAM.so | cut -d' ' -f1
 ```
 
-:::note[Attention!]
+:::warning
 
-This must be done on a trusted machine, with a secure and trusted connection to it.
+The TDX module hash (`MrSeam`) observed on the target platform might not be trustworthy.
+Your channel to the system or the system itself might be compromised.
+Make sure to retrieve or reproduce the value on a trusted machine.
 
 :::
 

--- a/docs/docs/howto/cluster-setup/bare-metal.md
+++ b/docs/docs/howto/cluster-setup/bare-metal.md
@@ -37,7 +37,8 @@ Consult AMD's [Using SEV with AMD EPYC Processors user guide](https://www.amd.co
 Follow Canonical's instructions in [4.2 Enable Intel TDX in Host OS](https://github.com/canonical/tdx?tab=readme-ov-file#42-enable-intel-tdx-in-host-os) (set `TDX_SETUP_ATTESTATION=1` in `setup-tdx-config`), [4.3 Enable Intel TDX in the Host's BIOS](https://github.com/canonical/tdx?tab=readme-ov-file#43-enable-intel-tdx-in-the-hosts-bios) and [9.2 Setup Intel® SGX Data Center Attestation Primitives (Intel® SGX DCAP) on the Host OS](https://github.com/canonical/tdx?tab=readme-ov-file#92-setup-intel-sgx-data-center-attestation-primitives-intel-sgx-dcap-on-the-host-os) (skipping step 9.2.1).
 You can ignore the other sections of the document.
 
-Follow Intel's guide to [Update Intel TDX Module via Binary Deployment](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/04/hardware_setup/#update-intel-tdx-module-via-binary-deployment). Intel recommends to install the latest TDX module version available.
+Follow Intel's guide to [Update Intel TDX Module via Binary Deployment](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/04/hardware_setup/#update-intel-tdx-module-via-binary-deployment).
+Intel recommends to install the latest TDX module version available.
 
 </TabItem>
 </Tabs>

--- a/docs/docs/howto/workload-deployment/generate-annotations.md
+++ b/docs/docs/howto/workload-deployment/generate-annotations.md
@@ -110,15 +110,21 @@ contrast generate --reference-values metal-qemu-tdx resources/
 On bare-metal TDX, `contrast generate` is unable to fill in the `MrSeam` value as it depends on your platform configuration.
 It will have to be filled in manually.
 
-`MrSeam` is the SHA384 hash of the TDX module. You can retrieve it by executing
+`MrSeam` is the SHA384 hash of the TDX module.
+You should retrieve the TDX module via a trustworthy channel from Intel, for example by downloading the TDX module [from Intel's GitHub repository](https://github.com/intel/confidential-computing.tdx.tdx-module/releases) and hashing the module on a trusted machine.
+You can also reproduce the release artifact by following the build instructions linked in the release notes.
+
+You can check the hash of the in-use TDX module by executing
 
 ```sh
 sha384sum /boot/efi/EFI/TDX/TDX-SEAM.so | cut -d' ' -f1
 ```
 
-:::note[Attention!]
+:::warning
 
-This must be done on a trusted machine, with a secure and trusted connection to it.
+The TDX module hash (`MrSeam`) observed on the target platform might not be trustworthy.
+Your channel to the system or the system itself might be compromised.
+Make sure to retrieve or reproduce the value on a trusted machine.
 
 :::
 

--- a/docs/versioned_docs/version-1.14/getting-started/deployment.md
+++ b/docs/versioned_docs/version-1.14/getting-started/deployment.md
@@ -353,15 +353,21 @@ contrast generate --reference-values metal-qemu-tdx resources/
 On bare-metal TDX, `contrast generate` is unable to fill in the `MrSeam` value as it depends on your platform configuration.
 It will have to be filled in manually.
 
-`MrSeam` is the SHA384 hash of the TDX module. You can retrieve it by executing
+`MrSeam` is the SHA384 hash of the TDX module.
+You should retrieve the TDX module via a trustworthy channel from Intel, for example by downloading the TDX module [from Intel's GitHub repository](https://github.com/intel/confidential-computing.tdx.tdx-module/releases) and hashing the module on a trusted machine.
+You can also reproduce the release artifact by following the build instructions linked in the release notes.
+
+You can check the hash of the in-use TDX module by executing
 
 ```sh
 sha384sum /boot/efi/EFI/TDX/TDX-SEAM.so | cut -d' ' -f1
 ```
 
-:::note[Attention!]
+:::warning
 
-This must be done on a trusted machine, with a secure and trusted connection to it.
+The TDX module hash (`MrSeam`) observed on the target platform might not be trustworthy.
+Your channel to the system or the system itself might be compromised.
+Make sure to retrieve or reproduce the value on a trusted machine.
 
 :::
 

--- a/docs/versioned_docs/version-1.14/howto/workload-deployment/generate-annotations.md
+++ b/docs/versioned_docs/version-1.14/howto/workload-deployment/generate-annotations.md
@@ -110,15 +110,21 @@ contrast generate --reference-values metal-qemu-tdx resources/
 On bare-metal TDX, `contrast generate` is unable to fill in the `MrSeam` value as it depends on your platform configuration.
 It will have to be filled in manually.
 
-`MrSeam` is the SHA384 hash of the TDX module. You can retrieve it by executing
+`MrSeam` is the SHA384 hash of the TDX module.
+You should retrieve the TDX module via a trustworthy channel from Intel, for example by downloading the TDX module [from Intel's GitHub repository](https://github.com/intel/confidential-computing.tdx.tdx-module/releases) and hashing the module on a trusted machine.
+You can also reproduce the release artifact by following the build instructions linked in the release notes.
+
+You can check the hash of the in-use TDX module by executing
 
 ```sh
 sha384sum /boot/efi/EFI/TDX/TDX-SEAM.so | cut -d' ' -f1
 ```
 
-:::note[Attention!]
+:::warning
 
-This must be done on a trusted machine, with a secure and trusted connection to it.
+The TDX module hash (`MrSeam`) observed on the target platform might not be trustworthy.
+Your channel to the system or the system itself might be compromised.
+Make sure to retrieve or reproduce the value on a trusted machine.
 
 :::
 


### PR DESCRIPTION
We should neither be using trust on first use here, nor require users to have a fully trustworthy and update to date reference system. Instead, describe how to retrieve, verify and reproduce the value on trusted hardware. Checking it on the potentially compromised target platform is still useful, but should not be used as source of truth.