### PR TITLE
tools/imagepuller-benchmark: set fixed limits

### DIFF
--- a/.github/workflows/imagepuller-benchmark.yml
+++ b/.github/workflows/imagepuller-benchmark.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
-        with:
-          role-to-assume: arn:aws:iam::795746500882:role/ContrastPublicBucketRW
-          aws-region: eu-central-1
       - name: Log in to ghcr.io Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
@@ -44,15 +39,11 @@ jobs:
           [registries."ghcr.io."]
           auth = "$auth"
           EOF
-      - name: Download baseline JSON from S3
-        run: |
-          aws s3 cp "s3://contrast-public/imagepuller-benchmark/baseline.json" "baseline.json"
       - name: Run imagepuller-benchmark script
         run: |
-          imagepullereval="$(nix build .#imagepuller-benchmark --print-out-paths)/bin/imagepuller-benchmark"
+          imagpullerbenchmark="$(nix build .#imagepuller-benchmark --print-out-paths)/bin/imagepuller-benchmark"
           imagepuller="$(nix build .#imagepuller --print-out-paths)/bin/imagepuller"
-          sudo "$imagepullereval" "$imagepuller" -c baseline.json -o baseline-new.json -i tools/imagepuller-benchmark/images.txt -a imagepuller.toml
-      - name: Upload new baseline.json to S3
-        if: github.event_name == 'push' && github.ref_name == 'main'
-        run: |
-          aws s3 cp "baseline-new.json" "s3://contrast-public/imagepuller-benchmark/baseline.json"
+          sudo "$imagpullerbenchmark" \
+            "$imagepuller" \
+            ./tools/imagepuller-benchmark/benchmark.json \
+            -a imagepuller.toml

--- a/tools/imagepuller-benchmark/benchmark.json
+++ b/tools/imagepuller-benchmark/benchmark.json
@@ -1,0 +1,25 @@
+{
+  "continuous": {
+    "time": 160,
+    "memory": 100,
+    "storage": 8858
+  },
+  "coordinator-imagepuller": {
+    "image": "ghcr.io/edgelesssys/contrast/coordinator@sha256:6f966a922cc9a39d7047ed41ffafc7eb7a3c6a4fd8966cbf30fa902b455789f7",
+    "time": 20,
+    "memory": 40,
+    "storage": 186
+  },
+  "dmesg-imagepuller": {
+    "image": "ghcr.io/edgelesssys/contrast/dmesg@sha256:6ad6bbb5735b84b10af42d2441e8d686b1d9a6cbf096b53842711ef5ddabd28d",
+    "time": 20,
+    "memory": 40,
+    "storage": 98
+  },
+  "tensorflow-imagepuller": {
+    "image": "ghcr.io/edgelesssys/tensorflow@sha256:73fe35b67dad5fa5ab0824ed7efeb586820317566a705dff76142f8949ffcaff",
+    "time": 120,
+    "memory": 80,
+    "storage": 8574
+  }
+}

--- a/tools/imagepuller-benchmark/images.txt
+++ b/tools/imagepuller-benchmark/images.txt
@@ -1,3 +1,0 @@
-ghcr.io/edgelesssys/contrast/dmesg@sha256:6ad6bbb5735b84b10af42d2441e8d686b1d9a6cbf096b53842711ef5ddabd28d
-ghcr.io/edgelesssys/contrast/coordinator@sha256:6f966a922cc9a39d7047ed41ffafc7eb7a3c6a4fd8966cbf30fa902b455789f7
-ghcr.io/edgelesssys/tensorflow@sha256:73fe35b67dad5fa5ab0824ed7efeb586820317566a705dff76142f8949ffcaff


### PR DESCRIPTION
Instead of reading/writing the moving baseline of the last successful benchmark to S3, set fixed limits for resource usage in the tool itself.

Values for time and memory were taken [from this failed run](https://github.com/edgelesssys/contrast/actions/runs/19421964985/job/55560871657), then increased somewhat generously, with the understanding that these values are not targets we aim for, but the limits beyond which we want to check what went wrong.

The storage values are generated by the new `imagepuller-benchmark-update-sizes` script, which `docker pulls` and `docker inspects` the images, then adds a 20% margin to the uncompressed size of the image in MB. 20% is very generous here.