### PR TITLE
e2e: short timeout for proxy server

### DIFF
--- a/e2e/proxy/proxy_test.go
+++ b/e2e/proxy/proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
@@ -72,7 +73,9 @@ func TestHTTPProxy(t *testing.T) {
 		if addr == "mcr.microsoft.com:443" {
 			registryConnectionProxied.Store(true)
 		}
-		return (&net.Dialer{}).DialContext(t.Context(), network, addr)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel()
+		return (&net.Dialer{}).DialContext(ctx, network, addr)
 	}
 
 	proxyListener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:")


### PR DESCRIPTION
Without the timeout, the proxy would keep waiting for a connection attempt that might have been dropped already by k8s networking. Failing early here should allow retry logic to eventually succeed, instead of waiting until timeout.

Proxy e2es:

- [x] https://github.com/edgelesssys/contrast/actions/runs/19435138380
- [x] https://github.com/edgelesssys/contrast/actions/runs/19435131887