### PR TITLE
resources: ensure emptyDir for secrets is memory-backed

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -274,7 +274,9 @@ func ensureVolumeExists(spec *applycorev1.PodSpecApplyConfiguration, volumeName 
 	// Create the volume written if it not already exists.
 	spec.WithVolumes(Volume().
 		WithName(volumeName).
-		WithEmptyDir(EmptyDirVolumeSource().Inner()),
+		WithEmptyDir(EmptyDirVolumeSource().
+			WithMedium(corev1.StorageMediumMemory),
+		),
 	)
 	return nil
 }


### PR DESCRIPTION
Previously, Contrast relied on the internals of the Kata agent, knowing it would create the emptyDir volume in memory when using the configuration option shared_fs = "none". With this change, we make that explicit, so it is more transparent to users and not relying on implementation details of Kata anymore.