### PR TITLE
cli/generate: support coordinator in different namespace

### DIFF
--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -16,7 +16,7 @@ func TestStatefulSetInjections(t *testing.T) {
 	resources := []any{statefulSet()}
 
 	t.Run("injectInitializer", func(t *testing.T) {
-		require.NoError(t, injectInitializer(resources))
+		require.NoError(t, injectInitializer(resources, "coordinator-namespace"))
 	})
 
 	t.Run("injectServiceMesh", func(t *testing.T) {

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -92,7 +92,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("finding yaml files: %w", err)
 	}
 
-	fileMap, err := extractTargets(paths, io.Discard, log)
+	fileMap, _, err := extractTargets(paths, io.Discard, log)
 	if err != nil {
 		return fmt.Errorf("extracting targets from yaml files: %w", err)
 	}

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -60,8 +60,9 @@ func TestPatchNamespaces(t *testing.T) {
 }
 
 func TestAddInitializer(t *testing.T) {
-	expectedInitializerContainerName := *Initializer().Name
-	expectedInitializerVolumeMountName := *Initializer().VolumeMounts[0].Name
+	initializer := Initializer("coordinator-ready.default")
+	expectedInitializerContainerName := *initializer.Name
+	expectedInitializerVolumeMountName := *initializer.VolumeMounts[0].Name
 	for _, tc := range []struct {
 		name      string
 		d         *applyappsv1.DeploymentApplyConfiguration
@@ -85,7 +86,7 @@ func TestAddInitializer(t *testing.T) {
 					WithTemplate(applycorev1.PodTemplateSpec().
 						WithSpec(applycorev1.PodSpec().
 							WithContainers(applycorev1.Container()).
-							WithInitContainers(Initializer()).
+							WithInitContainers(initializer).
 							WithRuntimeClassName("contrast-cc"),
 						))),
 			wantError: false,
@@ -99,7 +100,7 @@ func TestAddInitializer(t *testing.T) {
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc").
 							WithVolumes(Volume().
-								WithName(*Initializer().VolumeMounts[0].Name).
+								WithName(*initializer.VolumeMounts[0].Name).
 								WithEmptyDir(EmptyDirVolumeSource().Inner()),
 							),
 						))),
@@ -114,7 +115,7 @@ func TestAddInitializer(t *testing.T) {
 							WithContainers(applycorev1.Container()).
 							WithRuntimeClassName("contrast-cc").
 							WithVolumes(Volume().
-								WithName(*Initializer().VolumeMounts[0].Name).
+								WithName(*initializer.VolumeMounts[0].Name).
 								WithConfigMap(Volume().ConfigMap),
 							),
 						))),
@@ -232,7 +233,7 @@ func TestAddInitializer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			_, err := AddInitializer(tc.d, Initializer())
+			_, err := AddInitializer(tc.d, initializer)
 			if tc.wantError {
 				require.Error(err)
 				return

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -421,14 +421,14 @@ func PortForwarderForService(svc *applycorev1.ServiceApplyConfiguration) (*apply
 }
 
 // Initializer creates a new InitializerConfig.
-func Initializer() *applycorev1.ContainerApplyConfiguration {
+func Initializer(coordinatorHost string) *applycorev1.ContainerApplyConfiguration {
 	return applycorev1.Container().
 		WithName("contrast-initializer").
 		WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 		WithResources(ResourceRequirements().
 			WithMemoryRequest(50),
 		).
-		WithEnv(NewEnvVar("COORDINATOR_HOST", "coordinator-ready")).
+		WithEnv(NewEnvVar("COORDINATOR_HOST", coordinatorHost)).
 		WithVolumeMounts(VolumeMount().
 			WithName("contrast-secrets").
 			WithMountPath("/contrast"),


### PR DESCRIPTION
Instead of setting the `COORDINATOR_HOST` variable on the initializer to `coordinator-ready`, we set it to `coordinator-ready.<coordinator-namespace>` where the coordinator namespace is extracted from the coordinator resource definition during `contrast generate`. This allows for the coordinator to be in a separate namespace than the workload resources.