### PR TITLE
ci: prevent fixup/squash commits from merging

### DIFF
--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -41,7 +41,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if ! git log --pretty=format:"%s" "${BASE_SHA}..${HEAD_SHA}" | grep -iE "^[[]?(dnm|do not merge|draft|no ci|temp)"; then
+          if ! git log --pretty=format:"%s" "${BASE_SHA}..${HEAD_SHA}" | grep -iE "^[[]?(dnm|do not merge|draft|no ci|temp|fixup!|squash!)"; then
             exit 0
           fi
           echo '::error::This PR contains commits that should not be merged, see above.'


### PR DESCRIPTION
I just merged commits to main that should have been squashed. Let's try to prevent this from happening again.

Example failure: https://github.com/edgelesssys/contrast/actions/runs/19629562506/job/56205843443?pr=1963