### PR TITLE
scripts: do not flag newlines as non-ASCII

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -720,6 +720,8 @@ lib.makeScope pkgs.newScope (scripts: {
     name = "ascii-lint";
     runtimeInputs = [ pkgs.gnugrep ];
     text = ''
+      # The range expression below is locale-dependent, we want it to work in standard ASCII.
+      export LC_ALL="C"
       # Printable ASCII range is 0x20 SPACE to 0x7E TILDE.
       if grep -n '[^ -~]' "$@"; then
         echo "Found non-ASCII characters in above files. Is this an AI generated text?" >&2


### PR DESCRIPTION
Not sure if I'm the only one experiencing this, but since #1941, `nix fmt` / `just fmt` flags *every single line in the docs` as non-ASCII, because it contains a newline. ~~Switched the grep to use a Perl regex. Range should be as it previously was, plus the newline.~~
~~Using ripgrep also seems to fix the issue.~~
It's a locale issue.