### PR TITLE
packages: don't overwrite main program

### DIFF
--- a/.github/actions/release_artifacts/action.yml
+++ b/.github/actions/release_artifacts/action.yml
@@ -126,7 +126,7 @@ runs:
       run: |
         mkdir -p workspace
 
-        nix run .#contrast.resourcegen -- \
+        nix shell .#contrast.resourcegen --command resourcegen \
           --image-replacements "./image-replacements.txt" \
           --add-load-balancers \
           coordinator > "workspace/coordinator.yml"
@@ -139,7 +139,7 @@ runs:
           "metal-qemu-tdx"
         )
         for platform in "${platforms[@]}"; do
-          nix run .#contrast.resourcegen -- \
+          nix shell .#contrast.resourcegen --command resourcegen \
             --image-replacements ./image-replacements.txt \
             --platform "$platform" \
             runtime > "workspace/runtime-$platform.yml"
@@ -147,19 +147,19 @@ runs:
     - name: Create demo resource definitions
       shell: bash
       run: |
-        nix run .#contrast.resourcegen -- \
+        nix shell .#contrast.resourcegen --command resourcegen \
           --image-replacements ./image-replacements.txt \
           --add-load-balancers emojivoto-sm-ingress > workspace/emojivoto-demo.yml
-        nix run .#contrast.resourcegen -- \
+        nix shell .#contrast.resourcegen --command resourcegen \
           --image-replacements ./image-replacements.txt \
           --add-load-balancers mysql > workspace/mysql-demo.yml
-        nix run .#contrast.resourcegen -- \
+        nix shell .#contrast.resourcegen --command resourcegen \
           --image-replacements ./image-replacements.txt \
           --add-load-balancers vault > workspace/vault-demo.yml
     - name: Create node installer target configs
       shell: bash
       run: |
-        nix run .#contrast.resourcegen -- \
+        nix shell .#contrast.resourcegen --command resourcegen \
           --node-installer-target-conf-type k3s \
           node-installer-target-conf > workspace/node-installer-target-config-k3s.yml
     - name: Build CLI

--- a/justfile
+++ b/justfile
@@ -73,7 +73,7 @@ runtime target=default_deploy_target platform=default_platform:
     set -euo pipefail
     mkdir -p ./{{ workspace_dir }}/runtime
     if [[ "${node_installer_target_conf_type}" != "none" ]]; then
-        nix run .#contrast.resourcegen -- \
+        nix shell .#contrast.resourcegen --command resourcegen \
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
             --namespace {{ target }}${namespace_suffix-} \
             --add-namespace-object \
@@ -81,7 +81,7 @@ runtime target=default_deploy_target platform=default_platform:
             --platform {{ platform }} \
             node-installer-target-conf > ./{{ workspace_dir }}/runtime/target-conf.yml
     fi
-    nix run .#contrast.resourcegen -- \
+    nix shell .#contrast.resourcegen --command resourcegen \
         --image-replacements ./{{ workspace_dir }}/just.containerlookup \
         --namespace {{ target }}${namespace_suffix-} \
         --add-namespace-object \
@@ -112,7 +112,7 @@ populate target=default_deploy_target platform=default_platform:
     if [[ "${debug:-}" != "true" ]]; then
         dmesgFlag="--add-dmesg"
     fi
-    nix run .#contrast.resourcegen -- \
+    nix shell .#contrast.resourcegen --command resourcegen \
         --image-replacements ./{{ workspace_dir }}/just.containerlookup \
         --namespace {{ target }}${namespace_suffix-} \
         --add-port-forwarders \

--- a/packages/by-name/contrast/cli/package.nix
+++ b/packages/by-name/contrast/cli/package.nix
@@ -1,9 +1,4 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }:
-contrast.cli.overrideAttrs (prevAttrs: {
-  meta = prevAttrs.meta // {
-    mainProgram = "contrast";
-  };
-})
+{ contrast }: contrast.cli

--- a/packages/by-name/contrast/coordinator/package.nix
+++ b/packages/by-name/contrast/coordinator/package.nix
@@ -1,9 +1,4 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }:
-contrast.coordinator.overrideAttrs (prevAttrs: {
-  meta = prevAttrs.meta // {
-    mainProgram = "coordinator";
-  };
-})
+{ contrast }: contrast.coordinator

--- a/packages/by-name/contrast/initializer/package.nix
+++ b/packages/by-name/contrast/initializer/package.nix
@@ -1,11 +1,4 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }:
-contrast.initializer.overrideAttrs (prevAttrs: {
-  meta = prevAttrs.meta // {
-    mainProgram = "initializer";
-  };
-})
-
-# test rerun?
+{ contrast }: contrast.initializer

--- a/packages/by-name/contrast/nodeinstaller/package.nix
+++ b/packages/by-name/contrast/nodeinstaller/package.nix
@@ -1,9 +1,4 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }:
-contrast.nodeinstaller.overrideAttrs (prevAttrs: {
-  meta = prevAttrs.meta // {
-    mainProgram = "node-installer";
-  };
-})
+{ contrast }: contrast.nodeinstaller

--- a/packages/by-name/contrast/resourcegen/package.nix
+++ b/packages/by-name/contrast/resourcegen/package.nix
@@ -1,9 +1,4 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }:
-(contrast.overrideAttrs (prevAttrs: {
-  meta = prevAttrs.meta // {
-    mainProgram = "resourcegen";
-  };
-})).out
+{ contrast }: contrast.out


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/commit/befb2beebd2382aa9a6274b0fd609fbd872d8cc8, upstream started to include meta.mainProgram in the derivation as env, breaking the contract that meta attributes don't affect the build output. This caused Contrast packages that were built as part of contrast.contrast to rebuild (and run the unit test) separately every time something changed, instead of just overwriting the mainProgram so it could be invoked directly. Thus removing the mainProgram overwrite. We should reduce dependency on that mechanism further in the future.