### PR TITLE
cryptsetup: build alternative for non-Linux systems

### DIFF
--- a/internal/cryptsetup/ext4_fallback.go
+++ b/internal/cryptsetup/ext4_fallback.go
@@ -1,0 +1,18 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !linux
+
+package cryptsetup
+
+import "context"
+
+// IsExt4 is not implemented for non-Linux systems.
+func (d *Device) IsExt4(context.Context) (bool, error) {
+	panic("GOOS does not support cryptesetup")
+}
+
+// MkfsExt4 is not implemented for non-Linux systems.
+func (d *Device) MkfsExt4(context.Context) error {
+	panic("GOOS does not support cryptesetup")
+}

--- a/internal/cryptsetup/ext4_linux.go
+++ b/internal/cryptsetup/ext4_linux.go
@@ -1,6 +1,8 @@
 // Copyright 2025 Edgeless Systems GmbH
 // SPDX-License-Identifier: BUSL-1.1
 
+//go:build linux
+
 package cryptsetup
 
 import (


### PR DESCRIPTION
My exact problem is that `unix.O_DIRECT` is not available on Darwin. I could have just extracted `zeroBlocksDirect` into its own file, but this way we don't need yet another extra file and the content is only slightly larger. 