### PR TITLE
e2e: regression test for containerd bug

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,10 @@ jobs:
       - name: Build and push container images
         run: |
           just coordinator initializer port-forwarder openssl service-mesh-proxy memdump debugshell node-installer "${PLATFORM}"
+      - name: Build and push the (impure) containerd-reproducer image
+        if: env.TEST_NAME == 'containerd-digest-pinning'
+        run: |
+          just containerd-reproducer
       - name: Get credentials for CI cluster
         if: (!inputs.self-hosted)
         run: |

--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -10,6 +10,7 @@ on:
         options:
           # keep-sorted start
           - atls
+          - containerd-digest-pinning
           - genpolicy-unsupported
           - gpu
           - imagepuller-auth

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -35,6 +35,7 @@ jobs:
         test-name:
           # keep-sorted start
           - atls
+          - containerd-digest-pinning
           - genpolicy-unsupported
           - imagepuller-auth
           - imagestore

--- a/e2e/containerd-digest-pinning/containerd-digest-pinning_test.go
+++ b/e2e/containerd-digest-pinning/containerd-digest-pinning_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build e2e
+
+package containerddigestpinning
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestContainerdDigestPinning(t *testing.T) {
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
+	require.NoError(t, err)
+	ct := contrasttest.New(t)
+
+	runtimeHandler, err := manifest.RuntimeHandler(platform)
+	require.NoError(t, err)
+
+	deploymentName := "containerd-digest-pinning"
+	runcTester, ccTester := kuberesource.ContainerdDigestPinningTesters(deploymentName)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	// Start the runcTester outside the CC context.
+	ct.Init(t, []any{runcTester})
+	_, err = ct.Kubeclient.Client.AppsV1().
+		Deployments(ct.Namespace).
+		Apply(
+			ctx,
+			runcTester,
+			metav1.ApplyOptions{
+				FieldManager: "e2e-test",
+			},
+		)
+	require.NoError(t, err)
+	err = ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, *runcTester.Name)
+	require.NoError(t, err)
+
+	resources := kuberesource.CoordinatorBundle()
+	resources = append(resources, ccTester)
+	resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
+	resources = kuberesource.AddPortForwarders(resources)
+
+	ct.Init(t, resources)
+
+	require.NoError(t, err)
+	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
+	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+	require.True(t, t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
+	require.True(t, t.Run("contrast verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
+
+	err = ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, *ccTester.Name)
+	require.NoError(t, err)
+}
+
+func TestMain(m *testing.M) {
+	contrasttest.RegisterFlags()
+	flag.Parse()
+
+	os.Exit(m.Run())
+}

--- a/packages/by-name/contrast/e2e/package.nix
+++ b/packages/by-name/contrast/e2e/package.nix
@@ -59,6 +59,7 @@ buildGoModule {
     # keep-sorted start
     "e2e/atls"
     "e2e/attestation"
+    "e2e/containerd-digest-pinning"
     "e2e/genpolicy-unsupported"
     "e2e/gpu"
     "e2e/imagepuller-auth"


### PR DESCRIPTION
I'm really sorry this took so long, but the reproducer is finally reliable.

Some notes:
- the reproducer container is not built through nix. We *need* impurity here, and none of the hacks I considered to get this working were worth it. Instead, the new script does essentially the same as `pushOCIDir ( toOciImage ( dockerTools.buildImage ) )`, but causes a new digest and tag on every run
- one image is sufficient to trigger the bug: when the image is first pulled by tag in the `runc` context, containerd remembers the image by its tag. When we then pull by digest, containerd correctly identifies the image as already being present, but uses the old, tag-based name for it, causing the policy failure shown below (see `"io.kubernetes.cri.image-name": "ghcr.io/charludo/contrast/containerd-reproducer:1764579373"`)
- not all hosts are containerd >= 2.0 yet I believe, so some test failures are expected

```
failed to create containerd task: failed to create shim task: "CreateContainerRequest is blocked by policy: /run/measured-cfg/policy.rego:119: allow_create_container_input: input = {\"OCI\": {\"Annotations\": {\"io.katacontainers.pkg.oci.bundle_path\": \"/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/f30eb8920d04dce75766bc5318be61282191384d9bdb5d33389ebc5462f09cd1\", \"io.katacontainers.pkg.oci.container_type\": \"pod_container\", \"io.kubernetes.cri.container-name\": \"cc-by-digest\", \"io.kubernetes.cri.container-type\": \"container\", \"io.kubernetes.cri.image-name\": \"ghcr.io/charludo/contrast/containerd-reproducer:1764579373\", \"io.kubernetes.cri.sandbox-id\": \"a9c04fb64800ec3bce3b80b08390549c6423715ca5b50bc2b5847203ea9af621\", \"io.kubernetes.cri.sandbox-name\": \"containerd-digest-pinning-cc-67fdf47b68-n9fl9\", \"io.kubernetes.cri.sandbox-namespace\": \"testcontainerddigestpinning-e30f1510-ch\", \"io.kubernetes.cri.sandbox-uid\": \"b97016e1-6053-4719-9924-55cbc4302120\"}, ...
```