### PR TITLE
flake: fix 'system has been renamed to stdenv.hostPlatform.system' warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            (final: _prev: { fenix = self.inputs.fenix.packages.${final.system}; })
+            (final: _prev: { fenix = self.inputs.fenix.packages.${final.stdenv.hostPlatform.system}; })
             (import ./overlays/nixpkgs.nix)
             (import ./overlays/contrast.nix)
           ];


### PR DESCRIPTION
Relevant discussion [here](https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120), but tbh I was just annoyed by the warning. (Visible e.g. when running `nix flake check`)