### PR TITLE
[release/v1.15] kata: bump cdi crate version

### DIFF
--- a/packages/by-name/kata/runtime/0025-agent-Bump-CDI-rs-to-latest.patch
+++ b/packages/by-name/kata/runtime/0025-agent-Bump-CDI-rs-to-latest.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zvonko Kaiser <zkaiser@nvidia.com>
+Date: Thu, 27 Nov 2025 17:02:33 +0000
+Subject: [PATCH] agent: Bump CDI-rs to latest
+
+Latest version of container-device-interface is v0.1.1
+
+Signed-off-by: Zvonko Kaiser <zkaiser@nvidia.com>
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/agent/Cargo.lock | 22 +++++++++++-----------
+ src/agent/Cargo.toml |  2 +-
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/src/agent/Cargo.lock b/src/agent/Cargo.lock
+index a79e5fcf57cfb421c9a90ad77d52fbbeeaa69d2c..b630d106710f5fd72fdc4147c83aea7e809666f5 100644
+--- a/src/agent/Cargo.lock
++++ b/src/agent/Cargo.lock
+@@ -786,9 +786,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "container-device-interface"
+-version = "0.1.0"
++version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "653849f0c250f73d9afab4b2a9a6b07adaee1f34c44ffa6f2d2c3f9392002c1a"
++checksum = "62aabe8ef7f15f505201aa88a97f4856fd572cb869b73232db95ade2366090cd"
+ dependencies = [
+  "anyhow",
+  "clap",
+@@ -1213,9 +1213,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "fancy-regex"
+-version = "0.14.0"
++version = "0.16.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
++checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+ dependencies = [
+  "bit-set",
+  "regex-automata 0.4.9",
+@@ -2014,9 +2014,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "jsonschema"
+-version = "0.30.0"
++version = "0.33.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
++checksum = "d46662859bc5f60a145b75f4632fbadc84e829e45df6c5de74cfc8e05acb96b5"
+ dependencies = [
+  "ahash 0.8.12",
+  "base64 0.22.1",
+@@ -2268,9 +2268,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libz-sys"
+-version = "1.1.22"
++version = "1.1.23"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
++checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+ dependencies = [
+  "cc",
+  "pkg-config",
+@@ -3423,9 +3423,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "referencing"
+-version = "0.30.0"
++version = "0.33.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
++checksum = "9e9c261f7ce75418b3beadfb3f0eb1299fe8eb9640deba45ffa2cb783098697d"
+ dependencies = [
+  "ahash 0.8.12",
+  "fluent-uri 0.3.2",
+@@ -5029,7 +5029,7 @@ version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+ dependencies = [
+- "windows-sys 0.59.0",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+diff --git a/src/agent/Cargo.toml b/src/agent/Cargo.toml
+index a570d50cb5599d62edd4813cd692c54fd31c4bcd..be052ba21a0a9cfddd94ab20d76cb52fc6c4cdde 100644
+--- a/src/agent/Cargo.toml
++++ b/src/agent/Cargo.toml
+@@ -186,7 +186,7 @@ base64 = "0.22"
+ sha2 = "0.10.8"
+ async-compression = { version = "0.4.22", features = ["tokio", "gzip"] }
+ 
+-container-device-interface = "0.1.0"
++container-device-interface = "0.1.1"
+ 
+ [target.'cfg(target_arch = "s390x")'.dependencies]
+ pv_core = { git = "https://github.com/ibm-s390-linux/s390-tools", rev = "4942504a9a2977d49989a5e5b7c1c8e07dc0fa41", package = "s390_pv_core" }

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -154,6 +154,11 @@ buildGoModule (finalAttrs: {
       # Instead, this patch ensures that if a container has NVIDIA_VISIBLE_DEVICES=all set as an env var,
       # that container receives ALL Nvidia GPU devices known to the pod.
       ./0024-runtime-assign-GPU-devices-to-multiple-containers.patch
+
+      # The container-device-interface crate v0.1.0 was published without a corresponding git tag
+      # and is going to be yanked.
+      # Upstream PR: https://github.com/kata-containers/kata-containers/pull/12151.
+      ./0025-agent-Bump-CDI-rs-to-latest.patch
     ];
   };
 


### PR DESCRIPTION
Backport of https://github.com/edgelesssys/contrast/pull/1986 to `release/v1.15`.