### PR TITLE
kuberesource: make debug-shell a sidecar

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -228,11 +228,11 @@ func AddDebugShell(
 		}
 
 		// Remove already existing containers with unique debug shell name.
-		spec.Containers = slices.DeleteFunc(spec.Containers, func(c applycorev1.ContainerApplyConfiguration) bool {
+		spec.InitContainers = slices.DeleteFunc(spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
 			return c.Name != nil && *c.Name == *debugShell.Name
 		})
 
-		return spec.WithContainers(debugShell)
+		return spec.WithInitContainers(debugShell)
 	}), nil
 }
 

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -489,6 +489,7 @@ func DebugShell() *applycorev1.ContainerApplyConfiguration {
 	return applycorev1.Container().
 		WithName("contrast-debug-shell").
 		WithImage("ghcr.io/edgelesssys/contrast/debugshell:latest").
+		WithRestartPolicy(corev1.ContainerRestartPolicyAlways).
 		WithResources(ResourceRequirements().
 			WithMemoryLimitAndRequest(400),
 		)


### PR DESCRIPTION
If the debug shell is a regular container it will prevent the pod from completing, making our regression/job test fail.

* [x] [regression test w/ debug shell](https://github.com/edgelesssys/contrast/actions/runs/19852713312)