### PR TITLE
dev-docs/tcb-spec: update mrseam

### DIFF
--- a/dev-docs/e2e/tcb-specs.json
+++ b/dev-docs/e2e/tcb-specs.json
@@ -26,7 +26,7 @@
     ],
     "tdx": [
         {
-            "MrSeam": "5b38e33a6487958b72c3c12a938eaa5e3fd4510c51aeeab58c7d5ecee41d7c436489d6c8e4f92f160b7cad34207b00c1"
+            "MrSeam": "7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c9a9d"
         }
     ]
 }


### PR DESCRIPTION
The tdx-module was upgraded to v1.5.16 while the runner was setup from scratch again.