### PR TITLE
e2e: append to namespace file

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -127,7 +127,11 @@ func (ct *ContrastTest) Init(t *testing.T, resources []any) {
 	namespaceUnstr, err := kuberesource.ResourcesToUnstructured([]any{namespace})
 	require.NoError(err)
 	if ct.NamespaceFile != "" {
-		require.NoError(os.WriteFile(ct.NamespaceFile, []byte(ct.Namespace), 0o644))
+		file, err := os.OpenFile(ct.NamespaceFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+		require.NoError(err)
+		defer file.Close()
+		_, err = file.WriteString(ct.Namespace + "\n")
+		require.NoError(err)
 	}
 	// Creating a namespace should not take too long.
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)


### PR DESCRIPTION
This allows running E2E tests in multiple namespaces, even in parallel. Running `just undeploy` will automatically delete all namespaces in the file (one for each line). For the normal `just` flow we don't need to change anything, since we only ever have one namespace. The only exception is when running `just e2e` on an E2E test which includes multiple namespaces and then trying to run something like `just verify`. This will fail because we are trying to read one namespace but get two. However, running these commands will most likely fail anyway, since, e.g., we have no manifest in our workspace. "Solving" this by just running `tail -1 just.namespace` for example is also not helpful, since we cannot really predict which namespace will be returned if the tests run in parallel. So I left the `justfile` untouched for now.

Example:

```go
t.Run("1", func(t *testing.T) {
    t.Parallel()
    ct := contrasttest.New(t)
    ct.Init(t, resources1)
})

t.Run("2", func(t *testing.T) {
    t.Parallel()
    ct := contrasttest.New(t)
    ct.Init(t, resources2)
})
```

For each `contrasttest.New(t)` a new namespace with a unique name will be created and appended to the `just.namespace` file. Running `just undeploy` manually or in the cleanup step will delete both namespaces.