### PR TITLE
internal/kuberesource: increase memdump memory limits, again again

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -926,7 +926,7 @@ func MemDump() []any {
 								),
 							).
 							WithResources(ResourceRequirements().
-								WithMemoryLimitAndRequest(1000),
+								WithMemoryLimitAndRequest(1500),
 							),
 					),
 				),
@@ -953,7 +953,7 @@ func MemDump() []any {
 							WithImage("ghcr.io/edgelesssys/contrast/memdump:latest").
 							WithCommand("/bin/sh", "-c", "sleep inf").
 							WithResources(ResourceRequirements().
-								WithMemoryLimitAndRequest(1000),
+								WithMemoryLimitAndRequest(1500),
 							),
 					),
 				),


### PR DESCRIPTION
- [x] [memdump, debugshell, SNP](https://github.com/edgelesssys/contrast/actions/runs/20093289672)
- [x] [memdump, debugshell, TDX](https://github.com/edgelesssys/contrast/actions/runs/20093294142)