### PR TITLE
flake.nix: build all packages though a single evaluation

### DIFF
--- a/.github/workflows/cache_matrix.yml
+++ b/.github/workflows/cache_matrix.yml
@@ -1,0 +1,60 @@
+name: cache matrix
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  linux:
+    concurrency:
+      group: cache-matrix-x86_64-linux
+      cancel-in-progress: true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 240
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build base matrix
+        run: |
+          attr=".#legacyPackages.x86_64-linux.base.matrix"
+          if nix build --dry-run "$attr" 2>&1 | grep -q "will be built"; then
+            nix build --no-link --keep-going "$attr"
+          else
+            echo "Nothing to build. Cache already up to date."
+          fi
+
+  darwin:
+    # Runs after the linux job so the x86_64-linux runtime closure can be substituted here.
+    needs: linux
+    concurrency:
+      group: cache-matrix-aarch64-darwin
+      cancel-in-progress: true
+    runs-on: macos-latest
+    timeout-minutes: 240
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build base matrix
+        run: |
+          attr=".#legacyPackages.aarch64-darwin.base.matrix"
+          if nix build --dry-run "$attr" 2>&1 | grep -q "will be built"; then
+            nix build --no-link --keep-going "$attr"
+          else
+            echo "Nothing to build. Cache already up to date."
+          fi

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,4 +3,4 @@
 
 { lib }:
 
-{ }
+import ./matrix.nix { inherit lib; }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,6 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{ lib }:
+
+{ }

--- a/lib/matrix.nix
+++ b/lib/matrix.nix
@@ -1,0 +1,67 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{ lib }:
+
+rec {
+  # Do not recurse into these.
+  plumbingAttrs = [
+    "callPackage"
+    "newScope"
+    "overrideScope"
+    "overrideScope'"
+    "packages"
+    "override"
+    "overrideAttrs"
+    "overrideDerivation"
+    "__functor"
+    "__functionArgs"
+  ];
+
+  # Returns a list of { name = "a/b/c"; path = drv; } pairs for every derivation reachable.
+  # This is the shape linkFarm expects.
+  collectDerivations =
+    skip: attrs:
+    let
+      go =
+        path: v:
+        let
+          eval = builtins.tryEval v;
+          val = eval.value;
+        in
+        if lib.isDerivation val then
+          [
+            {
+              name = lib.concatStringsSep "/" path;
+              path = val;
+            }
+          ]
+        else if lib.isAttrs val && !lib.isFunction val then
+          lib.concatLists (
+            lib.mapAttrsToList (
+              n: c: if (lib.elem n plumbingAttrs) || (lib.elem n skip) then [ ] else go (path ++ [ n ]) c
+            ) val
+          )
+        else
+          [ ];
+    in
+    go [ ] attrs;
+
+  buildableOn =
+    hostPlatform: entries:
+    lib.filter (
+      e: lib.meta.availableOn hostPlatform e.path && e.path.system == hostPlatform.system
+    ) entries;
+
+  mkMatrix =
+    pkgs:
+    pkgs.linkFarm "contrast-matrix" (
+      buildableOn pkgs.stdenv.hostPlatform (
+        collectDerivations [
+          "contrastPkgsStatic"
+          "contrast-releases"
+          "matrix"
+        ] pkgs.contrastPkgs
+      )
+    );
+}

--- a/overlays/contrast.nix
+++ b/overlays/contrast.nix
@@ -1,8 +1,13 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-final: _prev:
+final: prev:
 
 {
   contrastPkgs = import ../packages { pkgs = final; };
+  lib = prev.lib.extend (
+    finalLib: _: {
+      contrast = import ../lib { lib = finalLib; };
+    }
+  );
 }

--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -22,6 +22,10 @@ final: prev:
       };
     }
   );
+  # Overridden go version makes helm rebuild. Helm has a flaky (possibly network dependent?) test.
+  kubernetes-helm = prev.kubernetes-helm.overrideAttrs (_: {
+    doCheck = false;
+  });
 
   erofs-utils = prev.erofs-utils.overrideAttrs (prevAttrs: {
     # The build environment sets SOURCE_DATE_EPOCH to 1980, but as mkfs.erofs

--- a/overlays/runtimepkgs.nix
+++ b/overlays/runtimepkgs.nix
@@ -60,6 +60,8 @@ else
               agent
               image
               kernel-uvm
+              runtime
+              runtime-rs
               calculateSnpLaunchDigest
               calculateTdxLaunchDigests
               ;
@@ -99,6 +101,8 @@ else
               cleanup-images
               cleanup-containerd
               nix-gc
+              upgrade-gpu-operator
+              sev-snp-measure-consistency
               ;
           }
         );

--- a/packages/by-name/scripts/show-input-diff/package.nix
+++ b/packages/by-name/scripts/show-input-diff/package.nix
@@ -1,0 +1,19 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{
+  writeShellApplication,
+  nix-diff,
+  jq,
+}:
+
+# show-input-diff shows which input derivations differ between two builds of the matrix output.
+# LEFT and RIGHT pick flake refs. Defaults to upstream vs. local checkout.
+writeShellApplication {
+  name = "show-input-diff";
+  text = builtins.readFile ./show-input-diff.sh;
+  runtimeInputs = [
+    nix-diff
+    jq
+  ];
+}

--- a/packages/by-name/scripts/show-input-diff/show-input-diff.sh
+++ b/packages/by-name/scripts/show-input-diff/show-input-diff.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+maxDepth=999
+set_name=base
+system=$(nix eval --impure --raw --expr builtins.currentSystem)
+new_args=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  --max-depth)
+    maxDepth="$2"
+    shift 2
+    ;;
+  --max-depth=*)
+    maxDepth="${1#*=}"
+    shift
+    ;;
+  --set)
+    set_name="$2"
+    shift 2
+    ;;
+  --set=*)
+    set_name="${1#*=}"
+    shift
+    ;;
+  --system)
+    system="$2"
+    shift 2
+    ;;
+  --system=*)
+    system="${1#*=}"
+    shift
+    ;;
+  *)
+    new_args+=("$1")
+    shift
+    ;;
+  esac
+done
+set -- "${new_args[@]}"
+
+attr="legacyPackages.$system.$set_name.matrix"
+left=$(nix eval --raw "${1:-github:edgelesssys/contrast}#$attr.drvPath" | tr -d '\n')
+right=$(nix eval --raw "${2:-.}#$attr.drvPath" | tr -d '\n')
+nix-diff "$left" "$right" --json | jq -r --argjson maxDepth "$maxDepth" '
+  def printTree(level):
+    (
+      select(.drvName != null and .drvName != "") | ("  " * level) + .drvName,
+      (.drvNames // [] | .[] | ("  " * (level + 1)) + .),
+      (if level + 1 < $maxDepth then (.drvDiff.inputsDiff.inputDerivationDiffs // [] | .[] | printTree(level + 1)) else empty end)
+    );
+  .inputsDiff.inputDerivationDiffs[] | printTree(0)
+'

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -21,7 +21,6 @@ byName.overrideScope (
       final: _: pkgs.callPackages ./scripts.nix { scripts = final; }
     );
     containers = pkgs.callPackages ./containers.nix { };
-    container-scripts = pkgs.callPackages ./container-scripts.nix { };
     contrast-releases = pkgs.callPackages ./contrast-releases.nix { };
   }
 )

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -17,6 +17,7 @@ in
 byName.overrideScope (
   _final: prev: {
     contrastPkgsStatic = pkgs.pkgsStatic.contrastPkgs;
+    matrix = pkgs.lib.contrast.mkMatrix pkgs;
     scripts = prev.scripts.overrideScope (
       final: _: pkgs.callPackages ./scripts.nix { scripts = final; }
     );


### PR DESCRIPTION
Adds new flake outputs `.#<set>.matrix`. Would not recommend building these on your local machine... 👀 

Of course, since we are now able to build/develop on Darwin as well, each individual machine can only build (their architectures') subset of the packages we ship. The CI job builds on both, and pushes both to the cache.

Apropros CI: I have commented out building the debug set as well. Thoughts? The tradeoff here is us not having to build debug versions, and the cache filling up faster.

Edit: almost forgot: This also wires in a custom lib for us to use. Could help clean up the flake, and is the right place for reused nix snippets. Available everywhere in the tree as `lib.contrast`.