### PR TITLE
just: fix location of containerd-reproducer push script

### DIFF
--- a/packages/by-name/scripts/containers/package.nix
+++ b/packages/by-name/scripts/containers/package.nix
@@ -35,6 +35,32 @@ in
   push-node-installer-kata-gpu =
     pushOCIDir "node-installer-kata-gpu" contrastPkgs.contrast.node-installer-image.gpu
       "v${contrastPkgs.contrast.nodeinstaller.version}";
+
+  # This is a script rather than a contrastPkgs.buildOciImage because we *want* impurity here,
+  # in order to generate a new image digest and a new tag every time the script runs.
+  push-containerd-reproducer = writeShellApplication {
+    name = "push-containerd-reproducer";
+    runtimeInputs = with pkgs; [
+      jq
+      umoci
+      skopeo
+    ];
+    text = ''
+      registry="$1"
+      tmpdir="$(mktemp -d)/oci"
+      timestamp=$(date +%s)
+
+      umoci init --layout "$tmpdir"
+      skopeo copy "docker://ghcr.io/edgelesssys/bash@sha256:cabc70d68e38584052cff2c271748a0506b47069ebbd3d26096478524e9b270b" "oci:$tmpdir:alpine" --insecure-policy
+      umoci unpack --image "$tmpdir:alpine" "$tmpdir/rootfs" --rootless
+      echo "$timestamp" > "$tmpdir/rootfs/rootfs/timestamp"
+      umoci repack --image "$tmpdir:alpine" "$tmpdir/rootfs"
+      skopeo copy "oci:$tmpdir" "docker://$registry/contrast/containerd-reproducer:$timestamp" --insecure-policy
+
+      digest=$(jq -r '.manifests[0].digest' "$tmpdir/index.json")
+      echo "$timestamp $digest"
+    '';
+  };
 }
 // (lib.concatMapAttrs (name: container: {
   "push-${name}" = pushOCIDir name container.outPath container.meta.tag;

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -748,32 +748,6 @@ lib.makeScope pkgs.newScope (scripts: {
     '';
   };
 
-  # This is a script rather than part of packages/containers.nix because we *want* impurity here,
-  # in order to generate a new image digest and a new tag every time the script runs.
-  push-containerd-reproducer = writeShellApplication {
-    name = "push-containerd-reproducer";
-    runtimeInputs = with pkgs; [
-      jq
-      umoci
-      skopeo
-    ];
-    text = ''
-      registry="$1"
-      tmpdir="$(mktemp -d)/oci"
-      timestamp=$(date +%s)
-
-      umoci init --layout "$tmpdir"
-      skopeo copy "docker://ghcr.io/edgelesssys/bash@sha256:cabc70d68e38584052cff2c271748a0506b47069ebbd3d26096478524e9b270b" "oci:$tmpdir:alpine" --insecure-policy
-      umoci unpack --image "$tmpdir:alpine" "$tmpdir/rootfs" --rootless
-      echo "$timestamp" > "$tmpdir/rootfs/rootfs/timestamp"
-      umoci repack --image "$tmpdir:alpine" "$tmpdir/rootfs"
-      skopeo copy "oci:$tmpdir" "docker://$registry/contrast/containerd-reproducer:$timestamp" --insecure-policy
-
-      digest=$(jq -r '.manifests[0].digest' "$tmpdir/index.json")
-      echo "$timestamp $digest"
-    '';
-  };
-
   mdsh-fmt = writeShellApplication {
     name = "mdsh-fmt";
     runtimeInputs = with pkgs; [


### PR DESCRIPTION
The installation target for the containerd-reproducer was accidentally changed in #2260, although the script for pushing the reproducer is different from other containers. 

This should fix the error here: https://github.com/edgelesssys/contrast/actions/runs/24218822301/job/70706785086. 

- [x] [test run](https://github.com/edgelesssys/contrast/actions/runs/24238629092)