### PR TITLE
kuberesource: increase memory footprint of initializer and coordinator

### DIFF
--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -349,7 +349,11 @@ func AddImageStore(resources []any) []any {
 			WithSecurityContext(SecurityContext().
 				WithPrivileged(true).SecurityContextApplyConfiguration).
 			WithResources(ResourceRequirements().
-				WithMemoryLimitAndRequest(50),
+				// If the pod does not have an initializer, or the main container has a memory
+				// limit larger than the initializer, the VM might receive too little memory to fit
+				// the initializer as sidecar. Thus, we're conservatively reserving the full size
+				// here.
+				WithMemoryLimitAndRequest(420),
 			).
 			WithVolumeDevices(
 				applycorev1.VolumeDevice().

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -300,7 +300,10 @@ func Coordinator(namespace string) *CoordinatorConfig {
 									WithPath("/probe/readiness")),
 							).
 							WithResources(ResourceRequirements().
-								WithMemoryLimitAndRequest(200),
+								// As of v1.18.0, the Coordinator is roughly 200MiB unpacked.
+								// Double that to account for only 50% of VM memory being available
+								// for /run.
+								WithMemoryLimitAndRequest(400),
 							),
 					).
 					WithAffinity(
@@ -454,7 +457,8 @@ func Initializer(coordinatorHost string) *applycorev1.ContainerApplyConfiguratio
 		WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 		WithResources(ResourceRequirements().
 			// In v1.18.0, the initializer image was 50MiB compressed, 160MiB uncompressed.
-			WithMemoryLimitAndRequest(210),
+			// Double that because only 50% of the VM memory are available for /run.
+			WithMemoryLimitAndRequest(420),
 		).
 		WithEnv(NewEnvVar("COORDINATOR_HOST", coordinatorHost)).
 		WithVolumeMounts(VolumeMount().


### PR DESCRIPTION
We only have 50% of memory available for the image store in `/run`:

https://github.com/edgelesssys/contrast/blob/08051c1cffe97626b054fa2f80d62b47e4f7e81a/packages/nixos/kata.nix#L98-L106

(matching [upstream](
https://github.com/kata-containers/kata-containers/blob/fd6375d8d5a850d05c756702553cbd3f5eb9a809/tools/osbuilder/rootfs-builder/rootfs.sh#L778-L790))

When I made my calculations for #2306, I forgot about that.