### PR TITLE
containers: build utilities with musl

### DIFF
--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -4,6 +4,7 @@
 {
   lib,
   pkgs,
+  pkgsMusl,
   contrastPkgs,
   dockerTools,
 }:
@@ -13,7 +14,7 @@
     name = "coordinator";
     tag = "v${contrastPkgs.contrast.coordinator.version}";
     copyToRoot =
-      (with pkgs; [
+      (with pkgsMusl; [
         busybox
         e2fsprogs # mkfs.ext4
         libuuid # blkid
@@ -33,7 +34,7 @@
     name = "initializer";
     tag = "v${contrastPkgs.contrast.initializer.version}";
     copyToRoot =
-      (with pkgs; [
+      (with pkgsMusl; [
         busybox
         cryptsetup
         e2fsprogs # mkfs.ext4


### PR DESCRIPTION
e2fsprogs and iptables depend on glibc, which in turn comes with megabytes of locale data and other cruft. Building the utilities against musl saves 12MiB (compressed) in both the coordinator and the initializer.