### PR TITLE
ci: update bm-tcb-specs for dgx-007

### DIFF
--- a/dev-docs/e2e/dgx-007/manifest.json
+++ b/dev-docs/e2e/dgx-007/manifest.json
@@ -8,7 +8,7 @@
     {
       "op": "replace",
       "path": "/MrSeam",
-      "value": "7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c9a9d"
+      "value": "489e585f1c54bc5a02066c8c6ec21619ff0334ec6f21e07e2a35202c59183789c8057e7d97dd591bb08314b185819e72"
     },
     {
       "op": "replace",
@@ -27,7 +27,7 @@
     {
       "op": "replace",
       "path": "/MrSeam",
-      "value": "7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c9a9d"
+      "value": "489e585f1c54bc5a02066c8c6ec21619ff0334ec6f21e07e2a35202c59183789c8057e7d97dd591bb08314b185819e72"
     },
     {
       "op": "replace",


### PR DESCRIPTION
Update MrSeam for this machine to the latest module, which is not published on Github so far, but distributed in BIOS updates. It's required to meet TCB-R 21.