### PR TITLE
kuberesource: double debugshell memory

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -513,7 +513,7 @@ func DebugShell() *applycorev1.ContainerApplyConfiguration {
 		WithImage("ghcr.io/edgelesssys/contrast/debugshell:latest").
 		WithRestartPolicy(corev1.ContainerRestartPolicyAlways).
 		WithResources(ResourceRequirements().
-			WithMemoryLimitAndRequest(500),
+			WithMemoryLimitAndRequest(1000),
 		)
 }
 


### PR DESCRIPTION
Was last adjusted a month ago.

https://github.com/edgelesssys/contrast/commit/9821b0cd3b2f6f72c6382eb978948ed61c7cdc67