### PR TITLE
imagepuller: listen before waiting for resolv.conf

### DIFF
--- a/imagepuller/main.go
+++ b/imagepuller/main.go
@@ -65,10 +65,6 @@ func run(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "Contrast image-puller %s\n", version)
 	fmt.Fprintln(os.Stderr, "Report issues at https://github.com/edgelesssys/contrast/issues")
 
-	if err := resolvconf.Wait(ctxSignal, log.WithGroup("DNS")); err != nil {
-		return fmt.Errorf("waiting for DNS: %w", err)
-	}
-
 	socketPath := cmd.Flag("listen").Value.String()
 	if err := os.MkdirAll(filepath.Dir(socketPath), os.ModePerm); err != nil {
 		return fmt.Errorf("creating directory for socket: %w", err)
@@ -77,12 +73,19 @@ func run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("removing existing socket: %w", err)
 	}
 
-	l, err := (&net.ListenConfig{}).Listen(ctxSignal, "unix", socketPath)
+	// We ListenUnix specifically to avoid the resolver being initialized, see below.
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath})
 	if err != nil {
 		return fmt.Errorf("listening on socket: %w", err)
 	}
 	defer l.Close()
 	defer os.RemoveAll(socketPath)
+
+	// Wait to accept connections until we have a valid resolv.conf. Otherwise, we won't be able to
+	// connect to remote services and fail the first pull.
+	if err := resolvconf.Wait(ctxSignal, log.WithGroup("DNS")); err != nil {
+		return fmt.Errorf("waiting for DNS: %w", err)
+	}
 
 	s, err := ttrpc.NewServer()
 	if err != nil {


### PR DESCRIPTION
Waiting for the resolv.conf in 1dd624137da11019ad60ac5642bdb70fc1333a18 just moved the race condition from the imagepuller into the agent, which now does not find the imagepuller socket if the server is still waiting, resulting in ENOENT (for the socket). This commit fixes the situation by starting a listener immediately, but only accepting when the resolv.conf is ready.

- [x] [regression](https://github.com/edgelesssys/contrast/actions/runs/24400601694)