### PR TITLE
e2e: wait for container running instead of pod running

### DIFF
--- a/e2e/internal/kubeclient/wait.go
+++ b/e2e/internal/kubeclient/wait.go
@@ -59,7 +59,7 @@ func (c *Kubeclient) WaitForCoordinator(ctx context.Context, namespace string) e
 		return err
 	}
 	ls := labels.SelectorFromSet(s.Spec.Selector.MatchLabels)
-	return c.WaitForPodCondition(ctx, namespace, &oneRunning{ls: ls})
+	return c.WaitForPodCondition(ctx, namespace, &containerRunning{ls: ls, podName: "coordinator-0", containerName: "coordinator"})
 }
 
 // WaitForDaemonSet waits until the DaemonSet is ready.
@@ -300,12 +300,43 @@ func (cr *containerReady) Check(lister listerscorev1.PodLister) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	return checkContainerStatus(pods, cr.podName, cr.containerName, func(cs corev1.ContainerStatus) bool {
+		return cs.Ready
+	}), nil
+}
+
+func (cr *containerReady) String() string {
+	return fmt.Sprintf("PodCondition(container %s in pod %s is ready)", cr.containerName, cr.podName)
+}
+
+// containerRunning checks that a named container in a named pod is running.
+type containerRunning struct {
+	ls            labels.Selector
+	podName       string
+	containerName string
+}
+
+func (cr *containerRunning) Check(lister listerscorev1.PodLister) (bool, error) {
+	pods, err := lister.List(cr.ls)
+	if err != nil {
+		return false, err
+	}
+	return checkContainerStatus(pods, cr.podName, cr.containerName, func(cs corev1.ContainerStatus) bool {
+		return cs.State.Running != nil
+	}), nil
+}
+
+func (cr *containerRunning) String() string {
+	return fmt.Sprintf("PodCondition(container %s in pod %s is running)", cr.containerName, cr.podName)
+}
+
+func checkContainerStatus(pods []*corev1.Pod, podName, containerName string, check func(corev1.ContainerStatus) bool) bool {
 	for _, pod := range pods {
-		if pod.Name != cr.podName {
+		if pod.Name != podName {
 			continue
 		}
 		if pod.DeletionTimestamp != nil {
-			return false, nil
+			return false
 		}
 		for _, statuses := range [][]corev1.ContainerStatus{
 			pod.Status.InitContainerStatuses,
@@ -313,40 +344,11 @@ func (cr *containerReady) Check(lister listerscorev1.PodLister) (bool, error) {
 			pod.Status.EphemeralContainerStatuses,
 		} {
 			for _, cs := range statuses {
-				if cs.Name == cr.containerName {
-					return cs.Ready, nil
+				if cs.Name == containerName {
+					return check(cs)
 				}
 			}
 		}
-		return false, nil
 	}
-	return false, nil
-}
-
-func (cr *containerReady) String() string {
-	return fmt.Sprintf("PodCondition(container %s in pod %s is ready)", cr.containerName, cr.podName)
-}
-
-type oneRunning struct {
-	ls labels.Selector
-}
-
-func (or *oneRunning) Check(lister listerscorev1.PodLister) (bool, error) {
-	pods, err := lister.List(or.ls)
-	if err != nil {
-		return false, err
-	}
-	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil {
-			continue
-		}
-		if pod.Status.Phase == corev1.PodRunning {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func (or *oneRunning) String() string {
-	return fmt.Sprintf("PodCondition(one pod matching %s is running)", or.ls)
+	return false
 }

--- a/e2e/internal/kubeclient/wait_test.go
+++ b/e2e/internal/kubeclient/wait_test.go
@@ -18,7 +18,8 @@ func TestStringRepresentation(t *testing.T) {
 		&numReady{n: 5, ls: sel},
 		&numSucceeded{n: 3, ls: sel},
 		&singlePodReady{name: "my-pod"},
-		&oneRunning{ls: sel},
+		&containerReady{podName: "my-pod", containerName: "my-container"},
+		&containerRunning{ls: sel, podName: "my-pod", containerName: "my-container"},
 	} {
 		t.Run(fmt.Sprintf("%T", cond), func(t *testing.T) {
 			assert := assert.New(t)


### PR DESCRIPTION
We had sporadic failures where the `WaitForCoordinator` method returned true but the container inside the pod could not be found afterwards (e.g., https://github.com/edgelesssys/contrast/actions/runs/24319240177/job/71002411757). I changed the logic to not check for the pod status to be `Running` but check if there is a running *container* matching the desired container name in the pod. My guess is that there is a small window where the pod is considered `Running` but the containers inside might not have startet completely yet. Hopefully this check works a bit better.