### PR TITLE
sets: enable debug output for badaml sets

### DIFF
--- a/overlays/sets/badaml-sandbox.nix
+++ b/overlays/sets/badaml-sandbox.nix
@@ -7,6 +7,14 @@
 _final: prev: {
   contrastPkgs = prev.contrastPkgs.overrideScope (
     contrastPkgsFinal: contrastPkgsPrev: {
+      # Build OVMF with debug output to the serial port so firmware messages
+      # are captured alongside kata/agent logs when a CVM crashes.
+      OVMF-SNP = contrastPkgsPrev.OVMF-SNP.override {
+        debug = true;
+      };
+      OVMF-TDX = contrastPkgsPrev.OVMF-TDX.override {
+        debug = true;
+      };
       kata = contrastPkgsPrev.kata.overrideScope (
         _kataFinal: kataPrev: {
           kernel-uvm = kataPrev.kernel-uvm.override {
@@ -26,6 +34,9 @@ _final: prev: {
       contrast = contrastPkgsPrev.contrast.overrideScope (
         _contrastFinal: contrastPrev: {
           node-installer-image = contrastPrev.node-installer-image.override {
+            inherit (contrastPkgsFinal) OVMF-SNP;
+            inherit (contrastPkgsFinal) OVMF-TDX;
+            withDebug = true;
             withExtraLayers = [
               (contrastPkgsFinal.ociLayerTar {
                 files = [

--- a/overlays/sets/badaml-vuln.nix
+++ b/overlays/sets/badaml-vuln.nix
@@ -4,6 +4,14 @@
 _final: prev: {
   contrastPkgs = prev.contrastPkgs.overrideScope (
     contrastPkgsFinal: contrastPkgsPrev: {
+      # Build OVMF with debug output to the serial port so firmware messages
+      # are captured alongside kata/agent logs when a CVM crashes.
+      OVMF-SNP = contrastPkgsPrev.OVMF-SNP.override {
+        debug = true;
+      };
+      OVMF-TDX = contrastPkgsPrev.OVMF-TDX.override {
+        debug = true;
+      };
       kata = contrastPkgsPrev.kata.overrideScope (
         _kataFinal: kataPrev: {
           kernel-uvm = kataPrev.kernel-uvm.override {
@@ -25,6 +33,9 @@ _final: prev: {
       contrast = contrastPkgsPrev.contrast.overrideScope (
         _contrastFinal: contrastPrev: {
           node-installer-image = contrastPrev.node-installer-image.override {
+            inherit (contrastPkgsFinal) OVMF-SNP;
+            inherit (contrastPkgsFinal) OVMF-TDX;
+            withDebug = true;
             withExtraLayers = [
               (contrastPkgsFinal.ociLayerTar {
                 files = [


### PR DESCRIPTION
Build OVMF with debug output to the serial port and enable the kata debug runtime for badaml-vuln and badaml-sandbox so that firmware, agent, and runtime messages are captured in the host journal when a CVM crashes. This gives us the visibility needed to investigate the intermittent crash seen in nightly runs.