### PR TITLE
overlays/runtimepkgs: redirect OVMF-SNP, badaml-payload, reference-values, snp-id-blocks to x86 builders

### DIFF
--- a/overlays/runtimepkgs.nix
+++ b/overlays/runtimepkgs.nix
@@ -38,6 +38,8 @@ else
               initializer
               node-installer-image
               nodeinstaller
+              reference-values
+              snp-id-blocks
               ;
           }
         );

--- a/overlays/runtimepkgs.nix
+++ b/overlays/runtimepkgs.nix
@@ -43,6 +43,7 @@ else
         );
 
         inherit (final.runtimePkgs)
+          badaml-payload
           debugshell
           service-mesh
           k8s-log-collector
@@ -50,6 +51,7 @@ else
           boot-microvm
           qemu-cc
           pause-bundle
+          OVMF-SNP
           OVMF-TDX
           calculateSnpIDBlock
           ;


### PR DESCRIPTION
See commit messages for details and reproducers. This is not causing issues in main but I discovered these when I was running e2e tests using sets which override `OVMF-SNP` properties (for instance) from my macbook.