### PR TITLE
k8s-log-collector: use short-iso-precise journal format for microseco…

### DIFF
--- a/packages/by-name/k8s-log-collector/collect-host-logs.sh
+++ b/packages/by-name/k8s-log-collector/collect-host-logs.sh
@@ -9,15 +9,15 @@ node="${NODE_NAME:?NODE_NAME must be set}"
 hostdir="/export/logs/host/$node"
 mkdir -p "$hostdir"
 echo "Collecting kernel logs (since $since)..." >&2
-journalctl --directory=/journal -k -q --since="$since" --no-pager >"$hostdir/kernel.log" 2>/dev/null || true
+journalctl --directory=/journal -o short-iso-precise -k -q --since="$since" --no-pager >"$hostdir/kernel.log" 2>/dev/null || true
 echo "Collecting k3s logs (since $since)..." >&2
-journalctl --directory=/journal -u k3s -q --since="$since" --no-pager >"$hostdir/k3s.log" 2>/dev/null || true
+journalctl --directory=/journal -o short-iso-precise -u k3s -q --since="$since" --no-pager >"$hostdir/k3s.log" 2>/dev/null || true
 echo "Collecting kubelet logs (since $since)..." >&2
-journalctl --directory=/journal -u kubelet -q --since="$since" --no-pager >"$hostdir/kubelet.log" 2>/dev/null || true
+journalctl --directory=/journal -o short-iso-precise -u kubelet -q --since="$since" --no-pager >"$hostdir/kubelet.log" 2>/dev/null || true
 echo "Collecting containerd logs (since $since)..." >&2
-journalctl --directory=/journal -u containerd -q --since="$since" --no-pager >"$hostdir/containerd.log" 2>/dev/null || true
+journalctl --directory=/journal -o short-iso-precise -u containerd -q --since="$since" --no-pager >"$hostdir/containerd.log" 2>/dev/null || true
 echo "Collecting kata logs (since $since)..." >&2
-journalctl --directory=/journal -t kata -q --since="$since" --no-pager >"$hostdir/kata.log" 2>/dev/null || true
+journalctl --directory=/journal -o short-iso-precise -t kata -q --since="$since" --no-pager >"$hostdir/kata.log" 2>/dev/null || true
 # Remove empty log files (services not running on this node).
 for f in "$hostdir"/*.log; do
   [[ -s $f ]] || rm -f "$f"


### PR DESCRIPTION
…nd timestamps

The default syslog format journalctl emits has second resolution, which is insufficient for correlating fast-sequence events across log sources. Switch every journalctl invocation in collect-host-logs to short-iso-precise, which prints ISO8601 timestamps with microsecond resolution and timezone, making log entries unambiguous across nodes.