### PR TITLE
e2e: pass genpolicy layer cache to test runner

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -50,6 +50,7 @@ var Flags testFlags
 type testFlags struct {
 	PlatformStr                 string
 	ImageReplacementsFile       string
+	GenpolicyCachePath          string
 	NamespaceFile               string
 	NamespaceSuffix             string
 	NodeInstallerTargetConfType string
@@ -60,6 +61,7 @@ type testFlags struct {
 // RegisterFlags registers the flags that are shared between all tests.
 func RegisterFlags() {
 	flag.StringVar(&Flags.ImageReplacementsFile, "image-replacements", "", "path to image replacements file")
+	flag.StringVar(&Flags.GenpolicyCachePath, "genpolicy-cache-path", "", "path to the genpolicy image layer cache file")
 	flag.StringVar(&Flags.NamespaceFile, "namespace-file", "", "file to store the namespace in")
 	flag.StringVar(&Flags.NamespaceSuffix, "namespace-suffix", "", "suffix to append to the namespace")
 	flag.StringVar(&Flags.PlatformStr, "platform", "", "Deployment platform")
@@ -225,8 +227,11 @@ func (ct *ContrastTest) RunGenerate(ctx context.Context) error {
 		"--image-replacements", ct.ImageReplacementsFile,
 		"--reference-values", ct.Platform.String(),
 		fmt.Sprintf("--insecure-enable-debug-shell-access=%t", Flags.InsecureEnableDebugShell),
-		ct.WorkDir,
 	)
+	if Flags.GenpolicyCachePath != "" {
+		args = append(args, "--genpolicy-cache-path", Flags.GenpolicyCachePath)
+	}
+	args = append(args, ct.WorkDir)
 
 	generate := cmd.NewGenerateCmd()
 	generate.Flags().String("workspace-dir", "", "") // Make generate aware of root flags

--- a/justfile
+++ b/justfile
@@ -118,6 +118,7 @@ _e2e target=default_deploy_target platform=default_platform set=default_set: sof
     trap 'kill $get_logs_pid || true' EXIT
     nix shell .#{{ set }}.contrast.e2e --command {{ target }}.test -test.v \
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
+            --genpolicy-cache-path ./{{ workspace_dir }}/layers-cache.json \
             --namespace-file ./{{ workspace_dir }}/just.namespace \
             --platform {{ platform }} \
             --node-installer-target-conf-type "${node_installer_target_conf_type}" \


### PR DESCRIPTION
contrast generate accepts --genpolicy-cache-path to avoid re-fetching image layer metadata on each invocation. just push already populates workspace/layers-cache.json as a side-effect of pushing containers, so pass it through to the test runner to skip redundant registry traffic during e2e runs.