### PR TITLE
sets: drop redundant OVMF-SNP/TDX inherits from node-installer-image

### DIFF
--- a/overlays/sets/debug.nix
+++ b/overlays/sets/debug.nix
@@ -3,7 +3,7 @@
 
 _final: prev: {
   contrastPkgs = prev.contrastPkgs.overrideScope (
-    contrastPkgsFinal: contrastPkgsPrev: {
+    _contrastPkgsFinal: contrastPkgsPrev: {
       # Build OVMF with debug output to serial port.
       OVMF-SNP = contrastPkgsPrev.OVMF-SNP.override {
         debug = true;
@@ -14,8 +14,6 @@ _final: prev: {
       contrast = contrastPkgsPrev.contrast.overrideScope (
         _contrastFinal: contrastPrev: {
           node-installer-image = contrastPrev.node-installer-image.override {
-            inherit (contrastPkgsFinal) OVMF-SNP;
-            inherit (contrastPkgsFinal) OVMF-TDX;
             withDebug = true;
           };
         }


### PR DESCRIPTION
The OVMF-SNP and OVMF-TDX overrides at the contrastPkgs level already propagate into contrast.node-installer-image via the fixpoint (the contrast sub-scope is built through packagesFromDirectoryRecursive + newScope and resolves its OVMF-SNP/OVMF-TDX args through the parent final). The explicit inherits were a no-op.

Verified by comparing the oci-image-layout drv deps with and without the inherits: both reference the same debug OVMF-SNP drv (which has buildConfig=DEBUG and DEBUG_ON_SERIAL_PORT=TRUE).