### PR TITLE
multiple: fix OVMF-TDX debug build with debug set

### DIFF
--- a/packages/by-name/OVMF-TDX/0002-IntelTdxX64-add-toggle-to-disable-firmware-UI.patch
+++ b/packages/by-name/OVMF-TDX/0002-IntelTdxX64-add-toggle-to-disable-firmware-UI.patch
@@ -4,10 +4,12 @@ Date: Wed, 11 Feb 2026 13:26:05 +0100
 Subject: [PATCH] IntelTdxX64: add toggle to disable firmware UI
 
 Signed-off-by: Paul Meyer <katexochen0@gmail.com>
+Co-authored-by: Spyros Seimenis <sse@edgeless.systems>
 ---
- OvmfPkg/IntelTdx/IntelTdxX64.dsc | 10 ++++++++++
- OvmfPkg/IntelTdx/IntelTdxX64.fdf |  6 ++++--
- 2 files changed, 14 insertions(+), 2 deletions(-)
+ OvmfPkg/IntelTdx/IntelTdxX64.dsc                     | 10 ++++++++++
+ OvmfPkg/IntelTdx/IntelTdxX64.fdf                     |  6 ++++--
+ OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c | 11 +++++++++++
+ 3 files changed, 25 insertions(+), 2 deletions(-)
 
 diff --git a/OvmfPkg/IntelTdx/IntelTdxX64.dsc b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
 index 18fd116311e14f611be609d202339c1deb52a7fb..7294a071ec953bb72b49941882ebfbbed48f6f6c 100644
@@ -69,3 +71,25 @@ index da48f67fb34279ca74636bd42825696db296bb75..238ff73d7ae7bfb08ebdaf14063c7496
  INF  OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf
  INF  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
  INF  MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
+diff --git a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+index b696f1b3389b38757621f7dd289b53a15a7fa8c0..153f509eb7057b884ecff44434dc819cf40e797f 100644
+--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
++++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+@@ -152,6 +152,17 @@ PlatformRegisterOptionsAndKeys (
+   Esc.ScanCode    = SCAN_ESC;
+   Esc.UnicodeChar = CHAR_NULL;
+   Status          = EfiBootManagerGetBootManagerMenu (&BootOption);
++  if (Status == EFI_NOT_FOUND) {
++    //
++    // Firmware was built without BootManagerMenuApp (BUILD_FIRMWARE_UI=FALSE),
++    // so the FFS lookup above returns EFI_NOT_FOUND. In DEBUG builds,
++    // ASSERT_EFI_ERROR below would halt the firmware. Skip F2/ESC hotkey
++    // registration instead, consistent with the graceful handling elsewhere
++    // in this file.
++    //
++    return;
++  }
++
+   ASSERT_EFI_ERROR (Status);
+   Status = EfiBootManagerAddKeyOptionVariable (
+              NULL,

--- a/packages/by-name/kata/calculateTdxLaunchDigests/package.nix
+++ b/packages/by-name/kata/calculateTdxLaunchDigests/package.nix
@@ -30,6 +30,12 @@ let
   # When we get more heterogenous test systems, or when TDX-GPU goes into production use,
   # this needs to be made configurable.
   gpuFlag = lib.optionalString withGPU "-g b200";
+  # The nodeinstaller sets use_legacy_serial=true when withDebug is enabled so
+  # OVMF's DEBUG_ON_SERIAL_PORT output reaches the host. That drops
+  # virtio-serial-pci from the QEMU command line and changes the ACPI tables
+  # the firmware measures into RTMR[0]. Tell tdx-measure so it picks the
+  # matching set of hardcoded ACPI hashes.
+  legacySerialFlag = lib.optionalString withDebug "--legacy-serial";
 in
 
 stdenvNoCC.mkDerivation {
@@ -42,7 +48,7 @@ stdenvNoCC.mkDerivation {
     mkdir $out
 
     ${lib.getExe tdx-measure} mrtd -f ${ovmf-tdx} --eventlog-dir eventlogs > $out/mrtd.hex
-    ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 0 > $out/rtmr0.hex
+    ${lib.getExe tdx-measure} rtmr ${gpuFlag} ${legacySerialFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 0 > $out/rtmr0.hex
     ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 1 > $out/rtmr1.hex
     ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 2 > $out/rtmr2.hex
     ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 3 > $out/rtmr3.hex

--- a/tools/tdx-measure/main.go
+++ b/tools/tdx-measure/main.go
@@ -128,6 +128,7 @@ func newRtMrCmd() *cobra.Command {
 	}
 	cmd.Flags().StringP("cmdline", "c", "", "kernel command line")
 	cmd.Flags().StringP("gpu-model", "g", "none", "GPU model used in the VM (none, h100, b200)")
+	cmd.Flags().Bool("legacy-serial", false, "VM uses -serial chardev:... instead of virtio-serial-pci (changes ACPI topology)")
 	return cmd
 }
 
@@ -152,7 +153,11 @@ func runRtMr(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid gpu model: %w", err)
 		}
-		digest, err = rtmr.CalcRtmr0(firmware, gpuModel)
+		legacySerial, err := cmd.Flags().GetBool("legacy-serial")
+		if err != nil {
+			return err
+		}
+		digest, err = rtmr.CalcRtmr0(firmware, gpuModel, legacySerial)
 		if err != nil {
 			return fmt.Errorf("can't calculate RTMR 0: %w", err)
 		}

--- a/tools/tdx-measure/rtmr/rtmr.go
+++ b/tools/tdx-measure/rtmr/rtmr.go
@@ -112,8 +112,11 @@ var (
 	}
 )
 
-// CalcRtmr0 calculates RTMR[0] for the given firmware.
-func CalcRtmr0(firmware []byte, gpu GPUModel) ([48]byte, error) {
+// CalcRtmr0 calculates RTMR[0] for the given firmware. If legacySerial is true,
+// the hardcoded ACPI hashes for a VM launched with -serial chardev:... are
+// used instead of the ones for a VM with virtio-serial-pci; the two topologies
+// produce different ACPI tables.
+func CalcRtmr0(firmware []byte, gpu GPUModel, legacySerial bool) ([48]byte, error) {
 	var rtmr Rtmr
 
 	// We don't measure the Hobs, the firmware verifies them instead.
@@ -142,16 +145,47 @@ func CalcRtmr0(firmware []byte, gpu GPUModel) ([48]byte, error) {
 	rtmr.extendSeparator()
 
 	// TODO(freax13): Don't hard-code these, calculate them instead.
+	//
+	// TODO(sespiros): the obvious approach of invoking qemu in the Nix
+	// build and hashing etc/acpi/* via fw_cfg does not work in a pure
+	// build sandbox (tdx-guest needs KVM, vhost-vsock-pci needs
+	// /dev/vhost-vsock). Refresh the digests by hand from inside any
+	// pod running on the set you want to capture. OVMF writes a TCG
+	// CC event log as it extends the RTMRs, and Linux exposes the
+	// raw log at /sys/firmware/acpi/tables/data/CCEL. Each ACPI DATA
+	// event's 48-byte SHA-384 digest sits 52 bytes before the marker
+	// (TCG_PCR_EVENT2: digest[48] + eventSize[4]):
+	//
+	//   kubectl exec -i -n <ns> <pod> -c contrast-debug-shell -- \
+	//       debugshell '
+	//     F=/sys/firmware/acpi/tables/data/CCEL
+	//     for off in $(grep -aob "ACPI DATA" "$F" | cut -d: -f1); do
+	//       dd if="$F" bs=1 skip=$((off-52)) count=48 status=none \
+	//         | xxd -p -c 48
+	//     done'
+	//
+	// Prints three digests in OVMF's measurement order; paste them
+	// into the matching hash set below.
 	acpiHashes := []string{
-		// These are the hashes for the ACPI tables (ACPI DATA).
-		// They might change depending on firmware/qemu version or qemu command line.
+		// Default (virtio-serial-pci + virtconsole) topology.
 		"978413224c711ace8c588bd45f9585657572c8053410df87f94bed7254feb88b4ce82233ead3db3721198a3a215efc1b",
 		"7d49579cd2b17a399b29b8fd40f2fd66bf3d0fafcbfdfd9a3b912b7d4f81dd7dba85ee15768b36214d7507dc10fc6464",
 		"4f564889e597ba62b02a0f5ad95ad9f8883947deadc3275fe289f5096c01ed3db8323d70681d04f694c025ee8426be11",
 	}
+	legacySerialAcpiHashes := []string{
+		// Legacy-serial topology, used when kata sets use_legacy_serial=true
+		// (debug set) so OVMF's DEBUG_ON_SERIAL_PORT output reaches the host.
+		"8916ff48d947a6c51cdd91015d1cac0c0fdaddb4f008730fb9f275521affea17c4dac10372f7073a5bfa22e53411ab34",
+		"855f3ccb8bc8d4f66f0097d8b893a62d9e8a903c0da1663bc03a1a268b0dc3e826d82199c5e4a3721a6d83e692b4a6dc",
+		"94c46e0d8c85d3632c241f6bcfba203287259711ab9616fa1f1174cdd2e30e777f9b393ef93b8aa4ac721deef3f54a59",
+	}
 	var configHashes []string
 	if gpu == GPUModelNone {
-		configHashes = slices.Concat(acpiHashes)
+		if legacySerial {
+			configHashes = slices.Concat(legacySerialAcpiHashes)
+		} else {
+			configHashes = slices.Concat(acpiHashes)
+		}
 	}
 	for _, hash := range configHashes {
 		var buffer [48]byte


### PR DESCRIPTION
`set=debug just` on TDX failed for two unrelated reasons:

1. We carry a patch for OVMF-TDX which enables `BUILD_FIRMWARE_UI=FALSE` which strips `BootManagerMenuApp` from the firmware volume. In OVMF debug builds (which we now do as part of the debug set), `PlatformRegisterOptionsAndKeys` asserts on the resulting `EFI_NOT_FOUND` and halts before the guest boots. Fixed by amending `0002-IntelTdxX64-add-toggle-to-disable-firmware-UI.patch` to return early on `EFI_NOT_FOUND`.

2. The debug set now also sets `use_legacy_serial=true` to make it possible to get early OVMF messages. This changes QEMU's PCI/ACPI topology. OVMF then extends different hashes into RTMR[0] than the hardcoded ones in `tdx-measure`, so attestation fails. Fixed by adding a second hash set for the legacy-serial topology, selected via a new `--legacy-serial` flag.