### PR TITLE
ci: add minimal integration of sets with ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,10 @@ on:
       debug-shell:
         description: "Debug shell"
         type: boolean
+      set:
+        description: "Package set override (e.g. debug). Empty falls back to the test-name derived default."
+        type: string
+        default: ""
     secrets:
       GITHUB_TOKEN_IN:
         required: true
@@ -39,7 +43,7 @@ env:
 
 jobs:
   test:
-    name: "${{ inputs.test-name }}${{ inputs.debug-shell && ' (with debug shell)' || '' }}"
+    name: "${{ inputs.test-name }}${{ inputs.debug-shell && ' (with debug shell)' || '' }}${{ inputs.set != '' && format(' [{0}]', inputs.set) || '' }}"
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
@@ -53,6 +57,7 @@ jobs:
       DEBUG_SHELL: ${{ inputs.debug-shell }}
       SET: >-
         ${{
+          (inputs.set != '' && inputs.set) ||
           (inputs.test-name == 'badaml-sandbox' && 'badaml-sandbox') ||
           (inputs.test-name == 'badaml-vuln' && 'badaml-vuln') ||
           'base'
@@ -131,7 +136,7 @@ jobs:
         if: always() && steps.skipped.outputs.skipped == 'false'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: e2e_pod_logs-${{ inputs.platform }}-${{ inputs.test-name }}${{ inputs.debug-shell && '-debug-shell' || '' }}
+          name: e2e_pod_logs-${{ inputs.platform }}-${{ inputs.test-name }}${{ inputs.debug-shell && '-debug-shell' || '' }}${{ inputs.set != '' && format('-{0}', inputs.set) || '' }}
           path: workspace/logs
           if-no-files-found: error
       - name: Notify teams channel of failure

--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -44,6 +44,17 @@ on:
           - Metal-QEMU-SNP-GPU
           - Metal-QEMU-TDX
           - Metal-QEMU-TDX-GPU
+      set:
+        description: "Package set"
+        required: false
+        type: choice
+        options:
+          - base
+          - debug
+          - badaml-sandbox
+          - badaml-vuln
+          - testcase-default
+        default: testcase-default
       skip-undeploy:
         description: "Skip undeploy"
         required: false
@@ -102,6 +113,7 @@ jobs:
       runner: ${{ needs.determine-platform-params.outputs.runner }}
       self-hosted: ${{ fromJSON(needs.determine-platform-params.outputs.self-hosted) }}
       debug-shell: ${{ inputs.debug-shell }}
+      set: ${{ inputs.set != 'default' && inputs.set || '' }}
     secrets:
       GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -72,6 +72,7 @@ jobs:
           - volumestatefulset
           - workloadsecret
           # keep-sorted end
+        set: [""]
         exclude:
           - platform:
               name: Metal-QEMU-SNP
@@ -83,6 +84,38 @@ jobs:
             test-name: badaml-vuln
           - debug-shell: false
             test-name: badaml-sandbox
+        include:
+          # Exercise the debug set on every platform with the cheapest
+          # per-platform test, to catch regressions in the debug overlay
+          # that the base-set matrix cannot surface.
+          - set: debug
+            debug-shell: false
+            test-name: openssl
+            platform:
+              name: Metal-QEMU-SNP
+              runner: SNP
+              self-hosted: true
+          - set: debug
+            debug-shell: false
+            test-name: gpu
+            platform:
+              name: Metal-QEMU-SNP-GPU
+              runner: SNP-GPU
+              self-hosted: true
+          - set: debug
+            debug-shell: false
+            test-name: openssl
+            platform:
+              name: Metal-QEMU-TDX
+              runner: TDX
+              self-hosted: true
+          - set: debug
+            debug-shell: false
+            test-name: gpu
+            platform:
+              name: Metal-QEMU-TDX-GPU
+              runner: TDX-GPU
+              self-hosted: true
       fail-fast: false
     name: "${{ matrix.platform.name }}"
     uses: ./.github/workflows/e2e.yml
@@ -93,6 +126,7 @@ jobs:
       runner: ${{ matrix.platform.runner }}
       self-hosted: ${{ matrix.platform.self-hosted }}
       debug-shell: ${{ matrix.debug-shell }}
+      set: ${{ matrix.set }}
     secrets:
       GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN_IN || secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
- run `e2e openssl` on non-gpu nodes and `e2e gpu` on gpu nodes using the debug set, as a smoke test during nightly runs
- add a set selector in the e2e manually dispatched workflow

- [x] [manual run with set=debug just e2e openssl Metal-QEMU-SNP](https://github.com/edgelesssys/contrast/actions/runs/24780943153)
- [ ] [manual run with set=debug just e2e gpu Metal-QEMU-SNP-GPU](https://github.com/edgelesssys/contrast/actions/runs/24780757579)
- [ ] [manual run with set=debug just e2e openssl Metal-QEMU-TDX](https://github.com/edgelesssys/contrast/actions/runs/24780686278) This is the one that is broken and will pass after https://github.com/edgelesssys/contrast/pull/2338 is merged
- [ ] [manual run with set=debug just e2e gpu Metal-QEMU-TDX-GPU](https://github.com/edgelesssys/contrast/actions/runs/24780975309)