### PR TITLE
kata: add darwin-compat patch for genpolicy's FileType::from

### DIFF
--- a/packages/by-name/kata/genpolicy/package.nix
+++ b/packages/by-name/kata/genpolicy/package.nix
@@ -11,6 +11,7 @@
   libiconv,
   zlib,
   cmake,
+  stdenv,
   stdenvNoCC,
   applyPatches,
 }:
@@ -57,6 +58,9 @@ rustPlatform.buildRustPackage rec {
   preBuild = ''
     make -C src/tools/genpolicy src/version.rs
   '';
+
+  # TODO(sespiros): drop once kata-agent-policy compiles on Darwin upstream.
+  doCheck = stdenv.hostPlatform.isLinux;
 
   # Only run library tests, the integration tests need internet access.
   cargoTestFlags = [


### PR DESCRIPTION
Lets genpolicy build as an aarch64-darwin Mach-O binary for the contrast CLI.

https://github.com/kata-containers/kata-containers/compare/main...sespiros:kata-containers:darwin-libc-mode