### PR TITLE
dev-docs: pin git format-patch to myers diff algorithm

### DIFF
--- a/dev-docs/patches.md
+++ b/dev-docs/patches.md
@@ -86,7 +86,7 @@ When updating a package, you might need to rebase the current patch set.
 When done, recreate the patch set:
 
 ```sh
-git format-patch -N --no-signature --zero-commit --full-index -o $pkgDir $rev
+git format-patch -N --no-signature --zero-commit --full-index --diff-algorithm=myers -o $pkgDir $rev
 ```
 
 Don't forget to `git add` patches you just added and to `git rm` patches you removed or renamed.


### PR DESCRIPTION
Users with a non-default 'diff.algorithm' in their global git config (e.g. 'patience') otherwise produce byte-different patches from the same commit range, which creates spurious churn whenever the patch set is regenerated.