### PR TITLE
nodeinstaller: add target config for RKE2

### DIFF
--- a/.github/actions/release_artifacts/action.yml
+++ b/.github/actions/release_artifacts/action.yml
@@ -120,6 +120,7 @@ runs:
         workspace/mysql-demo.yml
         workspace/vault-demo.yml
         workspace/node-installer-target-config-k3s.yml
+        workspace/node-installer-target-config-rke2.yml
         EOM
         EOF
     - name: Create coordinator resource definitions
@@ -174,11 +175,18 @@ runs:
       env:
         SET: base
       run: |
-        nix shell ".#${SET}.contrast.resourcegen" --command resourcegen \
-          --node-installer-target-conf-type k3s \
-          --namespace contrast-system \
-          --add-namespace-object \
-          node-installer-target-conf > workspace/node-installer-target-config-k3s.yml
+        set -u
+        distros=(
+          k3s
+          rke2
+        )
+        for distro in "${distros[@]}"; do
+          nix shell ".#${SET}.contrast.resourcegen" --command resourcegen \
+            --node-installer-target-conf-type "${distro}" \
+            --namespace contrast-system \
+            --add-namespace-object \
+            node-installer-target-conf > "workspace/node-installer-target-config-${distro}.yml"
+        done
     - uses: ./.github/actions/build_cli
       with:
         system: x86_64-linux

--- a/.github/workflows/k8s_compatibility.yml
+++ b/.github/workflows/k8s_compatibility.yml
@@ -1,4 +1,4 @@
-name: test nodeinstaller k3s compatibility
+name: test nodeinstaller k8s distro compatibility
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
     - cron: "16 6 * * 6" # 6:16 on Saturdays
   pull_request:
     paths:
-      - .github/workflows/k3s_compatibility.yml
+      - .github/workflows/k8s_compatibility.yml
 
 env:
   container_registry: ghcr.io/edgelesssys
@@ -17,6 +17,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        distro:
+          - k3s
+          - rke2
     env:
       SET: base
     steps:
@@ -35,21 +40,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN_IN || secrets.GITHUB_TOKEN }}
       - name: Create justfile.env
+        env:
+          DISTRO: ${{ matrix.distro }}
         run: |
           cat <<EOF > justfile.env
           container_registry=${{ env.container_registry }}
           # TDX does not require an ID Block, so we don't check the hardware.
           # This allows us to run the test on a GitHub runner.
           default_platform="Metal-QEMU-TDX"
-          node_installer_target_conf_type="k3s"
+          node_installer_target_conf_type="${DISTRO}"
           set=${SET}
           EOF
       - name: Build and push container images
         run: |
           just node-installer
       - name: Install K3s
+        if: matrix.distro == 'k3s'
         run: |
           curl -sfL https://get.k3s.io | K3S_KUBECONFIG_OUTPUT=~/.kube/config K3S_KUBECONFIG_MODE="644" sh -
+      - name: Install RKE2
+        if: matrix.distro == 'rke2'
+        run: |
+          mkdir -p "$HOME/.kube"
+          sudo mkdir -p /etc/rancher/rke2
+          sudo tee -a /etc/rancher/rke2/config.yaml <<EOF
+          write-kubeconfig: "$HOME/.kube/config"
+          write-kubeconfig-mode: "0644"
+          EOF
+          curl -sfL https://get.rke2.io | sudo sh -
+          sudo systemctl start rke2-server
+          sudo ln -s /var/lib/rancher/rke2/bin/crictl /usr/local/bin/crictl
+          # Not a typo, RKE2 launches containerd with the k3s socket path.
+          echo "CONTAINER_RUNTIME_ENDPOINT=/run/k3s/containerd/containerd.sock" >>"${GITHUB_ENV}"
       - name: Deploy Contrast Node Installer
         run: |
           just write-namespace default
@@ -61,7 +83,7 @@ jobs:
       - name: Check configured runtimes
         run: |
           runtimehandler=$(yq 'select(.kind=="RuntimeClass") | .handler' < workspace/runtime/runtime.yml)
-          sudo crictl info | jq -e --arg rh "$runtimehandler" '.config.containerd.runtimes[$rh]'
+          sudo -E crictl info | jq -e --arg rh "$runtimehandler" '.config.containerd.runtimes[$rh]'
       - name: Notify teams channel of failure
         if: failure() && github.event_name == 'schedule' && github.run_attempt == 1
         uses: ./.github/actions/post_to_teams

--- a/docs/docs/howto/cluster-setup/bare-metal.md
+++ b/docs/docs/howto/cluster-setup/bare-metal.md
@@ -85,7 +85,7 @@ Contrast can be deployed with different Kubernetes distributions, provided that 
 
 The default configuration should work for a vanilla containerd installation.
 Other Kubernetes variants may need subtle tweaks.
-We'll show a configuration for k3s below, see [the node installer configuration reference](../../reference/node-installer-configuration.md) for more details.
+We'll show configurations for k3s and RKE2 below, see [the node installer configuration reference](../../reference/node-installer-configuration.md) for more details.
 
 ### K3s
 
@@ -106,12 +106,40 @@ kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/downloa
 If you need to pull large images, configure K3s to use a longer `runtime-request-timeout` duration than the [default value of 2 minutes](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) used by the kubelet,
 for example by setting
 
-```bash
+```yaml
 kubelet-arg:
   - "runtime-request-timeout=5m"
 ```
 
 in `/etc/rancher/k3s/config.yaml`.
+
+### RKE2
+
+[RKE2](https://docs.rke2.io/) is Rancher's enterprise-ready next-generation Kubernetes distribution.
+
+1. Follow the [RKE2 setup instructions](https://docs.rke2.io/) to create a cluster.
+   Only the Contrast runtime installation is currently tested on RKE2.
+2. Install a block storage provider such as [Longhorn](https://longhorn.io/docs/1.9.1/deploy/install/install-with-helm/) and mark it as the default storage class.
+3. Ensure that a load balancer controller is installed.
+   RKE2 doesn't come with a bundled load balancer controller.
+
+Then, install the ConfigMap to configure the Contrast node-installer for use with RKE2:
+
+```sh
+kubectl apply -f https://github.com/edgelesssys/contrast/releases/latest/download/node-installer-target-config-rke2.yml
+```
+
+If you need to pull large images, configure RKE2 to use a longer `runtime-request-timeout` duration than the [default value of 2 minutes](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) used by the kubelet,
+for example by setting
+
+```yaml
+kubelet-arg:
+  - "runtime-request-timeout=5m"
+```
+
+in `/etc/rancher/rke2/config.yaml`.
+
+<!-- TODO(burgerdev): add instructions for kubeadm and make the k8s distros tabs instead of sections. -->
 
 ## Preparing a cluster for GPU usage
 

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -155,6 +155,12 @@ func NodeInstallerTargetConfig(target string) (*applycorev1.ConfigMapApplyConfig
 				"containerd-config-path": "var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl",
 				"systemd-unit-name":      "k3s.service,k3s-agent.service",
 			}), nil
+	case "rke2":
+		return applycorev1.ConfigMap("contrast-node-installer-target-config", ns).
+			WithData(map[string]string{
+				"containerd-config-path": "var/lib/rancher/rke2/agent/etc/containerd/config.toml.tmpl",
+				"systemd-unit-name":      "rke2-server.service,rke2-agent.service",
+			}), nil
 	default:
 		return nil, fmt.Errorf("unsupported target %q", target)
 	}


### PR DESCRIPTION
This PR adds a new nodeinstaller target config for [RKE2](https://docs.rke2.io/), integrates it into the `k3s_compatibility` test (which now is a matrix testing somewhat supported k8s distros), includes the config in the release and documents the setup on RKE2.

NOTE: RKE2 support is not fully tested in Contrast CI, we only verify that the installation works as expected.