### PR TITLE
[5/8] coordinator: support insecure manifests behind opt-in

### DIFF
--- a/coordinator/internal/userapi/userapi.go
+++ b/coordinator/internal/userapi/userapi.go
@@ -60,6 +60,10 @@ type Server struct {
 	guard     guard
 	discovery discovery
 
+	// allowInsecure selects the manifest security level accepted by the Coordinator. It defaults to
+	// secure manifests and can be switched to insecure manifests via MakeInsecure.
+	allowInsecure bool
+
 	userapi.UnimplementedUserAPIServer
 }
 
@@ -70,6 +74,14 @@ func New(logger *slog.Logger, guard guard, discovery discovery) *Server {
 		guard:     guard,
 		discovery: discovery,
 	}
+}
+
+// MakeInsecure configures the Server to accept only manifests that contain insecure platforms.
+//
+// This voids the security guarantees of the deployment and must only be used for testing or
+// benchmarking. It should be called before the Server starts serving requests.
+func (s *Server) MakeInsecure() {
+	s.allowInsecure = true
 }
 
 // SetManifest registers a new manifest at the Coordinator.
@@ -146,6 +158,11 @@ func (s *Server) SetManifest(ctx context.Context, req *userapi.SetManifestReques
 			Salt:       salt,
 			SeedShares: seedShares,
 		}
+	}
+
+	if err := s.checkManifestSecurity(m); err != nil {
+		s.logger.Warn("SetManifest rejected the manifest", "err", err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	state, err := s.guard.UpdateState(ctx, oldState, se, req.GetManifest(), req.GetPolicies())
@@ -229,18 +246,40 @@ func (s *Server) Recover(ctx context.Context, req *userapi.RecoverRequest) (*use
 		s.logger.Info("Skipping sanity checks because user recovery was forced")
 	}
 
-	_, err = s.guard.ResetState(ctx, oldState, &seedAuthorizer{req: req})
+	_, err = s.guard.ResetState(ctx, oldState, &seedAuthorizer{req: req, checkManifestSecurity: s.checkManifestSecurity})
 	if err != nil {
 		return nil, fmt.Errorf("resetting state: %w", err)
 	}
 	return &userapi.RecoverResponse{}, nil
 }
 
+// checkManifestSecurity verifies that the manifest doesn't mix secure and insecure platforms and
+// that its security level matches the Coordinator's configuration.
+func (s *Server) checkManifestSecurity(mnfst *manifest.Manifest) error {
+	hasInsecure := mnfst.HasInsecurePlatforms()
+	hasSecure := mnfst.HasSecurePlatforms()
+
+	if hasInsecure && hasSecure {
+		return ErrMixedManifestNotAllowed
+	}
+	if hasInsecure && !s.allowInsecure {
+		return ErrInsecureNotAllowed
+	}
+	if !hasInsecure && s.allowInsecure {
+		return ErrSecureNotAllowed
+	}
+	return nil
+}
+
 type seedAuthorizer struct {
-	req *userapi.RecoverRequest
+	req                   *userapi.RecoverRequest
+	checkManifestSecurity func(*manifest.Manifest) error
 }
 
 func (a *seedAuthorizer) AuthorizeByManifest(ctx context.Context, mnfst *manifest.Manifest) (*seedengine.SeedEngine, *ecdsa.PrivateKey, error) {
+	if err := a.checkManifestSecurity(mnfst); err != nil {
+		return nil, nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
 	if err := validatePeer(ctx, mnfst.SeedshareOwnerPubKeys); err != nil {
 		return nil, nil, status.Errorf(codes.PermissionDenied, "peer not authorized to recover existing state: %v", err)
 	}
@@ -337,6 +376,18 @@ var (
 	ErrAlreadyRecovered = errors.New("coordinator is already recovered")
 	// ErrNeedsRecovery is returned if state exists, but no secrets are available, e.g. after restart.
 	ErrNeedsRecovery = errors.New("coordinator is in recovery mode")
+
+	// ErrInsecureNotAllowed is returned when a manifest contains insecure platforms but the
+	// Coordinator is not configured to allow them.
+	ErrInsecureNotAllowed = errors.New("manifest contains insecure platforms, but the coordinator is not configured to allow them")
+
+	// ErrMixedManifestNotAllowed is returned when a manifest mixes secure and insecure platforms.
+	// Manifests must be either all-secure or all-insecure.
+	ErrMixedManifestNotAllowed = errors.New("manifest must not mix secure and insecure platforms")
+
+	// ErrSecureNotAllowed is returned when a secure manifest is submitted to a Coordinator that is
+	// configured to accept only insecure manifests.
+	ErrSecureNotAllowed = errors.New("secure manifest is not allowed when the coordinator is configured for insecure manifests")
 
 	errNoSignature = errors.New("manifest signature is empty")
 )

--- a/coordinator/internal/userapi/userapi_test.go
+++ b/coordinator/internal/userapi/userapi_test.go
@@ -232,6 +232,70 @@ func TestSetManifest(t *testing.T) {
 		require.Equal(codes.InvalidArgument, status.Code(err))
 	})
 
+	t.Run("manifest security matches coordinator", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			allowInsecure bool
+			manifest      func(*testing.T) *manifest.Manifest
+			wantErr       error
+		}{
+			{
+				name:     "secure coordinator accepts secure manifest",
+				manifest: func(*testing.T) *manifest.Manifest { return manifestWithTrustedKey },
+			},
+			{
+				name:     "secure coordinator rejects insecure manifest",
+				manifest: newInsecureManifest,
+				wantErr:  ErrInsecureNotAllowed,
+			},
+			{
+				name:     "secure coordinator rejects mixed manifest",
+				manifest: newMixedManifest,
+				wantErr:  ErrMixedManifestNotAllowed,
+			},
+			{
+				name:          "insecure coordinator rejects secure manifest",
+				allowInsecure: true,
+				manifest:      func(*testing.T) *manifest.Manifest { return manifestWithTrustedKey },
+				wantErr:       ErrSecureNotAllowed,
+			},
+			{
+				name:          "insecure coordinator accepts insecure manifest",
+				allowInsecure: true,
+				manifest:      newInsecureManifest,
+			},
+			{
+				name:          "insecure coordinator rejects mixed manifest",
+				allowInsecure: true,
+				manifest:      newMixedManifest,
+				wantErr:       ErrMixedManifestNotAllowed,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				require := require.New(t)
+				coordinator := newCoordinator()
+				if tc.allowInsecure {
+					coordinator.MakeInsecure()
+				}
+
+				manifestBytes, err := json.Marshal(tc.manifest(t))
+				require.NoError(err)
+				resp, err := coordinator.SetManifest(t.Context(), &userapi.SetManifestRequest{Manifest: manifestBytes})
+				if tc.wantErr == nil {
+					require.NoError(err)
+					require.NotNil(resp)
+					return
+				}
+
+				require.Error(err)
+				require.Equal(codes.InvalidArgument, status.Code(err))
+				require.ErrorContains(err, tc.wantErr.Error())
+			})
+		}
+	})
+
 	t.Run("atomic manifest update", func(t *testing.T) {
 		require := require.New(t)
 
@@ -517,6 +581,74 @@ func TestRecoveryFlow(t *testing.T) {
 	// Recover on a recovered Guard should fail.
 	_, err = a.Recover(ctx, recoverReq)
 	require.Error(err)
+}
+
+// TestRecoveryManifestSecurityMustMatchCoordinator verifies that recovery enforces the same
+// security-level matching as setting a manifest.
+func TestRecoveryManifestSecurityMustMatchCoordinator(t *testing.T) {
+	testCases := []struct {
+		name          string
+		insecure      bool
+		manifest      func(*testing.T) ([]byte, [][]byte)
+		mismatchError error
+	}{
+		{
+			name:          "secure manifest",
+			manifest:      newManifestWithSeedshareOwner,
+			mismatchError: ErrSecureNotAllowed,
+		},
+		{
+			name:          "insecure manifest",
+			insecure:      true,
+			manifest:      newInsecureManifestWithSeedshareOwner,
+			mismatchError: ErrInsecureNotAllowed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			logger := slog.Default()
+			fs := afero.NewMemMapFs()
+			store := aferostore.New(&afero.Afero{Fs: fs})
+			hist := history.NewWithStore(slog.Default(), store)
+			coordinator := New(logger, stateguard.New(hist, prometheus.NewRegistry(), logger), &stubDiscovery{})
+			if tc.insecure {
+				coordinator.MakeInsecure()
+			}
+
+			manifestBytes, policies := tc.manifest(t)
+			resp, err := coordinator.SetManifest(t.Context(), &userapi.SetManifestRequest{
+				Manifest: manifestBytes,
+				Policies: policies,
+			})
+			require.NoError(err)
+			require.Len(resp.SeedSharesDoc.SeedShares, 1)
+			seedShareOwnerKey := testkeys.RSA(t)
+			seed, err := manifest.DecryptSeedShare(seedShareOwnerKey, resp.SeedSharesDoc.SeedShares[0])
+			require.NoError(err)
+
+			recoverReq := &userapi.RecoverRequest{
+				Seed: seed,
+				Salt: resp.SeedSharesDoc.Salt,
+			}
+			ctx := rpcContext(t.Context(), seedShareOwnerKey)
+
+			mismatched := New(logger, stateguard.New(hist, prometheus.NewRegistry(), logger), &stubDiscovery{})
+			if !tc.insecure {
+				mismatched.MakeInsecure()
+			}
+			_, err = mismatched.Recover(ctx, recoverReq)
+			require.ErrorContains(err, tc.mismatchError.Error())
+
+			matching := New(logger, stateguard.New(hist, prometheus.NewRegistry(), logger), &stubDiscovery{})
+			if tc.insecure {
+				matching.MakeInsecure()
+			}
+			_, err = matching.Recover(ctx, recoverReq)
+			require.NoError(err)
+		})
+	}
 }
 
 // TestUserAPIConcurrent tests potential synchronization problems between the different
@@ -855,6 +987,46 @@ func newCoordinatorWithRegistry(reg *prometheus.Registry) *Server {
 	hist := history.NewWithStore(slog.Default(), store)
 	auth := stateguard.New(hist, reg, logger)
 	return New(logger, auth, &stubDiscovery{})
+}
+
+func newInsecureManifest(t *testing.T) *manifest.Manifest {
+	t.Helper()
+	mnfst := &manifest.Manifest{}
+	mnfst.ReferenceValues.SNP = []manifest.SNPReferenceValues{
+		{Platform: "Metal-QEMU-Insecure"},
+	}
+	return mnfst
+}
+
+func newInsecureManifestWithSeedshareOwner(t *testing.T) ([]byte, [][]byte) {
+	t.Helper()
+	policy := []byte("=== SOME REGO HERE ===")
+	policyHash := sha256.Sum256(policy)
+	policyHashHex := manifest.NewHexString(policyHash[:])
+
+	mnfst := newInsecureManifest(t)
+	mnfst.Policies = map[manifest.HexString]manifest.PolicyEntry{
+		policyHashHex: {
+			SANs:             []string{"test"},
+			WorkloadSecretID: "test2",
+			Role:             manifest.RoleCoordinator,
+		},
+	}
+	seedShareOwnerKey := testkeys.RSA(t)
+	mnfst.SeedshareOwnerPubKeys = []manifest.HexString{manifest.MarshalSeedShareOwnerKey(&seedShareOwnerKey.PublicKey)}
+	mnfstBytes, err := json.Marshal(mnfst)
+	require.NoError(t, err)
+	return mnfstBytes, [][]byte{policy}
+}
+
+func newMixedManifest(t *testing.T) *manifest.Manifest {
+	t.Helper()
+	mnfst := &manifest.Manifest{}
+	mnfst.ReferenceValues.SNP = []manifest.SNPReferenceValues{
+		{Platform: "Metal-QEMU-Insecure"},
+		{Platform: "Metal-QEMU-SNP"},
+	}
+	return mnfst
 }
 
 func newCoordinatorWithWatcher(t *testing.T, hist *history.History) *Server {

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -52,6 +52,7 @@ import (
 
 const (
 	metricsEnvVar       = "CONTRAST_METRICS"
+	allowInsecureEnvVar = "CONTRAST_ALLOW_INSECURE"
 	probeAndMetricsPort = 9102
 	// transitEngineAPIPort specifies the default port to expose the transit engine API.
 	transitEngineAPIPort = "8200"
@@ -126,7 +127,12 @@ func run() (retErr error) {
 
 	userAPICredentials := atlscredentials.New(issuer, nil, atls.NoMetrics, loggerpkg.NewNamed(logger, "atlscredentials"))
 	userAPIServer := newGRPCServer(userAPICredentials, serverMetrics)
-	userapi.RegisterUserAPIServer(userAPIServer, userapiserver.New(logger, meshAuth, discovery))
+	userapiService := userapiserver.New(logger, meshAuth, discovery)
+	if os.Getenv(allowInsecureEnvVar) != "" {
+		logger.Warn("Coordinator is configured to allow insecure manifests")
+		userapiService.MakeInsecure()
+	}
+	userapi.RegisterUserAPIServer(userAPIServer, userapiService)
 	serverMetrics.InitializeMetrics(userAPIServer)
 
 	month := 30 * 24 * time.Hour

--- a/internal/atls/issuer/issuer_linux.go
+++ b/internal/atls/issuer/issuer_linux.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/attestation/insecure"
 	snpissuer "github.com/edgelesssys/contrast/internal/attestation/snp/issuer"
 	tdxissuer "github.com/edgelesssys/contrast/internal/attestation/tdx/issuer"
 	"github.com/edgelesssys/contrast/internal/logger"
@@ -30,6 +31,14 @@ func New(log *slog.Logger, collateralProxy string) (atls.Issuer, error) {
 			logger.NewWithAttrs(logger.NewNamed(log, "issuer"), map[string]string{"tee-type": "tdx"}),
 		), nil
 	default:
-		return nil, fmt.Errorf("unsupported platform: %T", cpuid.CPU)
+		allowed, err := insecure.AttestationAllowed()
+		if err != nil {
+			return nil, fmt.Errorf("checking insecure attestation opt-in: %w", err)
+		}
+		if !allowed {
+			return nil, fmt.Errorf("unsupported platform: %T", cpuid.CPU)
+		}
+		log.Warn("No TEE platform detected, using insecure attestation issuer")
+		return insecure.NewIssuer(), nil
 	}
 }

--- a/internal/attestation/insecure/cmdline.go
+++ b/internal/attestation/insecure/cmdline.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package insecure
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// kernelCmdlinePath is the path to the kernel command line.
+const kernelCmdlinePath = "/proc/cmdline"
+
+// cmdlineFlag is the kernel command-line flag that opts a node into insecure (non-CC) attestation.
+const cmdlineFlag = "contrast.allow_insecure_attestation=1"
+
+// AttestationAllowed reports whether the kernel command line opts this node into insecure (non-CC)
+// attestation via the contrast.allow_insecure_attestation=1 flag.
+func AttestationAllowed() (bool, error) {
+	cmdline, err := os.ReadFile(kernelCmdlinePath)
+	if err != nil {
+		return false, fmt.Errorf("reading kernel command line: %w", err)
+	}
+	return slices.Contains(strings.Fields(string(cmdline)), cmdlineFlag), nil
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -91,6 +91,10 @@ func (m *Manifest) Validate() error {
 		errs = append(errs, newValidationError("ReferenceValues", err))
 	}
 
+	if m.HasInsecurePlatforms() && m.HasSecurePlatforms() {
+		errs = append(errs, newValidationError("ReferenceValues", errors.New("manifest must not mix secure and insecure platforms")))
+	}
+
 	for i, key := range m.WorkloadOwnerPubKeys {
 		if _, err := ParseWorkloadOwnerPublicKey(key); err != nil {
 			errs = append(errs, newValidationError(fmt.Sprintf("WorkloadOwnerPubKeys[%d]", i), err))
@@ -119,6 +123,41 @@ func (m *Manifest) CoordinatorPolicyHashes() ([]HexString, error) {
 	return all, nil
 }
 
+// HasInsecurePlatforms returns true if the manifest contains a reference value for a recognized
+// insecure platform.
+func (m *Manifest) HasInsecurePlatforms() bool {
+	return m.anyReferenceValue(func(p platforms.Platform, ok bool) bool {
+		return ok && platforms.IsInsecure(p)
+	})
+}
+
+// HasSecurePlatforms returns true if the manifest contains a reference value that does not target a
+// recognized insecure platform. Unknown or unset platforms are treated as secure (fail-closed), so
+// a malformed secure reference value mixed with an insecure one is still detected as a mix.
+func (m *Manifest) HasSecurePlatforms() bool {
+	return m.anyReferenceValue(func(p platforms.Platform, ok bool) bool {
+		return !ok || !platforms.IsInsecure(p)
+	})
+}
+
+// anyReferenceValue reports whether any SNP or TDX reference value's platform satisfies pred. pred
+// receives the parsed platform and whether parsing succeeded.
+func (m *Manifest) anyReferenceValue(pred func(p platforms.Platform, ok bool) bool) bool {
+	for _, v := range m.ReferenceValues.SNP {
+		p, err := platforms.FromString(v.Platform)
+		if pred(p, err == nil) {
+			return true
+		}
+	}
+	for _, v := range m.ReferenceValues.TDX {
+		p, err := platforms.FromString(v.Platform)
+		if pred(p, err == nil) {
+			return true
+		}
+	}
+	return false
+}
+
 // SNPValidateOpts returns validate options generators populated with the manifest's
 // SNP reference values and trusted measurement for the given runtime.
 func (m *Manifest) SNPValidateOpts(kdsGetter *certcache.CachedHTTPSGetter) ([]SNPValidatorOptions, error) {
@@ -128,6 +167,13 @@ func (m *Manifest) SNPValidateOpts(kdsGetter *certcache.CachedHTTPSGetter) ([]SN
 
 	var out []SNPValidatorOptions
 	for _, refVal := range m.ReferenceValues.SNP {
+		if p, err := platforms.FromString(refVal.Platform); err == nil && platforms.IsInsecure(p) {
+			continue
+		}
+		if len(refVal.TrustedMeasurement) == 0 {
+			return nil, errors.New("trusted measurement cannot be empty")
+		}
+
 		seed, err := refVal.TrustedMeasurement.Bytes()
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode TrustedMeasurement: %w", err)
@@ -231,6 +277,9 @@ func (m *Manifest) TDXValidateOpts(kdsGetter *certcache.CachedHTTPSGetter) ([]TD
 
 	var out []TDXValidatorOptions
 	for _, refVal := range m.ReferenceValues.TDX {
+		if p, err := platforms.FromString(refVal.Platform); err == nil && platforms.IsInsecure(p) {
+			continue
+		}
 		verifyOpts := tdxverify.DefaultOptions()
 
 		var err error

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -122,6 +122,13 @@ func TestValidate(t *testing.T) {
 			// APEIP is optional for backwards compatibility with older manifests.
 			wantErr: false,
 		},
+		"mixed secure and insecure platforms": {
+			m: newTestManifestSNP(),
+			mutate: func(m *Manifest) {
+				m.ReferenceValues.SNP = append(m.ReferenceValues.SNP, SNPReferenceValues{Platform: "Metal-QEMU-Insecure"})
+			},
+			wantErr: true,
+		},
 		"invalid workload owner key": {
 			m: newTestManifestSNP(),
 			mutate: func(m *Manifest) {
@@ -320,6 +327,61 @@ func TestSNPValidateOpts(t *testing.T) {
 	}
 	assert.Equal(tcbParts, opts[0].ValidateOpts.MinimumTCB)
 	assert.Equal(tcbParts, opts[0].ValidateOpts.MinimumLaunchTCB)
+}
+
+func TestSNPValidateOptsRejectsEmptyMeasurement(t *testing.T) {
+	require := require.New(t)
+
+	// This guards the code path that bypasses Validate: Validate's insecure early-return means the
+	// "non-empty TrustedMeasurement" invariant no longer holds for the whole SNP refval slice, so
+	// SNPValidateOpts must reject an empty measurement on a secure platform itself.
+	m := newTestManifestSNP()
+	m.ReferenceValues.SNP[0].TrustedMeasurement = ""
+
+	_, err := m.SNPValidateOpts(nil)
+	require.Error(err)
+}
+
+func TestHasInsecureAndSecurePlatforms(t *testing.T) {
+	insecureRefVal := SNPReferenceValues{Platform: "Metal-QEMU-Insecure"}
+
+	testCases := map[string]struct {
+		m            *Manifest
+		wantInsecure bool
+		wantSecure   bool
+	}{
+		"all secure": {
+			m:          newTestManifestSNP(),
+			wantSecure: true,
+		},
+		"all insecure": {
+			m: func() *Manifest {
+				m := &Manifest{}
+				m.ReferenceValues.SNP = []SNPReferenceValues{insecureRefVal}
+				return m
+			}(),
+			wantInsecure: true,
+		},
+		"mixed": {
+			m: func() *Manifest {
+				m := newTestManifestSNP()
+				m.ReferenceValues.SNP = append(m.ReferenceValues.SNP, insecureRefVal)
+				return m
+			}(),
+			wantInsecure: true,
+			wantSecure:   true,
+		},
+		"empty": {
+			m: &Manifest{},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tc.wantInsecure, tc.m.HasInsecurePlatforms())
+			assert.Equal(tc.wantSecure, tc.m.HasSecurePlatforms())
+		})
+	}
 }
 
 func TestHexString(t *testing.T) {

--- a/internal/manifest/referencevalues.go
+++ b/internal/manifest/referencevalues.go
@@ -212,6 +212,9 @@ type SNPReferenceValues struct {
 
 // Validate checks the validity of all fields in the AKS reference values.
 func (r SNPReferenceValues) Validate() error {
+	if p, err := platforms.FromString(r.Platform); err == nil && platforms.IsInsecure(p) {
+		return nil
+	}
 	var minTCBErrs []error
 	if r.MinimumTCB.BootloaderVersion == nil {
 		minTCBErrs = append(minTCBErrs, newValidationError("BootloaderVersion", ExpectedMissingReferenceValueError{Err: errors.New("field cannot be empty")}))
@@ -325,6 +328,9 @@ type TDXReferenceValues struct {
 
 // Validate checks the validity of all fields in the bare metal TDX reference values.
 func (r TDXReferenceValues) Validate() error {
+	if p, err := platforms.FromString(r.Platform); err == nil && platforms.IsInsecure(p) {
+		return nil
+	}
 	var errs []error
 	if err := validateHexString(r.MrTd, 48); err != nil {
 		errs = append(errs, newValidationError("MrTd", err))

--- a/internal/manifest/validators.go
+++ b/internal/manifest/validators.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
+	"github.com/edgelesssys/contrast/internal/attestation/insecure"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/logger"
@@ -59,6 +60,14 @@ func (m *Manifest) Validator(log *slog.Logger, kdsGetter *certcache.CachedHTTPSG
 		validator := tdx.NewValidatorWithReportSetter(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs,
 			logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), reportSetter, name)
 		allValidators = append(allValidators, validators.WithFixedOID(oid.RawTDXReport, validator))
+	}
+
+	if m.HasInsecurePlatforms() {
+		insecureValidator := insecure.NewValidatorWithReportSetter(
+			logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": "insecure"}),
+			reportSetter, "insecure",
+		)
+		allValidators = append(allValidators, validators.WithFixedOID(oid.RawInsecureReport, insecureValidator))
 	}
 
 	return validators.Any(allValidators...), nil


### PR DESCRIPTION
Split from #2337 as part of a stacked review series.

Depends on: https://github.com/edgelesssys/contrast/pull/2355

This PR wires insecure manifests into the Coordinator behind explicit opt-in:
- manifest helpers for insecure reference values
- Coordinator opt-in gate
- validator registration for insecure manifests
- user API and tests

Closes CON-212