### PR TITLE
.github: dry-run release pipeline nightly

### DIFF
--- a/.github/actions/parse_version/action.yml
+++ b/.github/actions/parse_version/action.yml
@@ -1,0 +1,73 @@
+name: Parse version
+description: Parses a vX.Y.Z version string into its components
+
+inputs:
+  version:
+    description: Full version string, e.g. v1.2.3 or v1.2.3-2024-01-01
+    required: true
+
+outputs:
+  without_v:
+    description: Base version without v prefix and pre-release suffix, e.g. 1.2.3
+    value: ${{ steps.parse.outputs.without_v }}
+  part_major:
+    description: Major version number
+    value: ${{ steps.parse.outputs.part_major }}
+  part_minor:
+    description: Minor version number
+    value: ${{ steps.parse.outputs.part_minor }}
+  part_patch:
+    description: Patch version number
+    value: ${{ steps.parse.outputs.part_patch }}
+  major_minor:
+    description: Major.Minor, e.g. 1.2
+    value: ${{ steps.parse.outputs.major_minor }}
+  major_minor_patch:
+    description: Major.Minor.Patch, e.g. 1.2.3
+    value: ${{ steps.parse.outputs.major_minor_patch }}
+  release_branch:
+    description: Release branch name, e.g. release/v1.2
+    value: ${{ steps.parse.outputs.release_branch }}
+  next_minor:
+    description: Next minor version, e.g. 1.3.0
+    value: ${{ steps.parse.outputs.next_minor }}
+  next_minor_pre_without_v:
+    description: Next minor pre-release version without v, e.g. 1.3.0-pre
+    value: ${{ steps.parse.outputs.next_minor_pre_without_v }}
+  next_patch_pre_without_v:
+    description: Next patch pre-release version without v, e.g. 1.2.4-pre
+    value: ${{ steps.parse.outputs.next_patch_pre_without_v }}
+  previous_minor_tag:
+    description: Previous minor release tag, e.g. v1.1.0. Empty if minor is 0.
+    value: ${{ steps.parse.outputs.previous_minor_tag }}
+
+runs:
+  using: composite
+  steps:
+    - id: parse
+      shell: bash
+      env:
+        FULL_VERSION: ${{ inputs.version }}
+      run: |
+        WITHOUT_V=$(echo "${FULL_VERSION#v}" | sed 's/-.*$//')
+        PART_MAJOR=${WITHOUT_V%%.*}
+        PART_MINOR=${WITHOUT_V#*.}
+        PART_MINOR=${PART_MINOR%%.*}
+        PART_PATCH=${WITHOUT_V##*.}
+        {
+          echo "without_v=${WITHOUT_V}"
+          echo "part_major=${PART_MAJOR}"
+          echo "part_minor=${PART_MINOR}"
+          echo "part_patch=${PART_PATCH}"
+          echo "major_minor=${PART_MAJOR}.${PART_MINOR}"
+          echo "major_minor_patch=${PART_MAJOR}.${PART_MINOR}.${PART_PATCH}"
+          echo "release_branch=release/v${PART_MAJOR}.${PART_MINOR}"
+          echo "next_minor=${PART_MAJOR}.$((PART_MINOR + 1)).0"
+          echo "next_minor_pre_without_v=${PART_MAJOR}.$((PART_MINOR + 1)).0-pre"
+          echo "next_patch_pre_without_v=${PART_MAJOR}.${PART_MINOR}.$((PART_PATCH + 1))-pre"
+          if (( PART_MINOR > 0 )); then
+            echo "previous_minor_tag=v${PART_MAJOR}.$((PART_MINOR - 1)).0"
+          else
+            echo "previous_minor_tag="
+          fi
+        } | tee -a "$GITHUB_OUTPUT"

--- a/.github/actions/prepare_github_release/action.yml
+++ b/.github/actions/prepare_github_release/action.yml
@@ -1,0 +1,45 @@
+name: Create backport label and milestone
+description: Creates a backport label for the release branch and the next minor milestone
+
+inputs:
+  release_branch:
+    description: Release branch, e.g. release/v1.2
+    required: true
+  next_minor:
+    description: Next minor version, e.g. 1.3.0
+    required: true
+  github_token:
+    description: GitHub token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Create backport label
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        GH_REPO: ${{ github.repository }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+      run: |
+        gh label create "backport ${RELEASE_BRANCH}" --color 576F61 --force
+    - name: Create milestone
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        NEXT_MINOR: ${{ inputs.next_minor }}
+        REPO: ${{ github.repository }}
+      run: |
+        gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${REPO}/milestones |
+          jq -r '.[] | .title' | \
+          grep -xqF "v${NEXT_MINOR}" && exit 0
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${REPO}/milestones \
+          -f title="v${NEXT_MINOR}" \
+          -f state='open'

--- a/.github/actions/prepare_post_release_pr/action.yml
+++ b/.github/actions/prepare_post_release_pr/action.yml
@@ -1,0 +1,152 @@
+name: Update main branch
+description: >
+  Updates the main branch with release artifacts, docs, and a version bump, then opens a PR. Assumes the workspace root is already checked out to the working/release ref.
+inputs:
+  checkout_main_ref:
+    description: Git ref for the main branch
+    required: false
+    default: main
+  version:
+    description: Full release version, e.g. v1.2.3
+    required: true
+  major_minor:
+    description: Major.Minor, e.g. 1.2
+    required: true
+  major_minor_patch:
+    description: Major.Minor.Patch, e.g. 1.2.3
+    required: true
+  without_v:
+    description: Version without v prefix, e.g. 1.2.3
+    required: true
+  next_minor_pre_without_v:
+    description: Next minor pre-release version without v, e.g. 1.3.0-pre
+    required: true
+  pr_branch_suffix:
+    description: Suffix for the automated PR branch (automated/update-main-after-<suffix>)
+    required: true
+  create_docs_release:
+    description: Whether to create a versioned docs snapshot
+    required: false
+    default: 'true'
+  bump_version:
+    description: Whether to bump the flake version post-release
+    required: false
+    default: 'true'
+  github_token:
+    description: GitHub token
+    required: true
+  nunki_ci_token:
+    description: Token with push and PR creation permissions (NUNKI_CI_COMMIT_PUSH_PR)
+    required: true
+  cachix_token:
+    description: Cachix auth token
+    required: true
+  artifacts_run_id:
+    description: Workflow run ID to download artifacts from. Defaults to the current run.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout main
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.checkout_main_ref }}
+        path: contrast-main
+        persist-credentials: false
+    - uses: ./.github/actions/setup_nix
+      with:
+        githubToken: ${{ inputs.github_token }}
+        cachixToken: ${{ inputs.cachix_token }}
+    - name: Configure git
+      shell: bash
+      run: |
+        git config --global user.name "edgelessci"
+        git config --global user.email "edgelessci@users.noreply.github.com"
+    - name: Create docs release
+      if: inputs.create_docs_release == 'true'
+      shell: bash
+      working-directory: contrast-main/docs
+      env:
+        MAJOR_MINOR: ${{ inputs.major_minor }}
+      run: |
+        nix run ".#base.nixpkgs.yarn" install
+        nix run ".#base.nixpkgs.yarn" docusaurus docs:version "${MAJOR_MINOR}"
+        git add .
+        git commit -am "docs: release ${MAJOR_MINOR}"
+        # Clean up auxiliary files, so next steps run on a clean tree
+        git clean -fx :/
+        git reset --hard HEAD
+    - name: Download image replacements
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: image-replacements
+        run-id: ${{ inputs.artifacts_run_id || github.run_id }}
+        github-token: ${{ inputs.github_token }}
+    - name: Update release urls in docs with tags
+      shell: bash
+      working-directory: contrast-main
+      run: nix run ".#base.scripts.update-release-urls"
+    - name: Commit updated docs
+      shell: bash
+      working-directory: contrast-main
+      env:
+        MAJOR_MINOR: ${{ inputs.major_minor }}
+      run: |
+        git add "docs/versioned_docs/version-${MAJOR_MINOR}"
+        git commit -m "docs: update release download urls"
+        git clean -fx :/
+        git reset --hard HEAD
+    - name: Download release artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: contrast-release-artifacts
+        path: ./contrast-main
+        run-id: ${{ inputs.artifacts_run_id || github.run_id }}
+        github-token: ${{ inputs.github_token }}
+    - name: Download darwin CLI artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: contrast-cli-aarch64-darwin
+        path: ./contrast-main/workspace
+        run-id: ${{ inputs.artifacts_run_id || github.run_id }}
+        github-token: ${{ inputs.github_token }}
+    - name: Update contrast-releases.json with new release
+      shell: bash
+      working-directory: contrast-main
+      run: nix run ".#base.scripts.update-contrast-releases"
+    - name: Commit updated contrast-releases.json
+      shell: bash
+      working-directory: contrast-main
+      env:
+        MAJOR_MINOR_PATCH: ${{ inputs.major_minor_patch }}
+      run: |
+        git add ./packages/contrast-releases.json
+        git commit -m "packages/contrast-releases: add ${MAJOR_MINOR_PATCH}"
+        git clean -fx :/
+        git reset --hard HEAD
+    - name: Bump flake version to post release pre-version
+      if: inputs.bump_version == 'true'
+      id: bump
+      uses: ./.github/actions/bump_version
+      with:
+        version: ${{ inputs.next_minor_pre_without_v }}
+        working-directory: contrast-main
+        commit: false
+    - name: Create PR
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+      with:
+        title: Post ${{ inputs.without_v }} release updates to main
+        body: |
+          Updating main as part of the ${{ inputs.without_v }} release.
+          Only merge after the release is published.
+        commit-message: ${{ steps.bump.outputs.commit-msg }}
+        base: main
+        draft: false
+        labels: "no changelog"
+        branch: automated/update-main-after-${{ inputs.pr_branch_suffix }}
+        committer: edgelessci <edgelessci@users.noreply.github.com>
+        author: edgelessci <edgelessci@users.noreply.github.com>
+        token: ${{ inputs.nunki_ci_token }}
+        path: ./contrast-main

--- a/.github/actions/regenerate_release_notes/action.yml
+++ b/.github/actions/regenerate_release_notes/action.yml
@@ -1,0 +1,37 @@
+name: Regenerate release notes
+description: Regenerate the release notes for an existing tag and update the release body
+
+inputs:
+  version:
+    description: Release tag to regenerate notes for
+    required: true
+  previous_tag:
+    description: Previous tag to diff against when generating notes
+    required: true
+  github_token:
+    description: GitHub token with contents:write
+    required: true
+  github_repo:
+    description: Repository in owner/name form
+    required: false
+    default: ${{ github.repository }}
+
+runs:
+  using: composite
+  steps:
+    - name: Regenerate release notes against the now-existing tag
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        GH_REPO: ${{ inputs.github_repo }}
+        VERSION: ${{ inputs.version }}
+        PREVIOUS_TAG: ${{ inputs.previous_tag }}
+      run: |
+        notes=$(gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          "/repos/${GH_REPO}/releases/generate-notes" \
+          -f "tag_name=${VERSION}" \
+          -f "previous_tag_name=${PREVIOUS_TAG}" \
+          --jq '.body')
+        gh release edit "${VERSION}" --repo "${GH_REPO}" --notes "${notes}"

--- a/.github/actions/release_build_darwin/action.yml
+++ b/.github/actions/release_build_darwin/action.yml
@@ -1,0 +1,57 @@
+name: Build and attach aarch64-darwin CLI
+description: >
+  Builds the aarch64-darwin CLI, attaches it to the draft release, and uploads it to S3. Assumes the workspace is already checked out to the working/release ref.
+inputs:
+  effective_version:
+    description: Full release tag, e.g. v1.2.3 or v1.2.3-2024-01-01
+    required: true
+  without_v:
+    description: Base version without v prefix, e.g. 1.2.3
+    required: true
+  github_token:
+    description: GitHub token
+    required: true
+  cachix_token:
+    description: Cachix auth token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup_nix
+      with:
+        githubToken: ${{ inputs.github_token }}
+        cachixToken: ${{ inputs.cachix_token }}
+    - name: Bump flake version to release version
+      uses: ./.github/actions/bump_version
+      with:
+        version: ${{ inputs.without_v }}
+        commit: false
+    - uses: ./.github/actions/build_cli
+      with:
+        system: aarch64-darwin
+    - name: Upload artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: contrast-cli-aarch64-darwin
+        path: workspace/contrast-aarch64-darwin
+    - name: Remove existing darwin asset from draft release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        VERSION: ${{ inputs.effective_version }}
+      run: |
+        if gh release view "${VERSION}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | grep -Fxq 'contrast-aarch64-darwin'; then
+          gh release delete-asset "${VERSION}" contrast-aarch64-darwin --repo "${{ github.repository }}" --yes
+        fi
+    - name: Attach to draft release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        VERSION: ${{ inputs.effective_version }}
+      run: |
+        gh release upload "${VERSION}" workspace/contrast-aarch64-darwin --repo "${{ github.repository }}"
+    - uses: ./.github/actions/s3_upload
+      with:
+        files: workspace/contrast-aarch64-darwin
+        s3-bucket-path: pre-releases/${{ inputs.effective_version }}/${{ github.run_id }}/${{ github.run_attempt }}

--- a/.github/actions/release_build_linux/action.yml
+++ b/.github/actions/release_build_linux/action.yml
@@ -1,0 +1,97 @@
+name: Build and push release artifacts (x86_64-linux)
+description: >
+  Builds container images and CLI, creates the draft release, and optionally commits version bumps. Assumes the workspace is already checked out to the working/release ref.
+inputs:
+  effective_version:
+    description: Full release tag, e.g. v1.2.3 or v1.2.3-2024-01-01
+    required: true
+  without_v:
+    description: Base version without v prefix, e.g. 1.2.3
+    required: true
+  working_branch:
+    description: Working branch or ref name, used as release target and for git reset
+    required: true
+  container_registry:
+    description: Container registry to push images to
+    required: true
+  commit_version_bump:
+    description: Whether to commit the version bump and push a post-release patch pre-version
+    required: false
+    default: 'false'
+  next_patch_pre_without_v:
+    description: Post-release patch pre-version without v, e.g. 1.2.4-pre. Required when commit_version_bump is true.
+    required: false
+    default: ''
+  previous_tag:
+    description: Tag to use as the base for generated release notes. If empty, GitHub auto-detects.
+    required: false
+    default: ''
+  github_token:
+    description: GitHub token
+    required: true
+  cachix_token:
+    description: Cachix auth token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup_nix
+      with:
+        githubToken: ${{ inputs.github_token }}
+        cachixToken: ${{ inputs.cachix_token }}
+    - name: Log in to ghcr.io Container registry
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+    - name: Configure git
+      shell: bash
+      run: |
+        git config --global user.name "edgelessci"
+        git config --global user.email "edgelessci@users.noreply.github.com"
+    - name: Bump flake version to release version
+      uses: ./.github/actions/bump_version
+      with:
+        version: ${{ inputs.without_v }}
+        commit: ${{ inputs.commit_version_bump }}
+    - name: Create release artifacts
+      id: create-artifacts
+      uses: ./.github/actions/release_artifacts
+      with:
+        version: v${{ inputs.without_v }}
+        container_registry: ${{ inputs.container_registry }}
+        s3-bucket-path: pre-releases/${{ inputs.effective_version }}
+    - name: Upload release artifacts (for main branch PR)
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: contrast-release-artifacts
+        # Keep the LICENSE file! It isn't used, but ensures the paths of the other artifacts aren't stripped, see
+        # https://github.com/actions/upload-artifact/blob/6027e3dd177782cd8ab9af838c04fd81a07f1d47/README.md?plain=1#L187
+        path: |
+          LICENSE
+          ${{ steps.create-artifacts.outputs.paths }}
+    - name: Create draft release
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2  # zizmor: ignore[superfluous-actions]
+      with:
+        draft: true
+        generate_release_notes: true
+        tag_name: ${{ inputs.effective_version }}
+        previous_tag: ${{ inputs.previous_tag }}
+        target_commitish: ${{ inputs.working_branch }}
+        fail_on_unmatched_files: true
+        files: ${{ steps.create-artifacts.outputs.paths }}
+    - name: Reset temporary changes
+      if: inputs.commit_version_bump == 'true'
+      shell: bash
+      env:
+        WORKING_BRANCH: ${{ inputs.working_branch }}
+      run: |
+        git reset --hard "${WORKING_BRANCH}"
+    - name: Bump flake version to post release patch pre-version
+      if: inputs.commit_version_bump == 'true'
+      uses: ./.github/actions/bump_version
+      with:
+        version: ${{ inputs.next_patch_pre_without_v }}
+        commit: true

--- a/.github/actions/release_e2e_test/action.yml
+++ b/.github/actions/release_e2e_test/action.yml
@@ -1,0 +1,97 @@
+name: e2e release test
+description: >
+  Runs the e2e release tests for a single platform. Assumes the workspace is already checked out to the release ref.
+inputs:
+  version:
+    description: Release tag to test against, e.g. v1.2.3
+    required: true
+  container_registry:
+    description: Container registry
+    required: true
+  platform_name:
+    description: Platform name, e.g. Metal-QEMU-SNP
+    required: true
+  node_installer_target_conf:
+    description: Node installer target configuration, e.g. none or k3s
+    required: true
+  self_hosted:
+    description: Whether this is a self-hosted runner ('true' or 'false')
+    required: true
+  github_token:
+    description: GitHub token
+    required: true
+  cachix_token:
+    description: Cachix auth token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup_nix
+      if: inputs.self_hosted != 'true'
+      with:
+        githubToken: ${{ inputs.github_token }}
+        cachixToken: ${{ inputs.cachix_token }}
+    - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+    - name: Log in to ghcr.io Container registry
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.github_token }}
+    - name: Create justfile.env
+      shell: bash
+      env:
+        CONTAINER_REGISTRY: ${{ inputs.container_registry }}
+        PLATFORM_NAME: ${{ inputs.platform_name }}
+      run: |
+        cat <<EOF > justfile.env
+        container_registry=${CONTAINER_REGISTRY}
+        default_platform=${PLATFORM_NAME}
+        set="base"
+        EOF
+    - name: Get credentials for CI cluster
+      if: inputs.self_hosted != 'true'
+      shell: bash
+      run: |
+        just get-credentials
+    - name: Request fifo ticket
+      if: inputs.self_hosted != 'true' || inputs.platform_name == 'Metal-QEMU-SNP-GPU' || inputs.platform_name == 'Metal-QEMU-TDX-GPU'
+      shell: bash
+      run: |
+        just request-fifo-ticket
+    - name: E2E Test
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        VERSION: ${{ inputs.version }}
+        PLATFORM_NAME: ${{ inputs.platform_name }}
+        NODE_INSTALLER_TARGET_CONF: ${{ inputs.node_installer_target_conf }}
+      run: |
+        mkdir -p workspace
+        nix build ".#base.scripts.get-logs"
+        nix run ".#base.scripts.get-logs" start workspace/just.namespace &
+        nix shell -L ".#base.contrast.e2e" --command release.test \
+          -test.v \
+          --tag "${VERSION}" \
+          --platform "${PLATFORM_NAME}" \
+          --node-installer-target-conf "${NODE_INSTALLER_TARGET_CONF}" \
+          --namespace-file workspace/just.namespace
+    - name: Cleanup
+      if: always()
+      shell: bash
+      run: |
+        kubectl delete -f workspace/log-collector.yaml
+        rm -f workspace/just.namespace
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: e2e_pod_logs-${{ inputs.platform_name }}-release
+        path: workspace/logs
+        if-no-files-found: error
+    - name: Release fifo ticket
+      if: always() && (inputs.self_hosted != 'true' || inputs.platform_name == 'Metal-QEMU-SNP-GPU' || inputs.platform_name == 'Metal-QEMU-TDX-GPU')
+      shell: bash
+      run: |
+        just release-fifo-ticket

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -14,8 +14,6 @@ on:
         required: true
       CONTRAST_GHCR_READ:
         required: true
-  schedule:
-    - cron: "30 23 * * *" # 23:30 UTC, every day
 
 jobs:
   maintenance:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,25 +40,27 @@ jobs:
     env:
       FULL_VERSION: ${{ inputs.version }}
     outputs:
-      WITHOUT_V: ${{ steps.version-info.outputs.WITHOUT_V }}
-      PART_MAJOR: ${{ steps.version-info.outputs.PART_MAJOR }}
-      PART_MINOR: ${{ steps.version-info.outputs.PART_MINOR }}
-      PART_PATCH: ${{ steps.version-info.outputs.PART_PATCH }}
-      MAJOR: ${{ steps.version-info.outputs.MAJOR }}
-      MAJOR_MINOR: ${{ steps.version-info.outputs.MAJOR_MINOR }}
-      MAJOR_MINOR_PATCH: ${{ steps.version-info.outputs.MAJOR_MINOR_PATCH }}
-      RELEASE_BRANCH: ${{ steps.version-info.outputs.RELEASE_BRANCH }}
-      WORKING_BRANCH: ${{ steps.version-info.outputs.WORKING_BRANCH }}
-      NEXT_MINOR: ${{ steps.version-info.outputs.NEXT_MINOR }}
-      NEXT_MINOR_PRE_WITHOUT_V: ${{ steps.version-info.outputs.NEXT_MINOR_PRE_WITHOUT_V }}
-      NEXT_PATCH_PRE_WITHOUT_V: ${{ steps.version-info.outputs.NEXT_PATCH_PRE_WITHOUT_V }}
+      EFFECTIVE_VERSION: ${{ inputs.version }}
+      WITHOUT_V: ${{ steps.version-info.outputs.without_v }}
+      MAJOR_MINOR: ${{ steps.version-info.outputs.major_minor }}
+      MAJOR_MINOR_PATCH: ${{ steps.version-info.outputs.major_minor_patch }}
+      RELEASE_BRANCH: ${{ steps.version-info.outputs.release_branch }}
+      WORKING_BRANCH: ${{ steps.branch.outputs.value }}
+      NEXT_MINOR: ${{ steps.version-info.outputs.next_minor }}
+      NEXT_MINOR_PRE_WITHOUT_V: ${{ steps.version-info.outputs.next_minor_pre_without_v }}
+      NEXT_PATCH_PRE_WITHOUT_V: ${{ steps.version-info.outputs.next_patch_pre_without_v }}
+      PREVIOUS_MINOR_TAG: ${{ steps.version-info.outputs.previous_minor_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Working branch
+          fetch-tags: true
+      - name: Get working branch
+        id: branch
         run: |
-          echo "WORKING_BRANCH=$(git branch --show-current)" | tee -a "$GITHUB_ENV"
+          WB=$(git branch --show-current)
+          echo "WORKING_BRANCH=${WB}" | tee -a "$GITHUB_ENV"
+          echo "value=${WB}" >> "$GITHUB_OUTPUT"
       - name: Verify minor version bump
         if: inputs.kind == 'minor'
         run: |
@@ -79,33 +81,11 @@ jobs:
             echo "Workflow can only be triggered from a temporary branch in the form of tmp/vX.Y.Z"
             exit 1
           fi
-      - name: Extract version info
+      - name: Parse version
         id: version-info
-        run: |
-          WITHOUT_V=${FULL_VERSION#v}
-          PART_MAJOR=${WITHOUT_V%%.*}
-          PART_MINOR=${WITHOUT_V#*.}
-          PART_MINOR=${PART_MINOR%%.*}
-          PART_PATCH=${WITHOUT_V##*.}
-          RELEASE_BRANCH=release/v${PART_MAJOR}.${PART_MINOR}
-          NEXT_MINOR=${PART_MAJOR}.$((PART_MINOR + 1)).0
-          NEXT_MINOR_PRE_WITHOUT_V=${PART_MAJOR}.$((PART_MINOR + 1)).0-pre
-          NEXT_PATCH_PRE_WITHOUT_V=${PART_MAJOR}.${PART_MINOR}.$((PART_PATCH + 1))-pre
-          {
-            echo "WITHOUT_V=${WITHOUT_V}"
-            echo "PART_MAJOR=${PART_MAJOR}"
-            echo "PART_MINOR=${PART_MINOR}"
-            echo "PART_PATCH=${PART_PATCH}"
-            echo "MAJOR=${PART_MAJOR}"
-            echo "MAJOR_MINOR=${PART_MAJOR}.${PART_MINOR}"
-            echo "MAJOR_MINOR_PATCH=${PART_MAJOR}.${PART_MINOR}.${PART_PATCH}"
-            echo "RELEASE_BRANCH=${RELEASE_BRANCH}"
-            echo "WORKING_BRANCH=${WORKING_BRANCH}"
-            echo "NEXT_MINOR=${NEXT_MINOR}"
-            echo "NEXT_MINOR_PRE_WITHOUT_V=${NEXT_MINOR_PRE_WITHOUT_V}"
-            echo "NEXT_PATCH_PRE_WITHOUT_V=${NEXT_PATCH_PRE_WITHOUT_V}"
-          } | tee -a "$GITHUB_OUTPUT"
-          echo "RELEASE_BRANCH=${RELEASE_BRANCH}" | tee -a "$GITHUB_ENV"
+        uses: ./.github/actions/parse_version
+        with:
+          version: ${{ inputs.version }}
       - name: Don't overwrite published releases
         if: (! inputs.overwrite_published_release)
         env:
@@ -118,241 +98,63 @@ jobs:
             exit 1
           fi
 
-  update-main:
-    name: Update main branch
-    runs-on: ubuntu-24.04
-    needs: [process-inputs, release-x86_64-linux, release-aarch64-darwin]
-    permissions:
-      contents: write
-    env:
-      RELEASE_BRANCH: ${{ needs.process-inputs.outputs.RELEASE_BRANCH }}
-      WORKING_BRANCH: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-      VERSION: ${{ inputs.version }}
-      MAJOR_MINOR: ${{ needs.process-inputs.outputs.MAJOR_MINOR }}
-      MAJOR_MINOR_PATCH: ${{ needs.process-inputs.outputs.MAJOR_MINOR_PATCH }}
-      SET: base
-    steps:
-      - name: Checkout working branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-          path: contrast-working
-          persist-credentials: false
-      - name: Checkout main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.checkout_main_ref }}
-          path: contrast-main
-          persist-credentials: false
-      - uses: ./contrast-working/.github/actions/setup_nix
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Configure git
-        run: |
-          git config --global user.name "edgelessci"
-          git config --global user.email "edgelessci@users.noreply.github.com"
-      - name: Create docs release
-        if: inputs.kind == 'minor'
-        working-directory: contrast-main/docs
-        run: |
-          nix run ".#${SET}.nixpkgs.yarn" install
-          nix run ".#${SET}.nixpkgs.yarn" docusaurus docs:version "${MAJOR_MINOR}"
-          git add .
-          git commit -am "docs: release ${MAJOR_MINOR}"
-          # Clean up auxiliary files, so next steps run on a clean tree
-          git clean -fx :/
-          git reset --hard HEAD
-      - name: Download image replacements file (from release branch)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: image-replacements
-      - name: Update release urls in docs with tags
-        working-directory: contrast-main
-        run: nix run ".#${SET}.scripts.update-release-urls"
-      - name: Commit updated docs
-        working-directory: contrast-main
-        run: |
-          git add "docs/versioned_docs/version-${MAJOR_MINOR}"
-          git commit -m "docs: update release download urls"
-          git clean -fx :/
-          git reset --hard HEAD
-      - name: Download release artifacts (from release branch)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: contrast-release-artifacts
-          path: ./contrast-main
-      - name: Download darwin CLI artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: contrast-cli-aarch64-darwin
-          path: ./contrast-main/workspace
-      - name: Update contrast-releases.json with new release
-        working-directory: contrast-main
-        run: nix run ".#${SET}.scripts.update-contrast-releases"
-      - name: Commit updated contrast-releases.json
-        working-directory: contrast-main
-        run: |
-          git add ./packages/contrast-releases.json
-          git commit -m "packages/contrast-releases: add ${MAJOR_MINOR_PATCH}"
-          git clean -fx :/
-          git reset --hard HEAD
-      - name: Bump flake version to post release patch pre-version
-        if: inputs.kind == 'minor'
-        id: bump
-        uses: ./contrast-working/.github/actions/bump_version # Run action from working branch!
-        with:
-          version: ${{ needs.process-inputs.outputs.NEXT_MINOR_PRE_WITHOUT_V }}
-          working-directory: contrast-main
-          commit: false
-      - name: Create PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          title: Post ${{ needs.process-inputs.outputs.WITHOUT_V }} release updates to main
-          body: |
-            Updating main as part of the ${{ needs.process-inputs.outputs.WITHOUT_V }} release.
-            Only merge after the release is published.
-          commit-message: ${{ steps.bump.outputs.commit-msg }}
-          base: main
-          draft: false
-          labels: "no changelog"
-          branch: automated/update-main-after-${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-          committer: edgelessci <edgelessci@users.noreply.github.com>
-          author: edgelessci <edgelessci@users.noreply.github.com>
-          token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
-          path: ./contrast-main
-
-  release-aarch64-darwin:
-    name: Build aarch64-darwin CLI
-    runs-on: macos-latest
-    needs: [process-inputs, release-x86_64-linux]
-    permissions:
-      contents: write
-      id-token: write
-    env:
-      VERSION: ${{ inputs.version }}
-      SET: base
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-          persist-credentials: false
-      - uses: ./.github/actions/setup_nix
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Bump flake version to release version
-        uses: ./.github/actions/bump_version
-        with:
-          version: ${{ needs.process-inputs.outputs.WITHOUT_V }}
-          commit: false
-      - uses: ./.github/actions/build_cli
-        with:
-          system: aarch64-darwin
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: contrast-cli-aarch64-darwin
-          path: workspace/contrast-aarch64-darwin
-      - name: Remove existing darwin asset from draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh release view "${VERSION}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | grep -Fxq 'contrast-aarch64-darwin'; then
-            gh release delete-asset "${VERSION}" contrast-aarch64-darwin --repo "${{ github.repository }}" --yes
-          fi
-      - name: Attach to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${VERSION}" workspace/contrast-aarch64-darwin --repo "${{ github.repository }}"
-      - uses: ./.github/actions/s3_upload
-        with:
-          files: workspace/contrast-aarch64-darwin
-          s3-bucket-path: pre-releases/${{ inputs.version }}/${{ github.run_id }}/${{ github.run_attempt }}
-
   release-x86_64-linux:
-    name: Build and push artifacts, create release
+    name: "release-requirement: Build and push artifacts, create release"
     runs-on: ubuntu-24.04
     needs: process-inputs
     permissions:
       contents: write
       packages: write
       id-token: write
-    outputs:
-      LOG_COLLECTOR_IMAGE: ${{ steps.push-log-collector.outputs.image }}
-    env:
-      RELEASE_BRANCH: ${{ needs.process-inputs.outputs.RELEASE_BRANCH }}
-      WORKING_BRANCH: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-      VERSION: ${{ inputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
           persist-credentials: true
-      - uses: ./.github/actions/setup_nix
+      - uses: ./.github/actions/release_build_linux
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Log in to ghcr.io Container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure git
-        run: |
-          git config --global user.name "edgelessci"
-          git config --global user.email "edgelessci@users.noreply.github.com"
-      - name: Bump flake version to release version
-        uses: ./.github/actions/bump_version
-        with:
-          version: ${{ needs.process-inputs.outputs.WITHOUT_V }}
-          commit: true
-      - name: Create release artifacts
-        id: create-artifacts
-        uses: ./.github/actions/release_artifacts
-        with:
-          version: ${{ inputs.version }}
+          effective_version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
+          working_branch: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
           container_registry: ${{ env.container_registry }}
-          s3-bucket-path: "pre-releases/${{ inputs.version }}"
-      - name: Upload release artifacts (for main branch PR)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+          commit_version_bump: 'true'
+          next_patch_pre_without_v: ${{ needs.process-inputs.outputs.NEXT_PATCH_PRE_WITHOUT_V }}
+          previous_tag: ${{ needs.process-inputs.outputs.PREVIOUS_MINOR_TAG }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  nightly:
+    name: "release-requirement: e2e nightly"
+    uses: ./.github/workflows/e2e_nightly.yml
+    secrets:
+      GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      NUNKI_CI_COMMIT_PUSH_PR: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+      TEAMS_CI_WEBHOOK: ${{ secrets.TEAMS_CI_WEBHOOK }}
+      CONTRAST_GHCR_READ: ${{ secrets.CONTRAST_GHCR_READ }}
+    permissions:
+      contents: read
+      packages: write
+
+  release-aarch64-darwin:
+    name: "release-requirement: Build aarch64-darwin CLI"
+    runs-on: macos-latest
+    needs: [process-inputs, release-x86_64-linux]
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          name: contrast-release-artifacts
-          # Keep the LICENSE file! It isn't used, but ensures the paths of the other artifacts aren't stripped, see
-          # https://github.com/actions/upload-artifact/blob/6027e3dd177782cd8ab9af838c04fd81a07f1d47/README.md?plain=1#L187
-          path: |
-            LICENSE
-            ${{ steps.create-artifacts.outputs.paths }}
-      # Push the (dev/test-only) k8s-log-collector image so the test matrix
-      # below picks it up via just.containerlookup. This is internal infra,
-      # not part of the release artifacts, but it shares the build job's
-      # packages:write permission.
-      - name: Push k8s-log-collector image
-        id: push-log-collector
-        run: |
-          just k8s-log-collector
-          digest=$(grep "k8s-log-collector:latest=" workspace/just.containerlookup | tail -1 | cut -d= -f2-)
-          echo "image=${digest}" >> "$GITHUB_OUTPUT"
-      - name: Create draft release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2 # zizmor: ignore[superfluous-actions]
+          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          persist-credentials: false
+      - uses: ./.github/actions/release_build_darwin
         with:
-          draft: true
-          generate_release_notes: true
-          tag_name: ${{ inputs.version }}
-          target_commitish: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-          fail_on_unmatched_files: true
-          files: ${{ steps.create-artifacts.outputs.paths }}
-      - name: Reset temporary changes
-        run: |
-          git reset --hard "${WORKING_BRANCH}"
-      - name: Bump flake version to post release patch pre-version
-        uses: ./.github/actions/bump_version
-        with:
-          version: ${{ needs.process-inputs.outputs.NEXT_PATCH_PRE_WITHOUT_V }}
-          commit: true
+          effective_version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   test:
     strategy:
@@ -375,100 +177,53 @@ jobs:
             runner: TDX-GPU
             self-hosted: true
       fail-fast: false
-    name: "e2e release on ${{ matrix.platform.name }}"
+    name: "release-requirement: e2e release on ${{ matrix.platform.name }}"
     runs-on: ${{ matrix.platform.runner }}
     permissions:
       # Job needs content:write to see draft releases.
       contents: write
       packages: read
     needs: [process-inputs, release-x86_64-linux, nightly]
-    env:
-      VERSION: ${{ inputs.version }}
-      SET: base
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
           persist-credentials: false
-      - uses: ./.github/actions/setup_nix
-        if: (!matrix.platform.self-hosted)
+      - uses: ./.github/actions/release_e2e_test
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
-      - name: Log in to ghcr.io Container registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create justfile.env
-        run: |
-          cat <<EOF > justfile.env
-          container_registry=${{ env.container_registry }}
-          default_platform=${{ matrix.platform.name }}
-          set="${SET}"
-          EOF
-      - name: Get credentials for CI cluster
-        if: (!matrix.platform.self-hosted)
-        run: |
-          just get-credentials
-      - name: Request fifo ticket
-        if: (!matrix.platform.self-hosted || matrix.platform.name == 'Metal-QEMU-SNP-GPU' || matrix.platform.name == 'Metal-QEMU-TDX-GPU')
-        run: |
-          just request-fifo-ticket
-      # Pick up the k8s-log-collector digest pushed by release-x86_64-linux so
-      # get-logs deploys the freshly-built image instead of the stale SHA in
-      # packages/log-collector.yaml.
-      - name: Record k8s-log-collector digest
-        env:
-          LOG_COLLECTOR_IMAGE: ${{ needs.release-x86_64-linux.outputs.LOG_COLLECTOR_IMAGE }}
-        run: |
-          mkdir -p workspace
-          echo "ghcr.io/edgelesssys/contrast/k8s-log-collector:latest=${LOG_COLLECTOR_IMAGE}" >> workspace/just.containerlookup
-      - name: E2E Test
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p workspace
-          nix build ".#${SET}.scripts.get-logs"
-          nix run ".#${SET}.scripts.get-logs" start workspace/just.namespace &
-          nix shell -L ".#${SET}.contrast.e2e" --command release.test \
-            -test.v \
-            --tag "${VERSION}" \
-            --platform "${{ matrix.platform.name }}" \
-            --node-installer-target-conf "${{ matrix.platform.node-installer-target-conf }}" \
-            --namespace-file workspace/just.namespace
-      - name: Cleanup
-        if: always()
-        run: |
-          kubectl delete -f workspace/log-collector.yaml
-          rm -f workspace/just.namespace
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: e2e_pod_logs-${{ matrix.platform.name }}-release
-          path: workspace/logs
-          if-no-files-found: error
-      - name: Release fifo ticket
-        if: always() && (!matrix.platform.self-hosted || matrix.platform.name == 'Metal-QEMU-SNP-GPU' || matrix.platform.name == 'Metal-QEMU-TDX-GPU')
-        run: |
-          just release-fifo-ticket
+          version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          container_registry: ${{ env.container_registry }}
+          platform_name: ${{ matrix.platform.name }}
+          node_installer_target_conf: ${{ matrix.platform.node-installer-target-conf }}
+          self_hosted: ${{ matrix.platform.self-hosted }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-  nightly:
-    name: e2e nightly
-    needs: release-x86_64-linux
-    uses: ./.github/workflows/e2e_nightly.yml
-    secrets:
-      GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN }}
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      NUNKI_CI_COMMIT_PUSH_PR: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
-      TEAMS_CI_WEBHOOK: ${{ secrets.TEAMS_CI_WEBHOOK }}
-      CONTRAST_GHCR_READ: ${{ secrets.CONTRAST_GHCR_READ }}
+  prepare-post-release-pr:
+    name: Prepare post-release PR to main
+    runs-on: ubuntu-24.04
+    needs: [process-inputs, release-x86_64-linux, release-aarch64-darwin, nightly]
     permissions:
-      contents: read
-      packages: write
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          persist-credentials: false
+      - uses: ./.github/actions/prepare_post_release_pr
+        with:
+          checkout_main_ref: ${{ inputs.checkout_main_ref }}
+          version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          major_minor: ${{ needs.process-inputs.outputs.MAJOR_MINOR }}
+          major_minor_patch: ${{ needs.process-inputs.outputs.MAJOR_MINOR_PATCH }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
+          next_minor_pre_without_v: ${{ needs.process-inputs.outputs.NEXT_MINOR_PRE_WITHOUT_V }}
+          pr_branch_suffix: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          create_docs_release: ${{ inputs.kind == 'minor' }}
+          bump_version: ${{ inputs.kind == 'minor' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          nunki_ci_token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   publish:
     name: Publish release
@@ -478,45 +233,48 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Create and push release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+        run: |
+          target=$(gh release view "${VERSION}" --repo "${GH_REPO}" --json targetCommitish --jq '.targetCommitish')
+          git fetch origin "${target}"
+          git tag "${VERSION}" "${target}"
+          git push origin "${VERSION}"
+      - uses: ./.github/actions/regenerate_release_notes
+        with:
+          version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          previous_tag: ${{ needs.process-inputs.outputs.PREVIOUS_MINOR_TAG }}
+          github_token: ${{ github.token }}
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
         run: |
           gh release edit "${VERSION}" --draft=false --repo "${{ github.repository }}"
 
-  create-github-stuff:
+  prepare-github-release:
     name: Create backport label and milestone
     if: inputs.kind == 'minor'
-    needs: process-inputs
+    needs: [process-inputs, nightly]
     runs-on: ubuntu-24.04
     permissions:
       issues: write
       contents: read
-    env:
-      RELEASE_BRANCH: ${{ needs.process-inputs.outputs.RELEASE_BRANCH }}
-      NEXT_MINOR: ${{ needs.process-inputs.outputs.NEXT_MINOR }}
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
           persist-credentials: false
-      - name: Create backport label
-        run: |
-          gh label create "backport ${RELEASE_BRANCH}" --color 576F61 --force
-      - name: Create milestone
-        run: |
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/edgelesssys/contrast/milestones |
-            jq -r '.[] | .title' | \
-            grep -xqF "v${NEXT_MINOR}" && exit 0
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/edgelesssys/contrast/milestones \
-            -f title="v${NEXT_MINOR}" \
-            -f state='open'
+      - uses: ./.github/actions/prepare_github_release
+        with:
+          release_branch: ${{ needs.process-inputs.outputs.RELEASE_BRANCH }}
+          next_minor: ${{ needs.process-inputs.outputs.NEXT_MINOR }}
+          github_token: ${{ github.token }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -1,0 +1,165 @@
+name: release nightly
+
+on:
+  schedule:
+    - cron: "15 20 * * *" # 20:15 UTC, every day
+  workflow_dispatch: {}
+
+env:
+  container_registry: ghcr.io/edgelesssys
+  DO_NOT_TRACK: 1
+
+concurrency:
+  group: release-nightly
+  cancel-in-progress: true
+
+jobs:
+  process-inputs:
+    name: Process inputs
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      EFFECTIVE_VERSION: ${{ steps.nightly-version.outputs.value }}
+      WITHOUT_V: ${{ steps.version-info.outputs.without_v }}
+      RELEASE_BRANCH: ${{ steps.version-info.outputs.release_branch }}
+      WORKING_BRANCH: ${{ steps.branch.outputs.value }}
+      PREVIOUS_MINOR_TAG: ${{ steps.version-info.outputs.previous_minor_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-tags: true
+      - name: Get working branch
+        id: branch
+        run: echo "value=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
+      - name: Determine nightly version
+        id: nightly-version
+        run: |
+          base=$(sed 's/-.*$//' version.txt)
+          echo "value=v${base}-$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+      - name: Parse version
+        id: version-info
+        uses: ./.github/actions/parse_version
+        with:
+          version: ${{ steps.nightly-version.outputs.value }}
+
+  cleanup-nightly-drafts:
+    name: Clean up old nightly draft releases
+    runs-on: ubuntu-24.04
+    needs: process-inputs
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Delete existing nightly draft releases
+        env:
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release list --repo "${GH_REPO}" --limit 10 --json tagName,isDraft \
+            | jq -r '.[] | select(.isDraft == true) | .tagName' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}$' \
+            | while IFS= read -r tag; do
+                echo "Deleting nightly draft release: ${tag}"
+                gh release delete "${tag}" --repo "${GH_REPO}" --yes --cleanup-tag
+              done
+
+  release-x86_64-linux:
+    name: "release-requirement: Build and push artifacts, create nightly draft release"
+    runs-on: ubuntu-24.04
+    needs: [process-inputs, cleanup-nightly-drafts]
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          persist-credentials: false
+      - uses: ./.github/actions/release_build_linux
+        with:
+          effective_version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
+          working_branch: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          container_registry: ${{ env.container_registry }}
+          previous_tag: ${{ needs.process-inputs.outputs.PREVIOUS_MINOR_TAG }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  release-aarch64-darwin:
+    name: "release-requirement: Build aarch64-darwin CLI"
+    runs-on: macos-latest
+    needs: [process-inputs, release-x86_64-linux]
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          persist-credentials: false
+      - uses: ./.github/actions/release_build_darwin
+        with:
+          effective_version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+  nightly:
+    name: "release-requirement: e2e nightly"
+    uses: ./.github/workflows/e2e_nightly.yml
+    secrets:
+      GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      NUNKI_CI_COMMIT_PUSH_PR: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+      TEAMS_CI_WEBHOOK: ${{ secrets.TEAMS_CI_WEBHOOK }}
+      CONTRAST_GHCR_READ: ${{ secrets.CONTRAST_GHCR_READ }}
+    permissions:
+      contents: read
+      packages: write
+
+  test:
+    strategy:
+      matrix:
+        platform:
+          - name: Metal-QEMU-SNP
+            node-installer-target-conf: none
+            runner: SNP
+            self-hosted: true
+          - name: Metal-QEMU-SNP-GPU
+            node-installer-target-conf: k3s
+            runner: SNP-GPU
+            self-hosted: true
+          - name: Metal-QEMU-TDX
+            node-installer-target-conf: k3s
+            runner: TDX
+            self-hosted: true
+          - name: Metal-QEMU-TDX-GPU
+            node-installer-target-conf: none
+            runner: TDX-GPU
+            self-hosted: true
+      fail-fast: false
+    name: "release-requirement: e2e release on ${{ matrix.platform.name }}"
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      # Job needs content:write to see draft releases.
+      contents: write
+      packages: read
+    needs: [process-inputs, release-x86_64-linux, release-aarch64-darwin, nightly]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+          persist-credentials: false
+      - uses: ./.github/actions/release_e2e_test
+        with:
+          version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          container_registry: ${{ env.container_registry }}
+          platform_name: ${{ matrix.platform.name }}
+          node_installer_target_conf: ${{ matrix.platform.node-installer-target-conf }}
+          self_hosted: ${{ matrix.platform.self-hosted }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -1,0 +1,226 @@
+name: release promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkout_main_ref:
+        description: Checkout this git ref as main branch (some workflows run on this state)
+        type: string
+        required: false
+        default: main
+
+env:
+  container_registry: ghcr.io/edgelesssys
+  DO_NOT_TRACK: 1
+
+concurrency:
+  group: release-promote
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Verify nightly and prepare release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      EFFECTIVE_VERSION: ${{ steps.effective-version.outputs.value }}
+      WITHOUT_V: ${{ steps.version-info.outputs.without_v }}
+      MAJOR_MINOR: ${{ steps.version-info.outputs.major_minor }}
+      MAJOR_MINOR_PATCH: ${{ steps.version-info.outputs.major_minor_patch }}
+      RELEASE_BRANCH: ${{ steps.version-info.outputs.release_branch }}
+      WORKING_BRANCH: ${{ steps.branch.outputs.value }}
+      NEXT_MINOR: ${{ steps.version-info.outputs.next_minor }}
+      NEXT_MINOR_PRE_WITHOUT_V: ${{ steps.version-info.outputs.next_minor_pre_without_v }}
+      PREVIOUS_MINOR_TAG: ${{ steps.version-info.outputs.previous_minor_tag }}
+      nightly_ref: ${{ steps.nightly-info.outputs.nightly_ref }}
+      nightly_tag: ${{ steps.nightly-info.outputs.nightly_tag }}
+      nightly_run_id: ${{ steps.nightly-info.outputs.nightly_run_id }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Determine version
+        id: effective-version
+        run: |
+          base=$(sed 's/-.*$//' version.txt)
+          FULL_VERSION="v${base}"
+          echo "FULL_VERSION=${FULL_VERSION}" | tee -a "$GITHUB_ENV"
+          echo "value=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Get nightly run info
+        id: nightly-info
+        env:
+          GH_REPO: ${{ github.repository }}
+        run: |
+          nightly_run_id=$(gh run list --repo "${GH_REPO}" --workflow=release_nightly.yml --status=completed --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [[ -z "${nightly_run_id}" ]]; then
+            echo "::error::No completed run of release_nightly.yml found."
+            exit 1
+          fi
+          nightly_ref=$(gh run view "${nightly_run_id}" --repo "${GH_REPO}" --json headSha --jq '.headSha')
+          nightly_date=$(gh run view "${nightly_run_id}" --repo "${GH_REPO}" --json createdAt --jq '.createdAt | .[0:10]')
+          nightly_tag="${FULL_VERSION}-${nightly_date}"
+          echo "nightly_run_id=${nightly_run_id}" | tee -a "$GITHUB_OUTPUT"
+          echo "nightly_ref=${nightly_ref}" | tee -a "$GITHUB_OUTPUT"
+          echo "nightly_tag=${nightly_tag}" | tee -a "$GITHUB_OUTPUT"
+      - name: Verify nightly tests passed
+        env:
+          NIGHTLY_RUN_ID: ${{ steps.nightly-info.outputs.nightly_run_id }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          failed=$(gh run view "${NIGHTLY_RUN_ID}" --repo "${GH_REPO}" --json jobs \
+            --jq '[.jobs[] | select(.name | startswith("release-requirement: ")) | select(.conclusion != "success")] | map("\(.name): \(.conclusion)") | .[]')
+          if [[ -n "${failed}" ]]; then
+            echo "::error::The following required jobs did not succeed in nightly run ${NIGHTLY_RUN_ID}:"
+            echo "${failed}"
+            exit 1
+          fi
+      - name: Verify nightly draft release has artifacts
+        env:
+          NIGHTLY_TAG: ${{ steps.nightly-info.outputs.nightly_tag }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          asset_count=$(gh release view "${NIGHTLY_TAG}" --repo "${GH_REPO}" --json assets --jq '.assets | length' 2>/dev/null || echo "0")
+          if [[ "${asset_count}" -eq 0 ]]; then
+            echo "::error::No assets found on nightly draft release ${NIGHTLY_TAG}. Expected artifacts from the build."
+            exit 1
+          fi
+          echo "Found ${asset_count} assets on ${NIGHTLY_TAG}."
+      - name: Don't overwrite published releases
+        run: |
+          is_draft=$(gh release view "${FULL_VERSION}" --json isDraft -q .isDraft 2>/dev/null || true)
+          if [[ "${is_draft}" == "false" ]]; then
+            echo "::error::Release ${FULL_VERSION} is already published."
+            exit 1
+          fi
+      - name: Get working branch
+        id: branch
+        run: echo "value=$(git branch --show-current)" >> "$GITHUB_OUTPUT"
+      - name: Parse version
+        id: version-info
+        uses: ./.github/actions/parse_version
+        with:
+          version: ${{ steps.effective-version.outputs.value }}
+
+  promote:
+    name: Promote nightly artifacts to release
+    runs-on: ubuntu-24.04
+    needs: prepare
+    permissions:
+      contents: write
+      actions: read
+    env:
+      VERSION: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Download release artifacts from nightly run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: contrast-release-artifacts
+          path: ./release-artifacts
+          run-id: ${{ needs.prepare.outputs.nightly_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download darwin CLI from nightly run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: contrast-cli-aarch64-darwin
+          path: ./darwin-artifacts
+          run-id: ${{ needs.prepare.outputs.nightly_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release draft
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2  # zizmor: ignore[superfluous-actions]
+        with:
+          draft: true
+          generate_release_notes: true
+          tag_name: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+          previous_tag: ${{ needs.prepare.outputs.PREVIOUS_MINOR_TAG }}
+          target_commitish: ${{ needs.prepare.outputs.nightly_ref }}
+          fail_on_unmatched_files: true
+          files: |
+            ./release-artifacts/**
+            !./release-artifacts/LICENSE
+            ./darwin-artifacts/contrast-aarch64-darwin
+      - name: Delete nightly draft release
+        env:
+          NIGHTLY_TAG: ${{ needs.prepare.outputs.nightly_tag }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete "${NIGHTLY_TAG}" --repo "${GH_REPO}" --yes --cleanup-tag
+
+  prepare-github-release:
+    name: Create backport label and milestone
+    needs: prepare
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.nightly_ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/prepare_github_release
+        with:
+          release_branch: ${{ needs.prepare.outputs.RELEASE_BRANCH }}
+          next_minor: ${{ needs.prepare.outputs.NEXT_MINOR }}
+          github_token: ${{ github.token }}
+
+  prepare-post-release-pr:
+    name: Prepare post-release PR to main
+    runs-on: ubuntu-24.04
+    needs: [prepare, promote]
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.nightly_ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/prepare_post_release_pr
+        with:
+          checkout_main_ref: ${{ inputs.checkout_main_ref }}
+          version: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+          major_minor: ${{ needs.prepare.outputs.MAJOR_MINOR }}
+          major_minor_patch: ${{ needs.prepare.outputs.MAJOR_MINOR_PATCH }}
+          without_v: ${{ needs.prepare.outputs.WITHOUT_V }}
+          next_minor_pre_without_v: ${{ needs.prepare.outputs.NEXT_MINOR_PRE_WITHOUT_V }}
+          pr_branch_suffix: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          nunki_ci_token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+          cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          artifacts_run_id: ${{ needs.prepare.outputs.nightly_run_id }}
+
+  publish:
+    name: Prepare post-release PR to main
+    needs: [prepare, promote, prepare-github-release, prepare-post-release-pr]
+    runs-on: ubuntu-24.04
+    environment: release-publish
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.nightly_ref }}
+          persist-credentials: true
+      - name: Create and push release tag
+        env:
+          VERSION: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+          REF: ${{ needs.prepare.outputs.nightly_ref }}
+        run: |
+          git tag "${VERSION}" "${REF}"
+          git push origin "${VERSION}"
+      - uses: ./.github/actions/regenerate_release_notes
+        with:
+          version: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+          previous_tag: ${{ needs.prepare.outputs.PREVIOUS_MINOR_TAG }}
+          github_token: ${{ github.token }}
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
+        run: |
+          gh release edit "${VERSION}" --draft=false --repo "${{ github.repository }}"

--- a/dev-docs/release.md
+++ b/dev-docs/release.md
@@ -1,6 +1,36 @@
 # How to release
 
-## Minor
+## Minor, by promoting nightly
+
+The CI should create a nightly minor draft release, called `v1.x.0-yyyy-mm-dd`, and runs the full test suite against it.
+This draft release can be promoted to actual release.
+
+1. Check that in the latest nightly, all checks and tests passed. A draft release is created even if that's not the case, but trying to promote a nightly release where linux/darwin releases, nightly e2es or the release e2e failed, will automatically fail anyway.
+
+2. Sanity-check the latest nightly draft release on GitHub. The tag should match `vX.Y.Z-yyyy-mm-dd` where
+  `X.Y.Z` is `version.txt` on main with the `-pre` suffix stripped, and the draft must have artifacts attached.
+
+3. Trigger the promote workflow (it always promotes the most recent completed `release_nightly.yml` run):
+
+    ```sh
+    gh workflow run release_promote.yml
+    ```
+
+4. Test the binary artifact. Send Privatemode a message to review the release artifacts as well and wait for their feedback.
+
+5. **Wait for PM approval before proceeding.**
+
+6. Review and merge the auto generated update PR for `main`.
+
+7. Review the release notes. If label/title/description changes are necessary, change them on the original PR itself.
+
+8. Approve the `Publish release` job in the GitHub Actions workflow run.
+
+9. Check that the publish job succeeds and confirm the release notes on GitHub were regenerated against the now-existing tag.
+
+## Minor, manually
+
+If you need to include new changes merged into main since the last successful nightly, you can instead release manually.
 
 1. Ensure all needed PRs were merged.
 


### PR DESCRIPTION
`e2e_nightly` workflow no longer triggers automatically. Instead, `release` workflow dry-runs every night. "dry run" here means no backport PRs, no draft releases. The artifacts are still published to S3, so we/pm can use them.