### PR TITLE
release: push k8s-log-collector

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,8 @@ jobs:
       contents: write
       packages: write
       id-token: write
+    outputs:
+      LOG_COLLECTOR_IMAGE: ${{ steps.push-log-collector.outputs.image }}
     env:
       RELEASE_BRANCH: ${{ needs.process-inputs.outputs.RELEASE_BRANCH }}
       WORKING_BRANCH: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
@@ -324,6 +326,16 @@ jobs:
           path: |
             LICENSE
             ${{ steps.create-artifacts.outputs.paths }}
+      # Push the (dev/test-only) k8s-log-collector image so the test matrix
+      # below picks it up via just.containerlookup. This is internal infra,
+      # not part of the release artifacts, but it shares the build job's
+      # packages:write permission.
+      - name: Push k8s-log-collector image
+        id: push-log-collector
+        run: |
+          just k8s-log-collector
+          digest=$(grep "k8s-log-collector:latest=" workspace/just.containerlookup | tail -1 | cut -d= -f2-)
+          echo "image=${digest}" >> "$GITHUB_OUTPUT"
       - name: Create draft release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
@@ -405,6 +417,15 @@ jobs:
         if: (!matrix.platform.self-hosted || matrix.platform.name == 'Metal-QEMU-SNP-GPU' || matrix.platform.name == 'Metal-QEMU-TDX-GPU')
         run: |
           just request-fifo-ticket
+      # Pick up the k8s-log-collector digest pushed by release-x86_64-linux so
+      # get-logs deploys the freshly-built image instead of the stale SHA in
+      # packages/log-collector.yaml.
+      - name: Record k8s-log-collector digest
+        env:
+          LOG_COLLECTOR_IMAGE: ${{ needs.release-x86_64-linux.outputs.LOG_COLLECTOR_IMAGE }}
+        run: |
+          mkdir -p workspace
+          echo "ghcr.io/edgelesssys/contrast/k8s-log-collector:latest=${LOG_COLLECTOR_IMAGE}" >> workspace/just.containerlookup
       - name: E2E Test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/by-name/scripts/get-logs/get-logs.sh
+++ b/packages/by-name/scripts/get-logs/get-logs.sh
@@ -103,7 +103,7 @@ download)
 
       echo "Collecting host-level logs (since $start_time)..." >&2
       retry kubectl exec -n "$namespace" "$pod" -- \
-        collect-host-logs "$start_time" || true
+        collect-host-logs "$start_time"
 
       retry kubectl exec -n "$namespace" "$pod" -- /bin/bash -c '
         rm -f /exported-logs.tar.gz


### PR DESCRIPTION
As it can be seen in https://github.com/edgelesssys/contrast/actions/runs/25005789022/job/73530829709, release workflow jobs fail to find the `collect-host-logs` binary because they are using an older `k8s-log-collector` image. That is because the `k8s-log-collector` image used to be hard-coded with a hash before the log host collection was added.

Also surface an error if the host log collection steps fail.

Fix this by making the release workflow also push a fresh k8s-log-collector image. 