### PR TITLE
go: migrate crypto/elliptic -> filippo.io/nistec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace github.com/google/go-tdx-guest => github.com/edgelesssys/go-tdx-guest v0
 
 require (
 	filippo.io/keygen v0.0.0-20260114151900-8e2790ea4c5b
+	filippo.io/nistec v0.0.4
 	github.com/containerd/ttrpc v1.2.8
 	github.com/coreos/go-iptables v0.8.0
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ filippo.io/bigmod v0.1.1-0.20260103110540-f8a47775ebe5 h1:JA0fFr+kxpqTdxR9LOBiTW
 filippo.io/bigmod v0.1.1-0.20260103110540-f8a47775ebe5/go.mod h1:OjOXDNlClLblvXdwgFFOQFJEocLhhtai8vGLy0JCZlI=
 filippo.io/keygen v0.0.0-20260114151900-8e2790ea4c5b h1:REI1FbdW71yO56Are4XAxD+OS/e+BQsB3gE4mZRQEXY=
 filippo.io/keygen v0.0.0-20260114151900-8e2790ea4c5b/go.mod h1:9nnw1SlYHYuPSo/3wjQzNjSbeHlq2NsKo5iEtfJPWP0=
+filippo.io/nistec v0.0.4 h1:F14ZHT5htWlMnQVPndX9ro9arf56cBhQxq4LnDI491s=
+filippo.io/nistec v0.0.4/go.mod h1:PK/lw8I1gQT4hUML4QGaqljwdDaFcMyFKSXN7kjrtKI=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/idblock/idblock.go
+++ b/internal/idblock/idblock.go
@@ -4,6 +4,7 @@
 package idblock
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha512"
@@ -12,8 +13,11 @@ import (
 	"math/big"
 	"slices"
 
+	"filippo.io/nistec"
 	"github.com/google/go-sev-guest/abi"
 )
+
+const p384CoordSize = 48
 
 // IDBlock is the ID block.
 // https://github.com/microsoft/igvm-tooling/blob/main/src/igvm/structure/igvmfileformat.py#L453
@@ -264,8 +268,14 @@ func recoverPublicKey(curve elliptic.Curve, r, s, z *big.Int) ([]ecdsa.PublicKey
 			pointY = new(big.Int).Sub(params.P, pointY)
 		}
 
-		// Verify if the point is on the curve
-		if !curve.IsOnCurve(pointX, pointY) { //nolint:staticcheck // SA1019: low-level arithmetic is needed for public key recovery
+		// Construct the candidate as an uncompressed, encoded point (0x04 || X || Y) as per https://www.secg.org/sec1-v2.pdf section 2.3.3,
+		// and rely on the documented behaviour of SetBytes to reject the point if it is not on the curve.
+		qBytes := make([]byte, 1+2*p384CoordSize)
+		qBytes[0] = 0x04
+		pointX.FillBytes(qBytes[1 : 1+p384CoordSize])
+		pointY.FillBytes(qBytes[1+p384CoordSize:])
+		q, err := nistec.NewP384Point().SetBytes(qBytes)
+		if err != nil {
 			continue
 		}
 
@@ -278,28 +288,37 @@ func recoverPublicKey(curve elliptic.Curve, r, s, z *big.Int) ([]ecdsa.PublicKey
 		u2 := new(big.Int).Mul(s, rInv)
 		u2.Mod(u2, order)
 
-		// Compute the candidate public key as u1*G + u2*Q
-		x1, y1 := curve.ScalarBaseMult(u1.Bytes()) //nolint:staticcheck // SA1019: low-level arithmetic is needed for public key recovery
+		// Compute u1 = -z * r^-1 mod n and u2 = s * r^-1 mod n.
+		// TODO(burgerdev): align variable naming to the nomenclature in SEC 1 (https://www.secg.org/sec1-v2.pdf) section 4.1.6.
+		u1Bytes := make([]byte, p384CoordSize)
+		u1.FillBytes(u1Bytes)
+		u2Bytes := make([]byte, p384CoordSize)
+		u2.FillBytes(u2Bytes)
+		p1, err := nistec.NewP384Point().ScalarBaseMult(u1Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("scalar base mult: %w", err)
+		}
+		p2, err := nistec.NewP384Point().ScalarMult(q, u2Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("scalar mult: %w", err)
+		}
+		sumBytes := nistec.NewP384Point().Add(p1, p2).Bytes()
 
-		x2, y2 := curve.ScalarMult(pointX, pointY, u2.Bytes()) //nolint:staticcheck // SA1019: low-level arithmetic is needed for public key recovery
-
-		finalX, finalY := curve.Add(x1, y1, x2, y2) //nolint:staticcheck // SA1019: low-level arithmetic is needed for public key recovery
-
-		publicKeys = append(publicKeys, ecdsa.PublicKey{
-			Curve: curve,
-			X:     finalX,
-			Y:     finalY,
-		})
-
+		// sumBytes is an uncompressed, encoded point, which ParseUncompressedPublicKey turns into a public key,
+		// rejecting it if it is not a valid point on the curve.
+		pubKey, err := ecdsa.ParseUncompressedPublicKey(curve, sumBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parsing recovered public key: %w", err)
+		}
+		publicKeys = append(publicKeys, *pubKey)
 	}
 
-	// sort public keys
+	// Sort the keys by their uncompressed encoding for a deterministic order.
 	slices.SortStableFunc(publicKeys, func(a, b ecdsa.PublicKey) int {
-		cmpX := a.X.Cmp(b.X)
-		if cmpX != 0 {
-			return cmpX
-		}
-		return a.Y.Cmp(b.Y)
+		// Bytes never fails for keys returned by ParseUncompressedPublicKey.
+		aBytes, _ := a.Bytes()
+		bBytes, _ := b.Bytes()
+		return bytes.Compare(aBytes, bBytes)
 	})
 
 	return publicKeys, nil
@@ -350,13 +369,18 @@ func IDBlocksFromLaunchDigest(launchDigest [48]byte, guestPolicy abi.SnpPolicy) 
 		return nil, nil, fmt.Errorf("failed to recover public key: %w", err)
 	}
 
-	// Always choose the same recovered public key
-	pubKey := pubKeys[0]
+	// Always choose the same recovered public key.
+	pubKeyBytes, err := pubKeys[0].Bytes()
+	if err != nil {
+		return nil, nil, fmt.Errorf("encoding recovered public key: %w", err)
+	}
 
-	xLittleEndian := pubKey.X.Bytes()
+	// pubKeyBytes is the uncompressed encoding 0x04 || X || Y, with X and Y each
+	// p384CoordSize bytes, big-endian. The ID block stores the coordinates little-endian.
+	xLittleEndian := pubKeyBytes[1 : 1+p384CoordSize]
 	slices.Reverse(xLittleEndian)
 
-	yLittleEndian := pubKey.Y.Bytes()
+	yLittleEndian := pubKeyBytes[1+p384CoordSize:]
 	slices.Reverse(yLittleEndian)
 
 	idAuth := &IDAuthentication{

--- a/internal/idblock/idblock.go
+++ b/internal/idblock/idblock.go
@@ -19,6 +19,12 @@ import (
 
 const p384CoordSize = 48
 
+func reverse(x []byte) []byte {
+	x = slices.Clone(x)
+	slices.Reverse(x)
+	return x
+}
+
 // IDBlock is the ID block.
 // https://github.com/microsoft/igvm-tooling/blob/main/src/igvm/structure/igvmfileformat.py#L453
 // https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/56860.pdf (revision 1.57)
@@ -262,6 +268,22 @@ func recoverPublicKey(curve elliptic.Curve, r, s, z *big.Int) ([]ecdsa.PublicKey
 		return nil, fmt.Errorf("no square root")
 	}
 
+	u1 := new(big.Int).Mul(z, rInv)
+	u1.Mod(u1, order)
+	u1.Neg(u1)
+	u1.Mod(u1, order)
+
+	// Compute u1 and u2
+	u2 := new(big.Int).Mul(s, rInv)
+	u2.Mod(u2, order)
+
+	// Compute u1 = -z * r^-1 mod n and u2 = s * r^-1 mod n.
+	// TODO(burgerdev): align variable naming to the nomenclature in SEC 1 (https://www.secg.org/sec1-v2.pdf) section 4.1.6.
+	u1Bytes := make([]byte, p384CoordSize)
+	u1.FillBytes(u1Bytes)
+	u2Bytes := make([]byte, p384CoordSize)
+	u2.FillBytes(u2Bytes)
+
 	// Try both y-coordinates for recovery
 	for _, ySign := range []int64{1, -1} {
 		if ySign == -1 {
@@ -279,21 +301,6 @@ func recoverPublicKey(curve elliptic.Curve, r, s, z *big.Int) ([]ecdsa.PublicKey
 			continue
 		}
 
-		u1 := new(big.Int).Mul(z, rInv)
-		u1.Mod(u1, order)
-		u1.Neg(u1)
-		u1.Mod(u1, order)
-
-		// Compute u1 and u2
-		u2 := new(big.Int).Mul(s, rInv)
-		u2.Mod(u2, order)
-
-		// Compute u1 = -z * r^-1 mod n and u2 = s * r^-1 mod n.
-		// TODO(burgerdev): align variable naming to the nomenclature in SEC 1 (https://www.secg.org/sec1-v2.pdf) section 4.1.6.
-		u1Bytes := make([]byte, p384CoordSize)
-		u1.FillBytes(u1Bytes)
-		u2Bytes := make([]byte, p384CoordSize)
-		u2.FillBytes(u2Bytes)
 		p1, err := nistec.NewP384Point().ScalarBaseMult(u1Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("scalar base mult: %w", err)
@@ -377,11 +384,8 @@ func IDBlocksFromLaunchDigest(launchDigest [48]byte, guestPolicy abi.SnpPolicy) 
 
 	// pubKeyBytes is the uncompressed encoding 0x04 || X || Y, with X and Y each
 	// p384CoordSize bytes, big-endian. The ID block stores the coordinates little-endian.
-	xLittleEndian := pubKeyBytes[1 : 1+p384CoordSize]
-	slices.Reverse(xLittleEndian)
-
-	yLittleEndian := pubKeyBytes[1+p384CoordSize:]
-	slices.Reverse(yLittleEndian)
+	xLittleEndian := reverse(pubKeyBytes[1 : 1+p384CoordSize])
+	yLittleEndian := reverse(pubKeyBytes[1+p384CoordSize:])
 
 	idAuth := &IDAuthentication{
 		IDKeyAlgo:   0x1,

--- a/internal/idblock/idblock_test.go
+++ b/internal/idblock/idblock_test.go
@@ -4,6 +4,7 @@
 package idblock
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -92,8 +93,11 @@ func TestRecoverPublicKey(t *testing.T) {
 			}
 
 			if tc.pubKey != nil {
+				wantBytes, err := tc.pubKey.Bytes()
+				require.NoError(err)
 				assert.True(slices.ContainsFunc(publicKeys, func(pk ecdsa.PublicKey) bool {
-					return pk.X.Cmp(tc.pubKey.X) == 0 && pk.Y.Cmp(tc.pubKey.Y) == 0
+					gotBytes, err := pk.Bytes()
+					return err == nil && bytes.Equal(gotBytes, wantBytes)
 				}))
 			}
 		})

--- a/packages/by-name/contrast/contrast/package.nix
+++ b/packages/by-name/contrast/contrast/package.nix
@@ -53,7 +53,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-JIp9Dn+i/6Ac3SqH8YuK97OKUQom55WxPcGXVKovKdE=";
+  vendorHash = "sha256-NJyzfx4LAD9PRMIGPPiL/U4CxwXCn7CrN6/59EIa+to=";
 
   subPackages = packageOutputs;
 

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -165,6 +165,7 @@
         --ignore github.com/edgelesssys/contrast
         --ignore github.com/rootless-containers/proto/go-proto # Apache-2.0, but not correctly recognized https://github.com/rootless-containers/proto/issues/5
         --ignore github.com/cyphar/filepath-securejoin # MPL-2.0, which is reciprocal but only for the original source.
+        --ignore filippo.io/nistec/internal/fiat # permissive fiat-crypto (BSD-1-Clause) license, misclassified as unknown by go-licenses.
       )
 
       tags="${lib.concatStringsSep "," contrastPkgs.contrast.contrast.tags}"


### PR DESCRIPTION
No idea why `generate` keeps failing, checks out locally.

Disclaimer: migration to `nistec` package was done with help from an LLM.