### PR TITLE
[3/8] runtime/nodeinstaller: add insecure platform variants

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -28,6 +28,15 @@ func ContrastRuntimeClass(platform platforms.Platform) (*RuntimeClassConfig, err
 
 	// Consists of the default VM memory, 70MiB for the Kata shim and 100MiB for qemu overhead.
 	memoryOverhead := platforms.DefaultMemoryInMebiBytes(platform) + 170
+	if platforms.IsInsecure(platform) && platforms.IsGPU(platform) {
+		// On insecure (non-CC) GPU platforms, iommufd VFIO passthrough pins guest
+		// memory and allocates IOMMU page tables that are charged to the pod's
+		// cgroup. On CC platforms, TDX manages this memory outside the cgroup.
+		// (in the kernel / TDX module memory)
+		// Add extra headroom to avoid OOM kills. 512MB should suffice for VMs up
+		// to ~256GB of memory, which is our current limit on TDX as well.
+		memoryOverhead += 512
+	}
 
 	r := RuntimeClass(runtimeHandler).
 		WithHandler(runtimeHandler).

--- a/internal/manifest/runtimehandler.go
+++ b/internal/manifest/runtimehandler.go
@@ -33,16 +33,28 @@ func RuntimeHandler(platform platforms.Platform) (string, error) {
 // PlatformFromHandler extracts the platform from the runtime handler name.
 func PlatformFromHandler(handler string) (platforms.Platform, error) {
 	rest, found := strings.CutPrefix(handler, "contrast-cc-")
+	isInsecure := false
+	if !found {
+		rest, found = strings.CutPrefix(handler, "contrast-insecure-")
+		isInsecure = true
+	}
 	if !found {
 		return platforms.Unknown, fmt.Errorf("invalid handler name: %s", handler)
 	}
 
 	parts := strings.Split(rest, "-")
-	if len(parts) != 4 && len(parts) != 5 {
+	if len(parts) < 3 || len(parts) > 5 {
 		return platforms.Unknown, fmt.Errorf("invalid handler name: %s", handler)
 	}
 
 	rawPlatform := strings.Join(parts[:len(parts)-1], "-")
+	if isInsecure {
+		if before, ok := strings.CutSuffix(rawPlatform, "-gpu"); ok {
+			rawPlatform = before + "-insecure-gpu"
+		} else {
+			rawPlatform += "-insecure"
+		}
+	}
 
 	platform, err := platforms.FromString(rawPlatform)
 	if err != nil {

--- a/internal/platforms/platforms.go
+++ b/internal/platforms/platforms.go
@@ -24,11 +24,18 @@ const (
 	MetalQEMUSNPGPU
 	// MetalQEMUTDXGPU is the generic platform for bare-metal TDX deployments with GPU passthrough.
 	MetalQEMUTDXGPU
+	// MetalQEMUInsecure is the platform for bare-metal deployments with a non-CC runtime class.
+	MetalQEMUInsecure
+	// MetalQEMUInsecureGPU is the platform for bare-metal deployments with GPU passthrough and a non-CC runtime class.
+	MetalQEMUInsecureGPU
 )
 
 // All returns a list of all available platforms.
 func All() []Platform {
-	return []Platform{MetalQEMUSNP, MetalQEMUTDX, MetalQEMUSNPGPU, MetalQEMUTDXGPU}
+	return []Platform{
+		MetalQEMUSNP, MetalQEMUTDX, MetalQEMUSNPGPU, MetalQEMUTDXGPU,
+		MetalQEMUInsecure, MetalQEMUInsecureGPU,
+	}
 }
 
 // AllStrings returns a list of all available platforms as strings.
@@ -51,8 +58,25 @@ func (p Platform) String() string {
 		return "Metal-QEMU-TDX"
 	case MetalQEMUTDXGPU:
 		return "Metal-QEMU-TDX-GPU"
+	case MetalQEMUInsecure:
+		return "Metal-QEMU-Insecure"
+	case MetalQEMUInsecureGPU:
+		return "Metal-QEMU-Insecure-GPU"
 	default:
 		return "Unknown"
+	}
+}
+
+// InsecureVariant returns the insecure (non-CC) variant of the
+// platform, or Unknown if there is no such variant.
+func (p Platform) InsecureVariant() Platform {
+	switch p {
+	case MetalQEMUSNP, MetalQEMUTDX:
+		return MetalQEMUInsecure
+	case MetalQEMUSNPGPU, MetalQEMUTDXGPU:
+		return MetalQEMUInsecureGPU
+	default:
+		return Unknown
 	}
 }
 
@@ -99,6 +123,10 @@ func FromString(s string) (Platform, error) {
 		return MetalQEMUTDX, nil
 	case "metal-qemu-tdx-gpu":
 		return MetalQEMUTDXGPU, nil
+	case "metal-qemu-insecure":
+		return MetalQEMUInsecure, nil
+	case "metal-qemu-insecure-gpu":
+		return MetalQEMUInsecureGPU, nil
 	default:
 		return Unknown, fmt.Errorf("unknown platform: %s", s)
 	}
@@ -125,6 +153,10 @@ func FromRuntimeClassString(s string) (Platform, error) {
 		return MetalQEMUTDXGPU, nil
 	case strings.HasPrefix(s, "contrast-cc-metal-qemu-tdx"):
 		return MetalQEMUTDX, nil
+	case strings.HasPrefix(s, "contrast-insecure-metal-qemu-gpu"):
+		return MetalQEMUInsecureGPU, nil
+	case strings.HasPrefix(s, "contrast-insecure-metal-qemu"):
+		return MetalQEMUInsecure, nil
 	default:
 		return Unknown, fmt.Errorf("unknown platform: %s", s)
 	}
@@ -133,7 +165,7 @@ func FromRuntimeClassString(s string) (Platform, error) {
 // DefaultMemoryInMebiBytes returns the desired VM overhead for the given platform.
 func DefaultMemoryInMebiBytes(p Platform) int {
 	switch p {
-	case MetalQEMUSNPGPU, MetalQEMUTDXGPU:
+	case MetalQEMUSNPGPU, MetalQEMUTDXGPU, MetalQEMUInsecureGPU:
 		// Guest components contribute around 600MiB with GPU enabled.
 		return 1024
 	default:
@@ -141,6 +173,16 @@ func DefaultMemoryInMebiBytes(p Platform) int {
 		// pulled in the guest we leave a little bit of extra room to accommodate for our init
 		// containers.
 		return 512
+	}
+}
+
+// IsInsecure returns true if the platform is an insecure (non-CC) platform.
+func IsInsecure(p Platform) bool {
+	switch p {
+	case MetalQEMUInsecure, MetalQEMUInsecureGPU:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -167,7 +209,7 @@ func IsTDX(p Platform) bool {
 // IsGPU returns true if the platform supports GPUs.
 func IsGPU(p Platform) bool {
 	switch p {
-	case MetalQEMUSNPGPU, MetalQEMUTDXGPU:
+	case MetalQEMUSNPGPU, MetalQEMUTDXGPU, MetalQEMUInsecureGPU:
 		return true
 	default:
 		return false
@@ -177,7 +219,8 @@ func IsGPU(p Platform) bool {
 // IsQEMU returns true if the platform uses QEMU as the hypervisor.
 func IsQEMU(p Platform) bool {
 	switch p {
-	case MetalQEMUSNP, MetalQEMUSNPGPU, MetalQEMUTDX, MetalQEMUTDXGPU:
+	case MetalQEMUSNP, MetalQEMUSNPGPU, MetalQEMUTDX, MetalQEMUTDXGPU,
+		MetalQEMUInsecure, MetalQEMUInsecureGPU:
 		return true
 	default:
 		return false
@@ -191,6 +234,8 @@ func (p Platform) WithGPU() Platform {
 		return MetalQEMUSNPGPU
 	case MetalQEMUTDX, MetalQEMUTDXGPU:
 		return MetalQEMUTDXGPU
+	case MetalQEMUInsecure, MetalQEMUInsecureGPU:
+		return MetalQEMUInsecureGPU
 	default:
 		return Unknown
 	}

--- a/justfile
+++ b/justfile
@@ -223,7 +223,7 @@ runtime target=default_deploy_target platform=default_platform set=default_set:
         --namespace {{ target }}${namespace_suffix-} \
         --node-installer-target-conf-type ${node_installer_target_conf_type} \
         --platform "$platforms" \
-        runtime >> "./{{ workspace_dir }}/runtime/runtime.yml"
+        runtime > "./{{ workspace_dir }}/runtime/runtime.yml"
 
 # Populate the workspace with a Kubernetes deployment
 populate target=default_deploy_target platform=default_platform set=default_set:

--- a/justfile
+++ b/justfile
@@ -58,10 +58,10 @@ node-installer platform=default_platform:
     #!/usr/bin/env bash
     set -euo pipefail
     case {{ platform }} in
-        "Metal-QEMU-SNP"|"Metal-QEMU-TDX")
+        "Metal-QEMU-SNP"|"Metal-QEMU-TDX"|"Metal-QEMU-Insecure")
             just push "node-installer-kata"
         ;;
-        "Metal-QEMU-SNP-GPU"|"Metal-QEMU-TDX-GPU")
+        "Metal-QEMU-SNP-GPU"|"Metal-QEMU-TDX-GPU"|"Metal-QEMU-Insecure-GPU")
             just push "node-installer-kata-gpu"
         ;;
         *)

--- a/nodeinstaller/internal/containerdconfig/config.go
+++ b/nodeinstaller/internal/containerdconfig/config.go
@@ -144,12 +144,12 @@ func ContrastRuntime(baseDir string, platform platforms.Platform) (Runtime, erro
 		PrivilegedWithoutHostDevices: true,
 	}
 
-	switch {
-	case platforms.IsTDX(platform):
+	switch platform {
+	case platforms.MetalQEMUTDX, platforms.MetalQEMUTDXGPU:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-tdx.toml"),
 		}
-	case platforms.IsSNP(platform):
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU, platforms.MetalQEMUInsecure, platforms.MetalQEMUInsecureGPU:
 		cfg.Options = map[string]any{
 			"ConfigPath": filepath.Join(baseDir, "etc", "configuration-qemu-snp.toml"),
 		}

--- a/nodeinstaller/internal/kataconfig/config.go
+++ b/nodeinstaller/internal/kataconfig/config.go
@@ -30,20 +30,27 @@ func KataRuntimeConfig(
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
 		config.Hypervisor["qemu"]["firmware"] = filepath.Join(baseDir, "tdx", "share", "OVMF.fd")
-	case platforms.IsSNP(platform):
+	case platforms.IsSNP(platform) || platforms.IsInsecure(platform):
 		if err := toml.Unmarshal([]byte(kataBareMetalQEMUSNPBaseConfig), &config); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal kata runtime configuration: %w", err)
 		}
 
-		for _, productLine := range []string{"_Milan", "_Genoa"} {
-			for _, annotationType := range []string{"snp_id_block", "snp_id_auth", "snp_guest_policy"} {
-				customContrastAnnotations = append(customContrastAnnotations, annotationType+productLine)
+		if !platforms.IsInsecure(platform) {
+			for _, productLine := range []string{"_Milan", "_Genoa"} {
+				for _, annotationType := range []string{"snp_id_block", "snp_id_auth", "snp_guest_policy"} {
+					customContrastAnnotations = append(customContrastAnnotations, annotationType+productLine)
+				}
 			}
 		}
 
 		config.Hypervisor["qemu"]["firmware"] = filepath.Join(baseDir, "snp", "share", "OVMF.fd")
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", platform)
+	}
+	// Disable confidential computing features for insecure platforms.
+	if platforms.IsInsecure(platform) {
+		config.Hypervisor["qemu"]["confidential_guest"] = false
+		config.Hypervisor["qemu"]["sev_snp_guest"] = false
 	}
 	if debug {
 		config.Agent["kata"]["enable_debug"] = true

--- a/nodeinstaller/internal/kataconfig/config_test.go
+++ b/nodeinstaller/internal/kataconfig/config_test.go
@@ -34,6 +34,14 @@ func TestKataRuntimeConfig(t *testing.T) {
 			changeSnpFields: false,
 			want:            string(expectedConfMetalQEMUTDXGPU),
 		},
+		platforms.MetalQEMUInsecure: {
+			changeSnpFields: true,
+			want:            string(expectedConfMetalQEMUInsecure),
+		},
+		platforms.MetalQEMUInsecureGPU: {
+			changeSnpFields: true,
+			want:            string(expectedConfMetalQEMUInsecureGPU),
+		},
 	}
 	for platform, tc := range testCases {
 		t.Run(platform.String(), func(t *testing.T) {

--- a/nodeinstaller/internal/kataconfig/runtime_go_test.go
+++ b/nodeinstaller/internal/kataconfig/runtime_go_test.go
@@ -16,4 +16,8 @@ var (
 	expectedConfMetalQEMUSNPGPU []byte
 	//go:embed testdata/runtime-go/expected-configuration-qemu-tdx-gpu.toml
 	expectedConfMetalQEMUTDXGPU []byte
+	//go:embed testdata/runtime-go/expected-configuration-qemu-insecure.toml
+	expectedConfMetalQEMUInsecure []byte
+	//go:embed testdata/runtime-go/expected-configuration-qemu-insecure-gpu.toml
+	expectedConfMetalQEMUInsecureGPU []byte
 )

--- a/nodeinstaller/internal/kataconfig/runtime_rs_test.go
+++ b/nodeinstaller/internal/kataconfig/runtime_rs_test.go
@@ -16,4 +16,8 @@ var (
 	expectedConfMetalQEMUSNPGPU []byte
 	//go:embed testdata/runtime-rs/expected-configuration-qemu-tdx-gpu.toml
 	expectedConfMetalQEMUTDXGPU []byte
+	//go:embed testdata/runtime-rs/expected-configuration-qemu-insecure.toml
+	expectedConfMetalQEMUInsecure []byte
+	//go:embed testdata/runtime-rs/expected-configuration-qemu-insecure-gpu.toml
+	expectedConfMetalQEMUInsecureGPU []byte
 )

--- a/nodeinstaller/internal/kataconfig/testdata/runtime-go/expected-configuration-qemu-insecure-gpu.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/runtime-go/expected-configuration-qemu-insecure-gpu.toml
@@ -1,0 +1,121 @@
+[hypervisor]
+[hypervisor.qemu]
+block_device_aio = 'threads'
+block_device_cache_direct = false
+block_device_cache_noflush = false
+block_device_cache_set = false
+block_device_driver = 'virtio-scsi'
+block_device_logical_sector_size = 0
+block_device_physical_sector_size = 0
+cold_plug_vfio = 'root-port'
+confidential_guest = false
+contrast_imagepuller_config = ''
+cpu_features = 'pmu=off'
+default_bridges = 1
+default_maxmemory = 0
+default_maxvcpus = 0
+default_memory = 1024
+default_vcpus = 1
+disable_block_device_use = true
+disable_guest_selinux = true
+disable_image_nvdimm = true
+disable_nesting_checks = true
+disable_selinux = false
+disable_vhost_net = false
+enable_annotations = ['cc_init_data']
+enable_debug = false
+enable_guest_swap = false
+enable_hugepages = false
+enable_iommu = false
+enable_iommu_platform = false
+enable_iothreads = false
+enable_mem_prealloc = false
+enable_numa = false
+enable_vhost_user_store = false
+enable_virtio_mem = false
+entropy_source = '/dev/urandom'
+file_mem_backend = ''
+firmware = '/snp/share/OVMF.fd'
+firmware_volume = ''
+guest_hook_path = ''
+guest_memory_dump_paging = false
+guest_memory_dump_path = ''
+image = '/share/kata-containers.img'
+indep_iothreads = 0
+initrd = '/share/kata-initrd.zst'
+kernel = '/share/kata-kernel'
+kernel_params = ''
+kernel_verity_params = ''
+machine_accelerators = ''
+machine_type = 'q35'
+memory_offset = 0
+memory_slots = 10
+msize_9p = 8192
+numa_mapping = []
+path = '/bin/qemu-system-x86_64'
+pcie_root_port = 0
+pflashes = []
+reclaim_guest_freed_memory = false
+rootfs_type = 'erofs'
+rootless = false
+rx_rate_limiter_max_rate = 0
+seccompsandbox = ''
+sev_snp_guest = false
+shared_fs = 'none'
+snp_guest_policy = 196608
+snp_id_auth = ''
+snp_id_block = ''
+tx_rate_limiter_max_rate = 0
+use_legacy_serial = false
+valid_entropy_sources = ['/dev/urandom', '/dev/random', '']
+valid_file_mem_backends = ['']
+valid_hypervisor_paths = ['/bin/qemu-system-x86_64']
+valid_vhost_user_store_paths = ['/var/run/kata-containers/vhost-user']
+valid_virtio_fs_daemon_paths = ['/opt/kata/libexec/virtiofsd']
+vhost_user_reconnect_timeout_sec = 0
+vhost_user_store_path = '/var/run/kata-containers/vhost-user'
+virtio_fs_cache = 'auto'
+virtio_fs_cache_size = 0
+virtio_fs_daemon = '/opt/kata/libexec/virtiofsd'
+virtio_fs_extra_args = ['--thread-pool-size=1', '--announce-submounts']
+virtio_fs_queue_size = 1024
+
+[agent]
+[agent.kata]
+debug_console_enabled = false
+dial_timeout = 600
+enable_debug = false
+enable_tracing = false
+kernel_modules = []
+launch_process_timeout = 6
+
+[factory]
+enable_template = false
+template_path = '/run/vc/vm/template'
+vm_cache_endpoint = '/var/run/kata-containers/cache.sock'
+vm_cache_number = 0
+
+[runtime]
+create_container_timeout = 600
+dan_conf = '/run/kata-containers/dans'
+disable_guest_empty_dir = false
+disable_guest_seccomp = true
+disable_new_netns = false
+emptydir_mode = 'shared-fs'
+enable_debug = false
+enable_pprof = false
+enable_tracing = false
+enable_vcpus_pinning = false
+experimental = []
+experimental_force_guest_pull = true
+guest_selinux_label = ''
+internetworking_model = 'tcfilter'
+jaeger_endpoint = ''
+jaeger_password = ''
+jaeger_user = ''
+kubelet_root_dir = '/var/lib/kubelet'
+pod_resource_api_sock = '/var/lib/kubelet/pod-resources/kubelet.sock'
+sandbox_bind_mounts = []
+sandbox_cgroup_only = true
+static_sandbox_resource_mgmt = true
+vfio_mode = 'guest-kernel'

--- a/nodeinstaller/internal/kataconfig/testdata/runtime-go/expected-configuration-qemu-insecure.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/runtime-go/expected-configuration-qemu-insecure.toml
@@ -1,0 +1,120 @@
+[hypervisor]
+[hypervisor.qemu]
+block_device_aio = 'threads'
+block_device_cache_direct = false
+block_device_cache_noflush = false
+block_device_cache_set = false
+block_device_driver = 'virtio-scsi'
+block_device_logical_sector_size = 0
+block_device_physical_sector_size = 0
+confidential_guest = false
+contrast_imagepuller_config = ''
+cpu_features = 'pmu=off'
+default_bridges = 1
+default_maxmemory = 0
+default_maxvcpus = 0
+default_memory = 512
+default_vcpus = 1
+disable_block_device_use = true
+disable_guest_selinux = true
+disable_image_nvdimm = true
+disable_nesting_checks = true
+disable_selinux = false
+disable_vhost_net = false
+enable_annotations = ['cc_init_data']
+enable_debug = false
+enable_guest_swap = false
+enable_hugepages = false
+enable_iommu = false
+enable_iommu_platform = false
+enable_iothreads = false
+enable_mem_prealloc = false
+enable_numa = false
+enable_vhost_user_store = false
+enable_virtio_mem = false
+entropy_source = '/dev/urandom'
+file_mem_backend = ''
+firmware = '/snp/share/OVMF.fd'
+firmware_volume = ''
+guest_hook_path = ''
+guest_memory_dump_paging = false
+guest_memory_dump_path = ''
+image = '/share/kata-containers.img'
+indep_iothreads = 0
+initrd = '/share/kata-initrd.zst'
+kernel = '/share/kata-kernel'
+kernel_params = ''
+kernel_verity_params = ''
+machine_accelerators = ''
+machine_type = 'q35'
+memory_offset = 0
+memory_slots = 10
+msize_9p = 8192
+numa_mapping = []
+path = '/bin/qemu-system-x86_64'
+pcie_root_port = 0
+pflashes = []
+reclaim_guest_freed_memory = false
+rootfs_type = 'erofs'
+rootless = false
+rx_rate_limiter_max_rate = 0
+seccompsandbox = ''
+sev_snp_guest = false
+shared_fs = 'none'
+snp_guest_policy = 196608
+snp_id_auth = ''
+snp_id_block = ''
+tx_rate_limiter_max_rate = 0
+use_legacy_serial = false
+valid_entropy_sources = ['/dev/urandom', '/dev/random', '']
+valid_file_mem_backends = ['']
+valid_hypervisor_paths = ['/bin/qemu-system-x86_64']
+valid_vhost_user_store_paths = ['/var/run/kata-containers/vhost-user']
+valid_virtio_fs_daemon_paths = ['/opt/kata/libexec/virtiofsd']
+vhost_user_reconnect_timeout_sec = 0
+vhost_user_store_path = '/var/run/kata-containers/vhost-user'
+virtio_fs_cache = 'auto'
+virtio_fs_cache_size = 0
+virtio_fs_daemon = '/opt/kata/libexec/virtiofsd'
+virtio_fs_extra_args = ['--thread-pool-size=1', '--announce-submounts']
+virtio_fs_queue_size = 1024
+
+[agent]
+[agent.kata]
+debug_console_enabled = false
+dial_timeout = 120
+enable_debug = false
+enable_tracing = false
+kernel_modules = []
+launch_process_timeout = 6
+
+[factory]
+enable_template = false
+template_path = '/run/vc/vm/template'
+vm_cache_endpoint = '/var/run/kata-containers/cache.sock'
+vm_cache_number = 0
+
+[runtime]
+create_container_timeout = 120
+dan_conf = '/run/kata-containers/dans'
+disable_guest_empty_dir = false
+disable_guest_seccomp = true
+disable_new_netns = false
+emptydir_mode = 'shared-fs'
+enable_debug = false
+enable_pprof = false
+enable_tracing = false
+enable_vcpus_pinning = false
+experimental = []
+experimental_force_guest_pull = true
+guest_selinux_label = ''
+internetworking_model = 'tcfilter'
+jaeger_endpoint = ''
+jaeger_password = ''
+jaeger_user = ''
+kubelet_root_dir = '/var/lib/kubelet'
+pod_resource_api_sock = ''
+sandbox_bind_mounts = []
+sandbox_cgroup_only = true
+static_sandbox_resource_mgmt = true
+vfio_mode = 'guest-kernel'

--- a/nodeinstaller/internal/kataconfig/testdata/runtime-rs/expected-configuration-qemu-insecure-gpu.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/runtime-rs/expected-configuration-qemu-insecure-gpu.toml
@@ -1,0 +1,113 @@
+[hypervisor]
+[hypervisor.qemu]
+block_device_aio = 'threads'
+block_device_cache_direct = false
+block_device_cache_noflush = false
+block_device_cache_set = false
+block_device_driver = 'virtio-scsi'
+block_device_logical_sector_size = 0
+block_device_physical_sector_size = 0
+confidential_guest = false
+contrast_imagepuller_config = ''
+cpu_features = 'pmu=off'
+default_bridges = 1
+default_maxmemory = 0
+default_maxvcpus = 0
+default_memory = 1024
+default_vcpus = 1
+disable_block_device_use = false
+disable_guest_selinux = true
+disable_image_nvdimm = true
+disable_nesting_checks = true
+disable_selinux = false
+disable_vhost_net = false
+enable_annotations = ['cc_init_data']
+enable_debug = false
+enable_guest_swap = false
+enable_hugepages = false
+enable_iommu = false
+enable_iommu_platform = false
+enable_iothreads = false
+enable_mem_prealloc = false
+enable_vhost_user_store = false
+enable_virtio_mem = false
+entropy_source = '/dev/urandom'
+extra_monitor_socket = ''
+file_mem_backend = ''
+firmware = '/snp/share/OVMF.fd'
+guest_hook_path = ''
+guest_memory_dump_paging = false
+guest_memory_dump_path = ''
+image = '/share/kata-containers.img'
+initrd = '/share/kata-initrd.zst'
+kernel = '/share/kata-kernel'
+kernel_params = ''
+kernel_verity_params = ''
+machine_accelerators = ''
+machine_type = 'q35'
+memory_offset = 0
+memory_slots = 10
+network_queues = 1
+path = '/bin/qemu-system-x86_64'
+pcie_root_port = 0
+pflashes = []
+reclaim_guest_freed_memory = false
+rootfs_type = 'erofs'
+rootless = false
+rx_rate_limiter_max_rate = 0
+seccomp_sandbox = ''
+sev_snp_guest = false
+shared_fs = 'none'
+snp_guest_policy = 196608
+snp_id_auth = ''
+snp_id_block = ''
+tx_rate_limiter_max_rate = 0
+valid_entropy_sources = ['/dev/urandom', '/dev/random', '']
+valid_file_mem_backends = ['']
+valid_hypervisor_paths = ['/bin/qemu-system-x86_64']
+valid_vhost_user_store_paths = ['/var/run/kata-containers/vhost-user']
+valid_virtio_fs_daemon_paths = ['/opt/kata/libexec/virtiofsd']
+vhost_user_store_path = '/var/run/kata-containers/vhost-user'
+virtio_fs_cache = 'auto'
+virtio_fs_cache_size = 0
+virtio_fs_daemon = '/opt/kata/libexec/virtiofsd'
+virtio_fs_extra_args = ['--thread-pool-size=1', '-o', 'announce_submounts']
+virtio_fs_queue_size = 1024
+vm_rootfs_driver = 'virtio-blk-pci'
+
+[hypervisor.qemu.factory]
+enable_template = false
+template_path = '/run/vc/vm/template'
+
+[agent]
+[agent.kata]
+create_container_timeout = 120
+debug_console_enabled = false
+dial_timeout_ms = 1000
+enable_debug = false
+enable_tracing = false
+kernel_modules = []
+launch_process_timeout = 6
+reconnect_timeout_ms = 60000
+
+[runtime]
+agent_name = 'kata'
+dan_conf = '/run/kata-containers/dans'
+disable_guest_empty_dir = false
+disable_guest_seccomp = true
+disable_new_netns = false
+enable_debug = false
+enable_pprof = false
+enable_tracing = false
+enable_vcpus_pinning = false
+experimental = ['force_guest_pull']
+hypervisor_name = 'qemu'
+internetworking_model = 'tcfilter'
+jaeger_endpoint = ''
+jaeger_password = ''
+jaeger_user = ''
+name = 'virt_container'
+sandbox_bind_mounts = []
+sandbox_cgroup_only = true
+static_sandbox_resource_mgmt = true
+vfio_mode = 'guest-kernel'

--- a/nodeinstaller/internal/kataconfig/testdata/runtime-rs/expected-configuration-qemu-insecure.toml
+++ b/nodeinstaller/internal/kataconfig/testdata/runtime-rs/expected-configuration-qemu-insecure.toml
@@ -1,0 +1,113 @@
+[hypervisor]
+[hypervisor.qemu]
+block_device_aio = 'threads'
+block_device_cache_direct = false
+block_device_cache_noflush = false
+block_device_cache_set = false
+block_device_driver = 'virtio-scsi'
+block_device_logical_sector_size = 0
+block_device_physical_sector_size = 0
+confidential_guest = false
+contrast_imagepuller_config = ''
+cpu_features = 'pmu=off'
+default_bridges = 1
+default_maxmemory = 0
+default_maxvcpus = 0
+default_memory = 512
+default_vcpus = 1
+disable_block_device_use = false
+disable_guest_selinux = true
+disable_image_nvdimm = true
+disable_nesting_checks = true
+disable_selinux = false
+disable_vhost_net = false
+enable_annotations = ['cc_init_data']
+enable_debug = false
+enable_guest_swap = false
+enable_hugepages = false
+enable_iommu = false
+enable_iommu_platform = false
+enable_iothreads = false
+enable_mem_prealloc = false
+enable_vhost_user_store = false
+enable_virtio_mem = false
+entropy_source = '/dev/urandom'
+extra_monitor_socket = ''
+file_mem_backend = ''
+firmware = '/snp/share/OVMF.fd'
+guest_hook_path = ''
+guest_memory_dump_paging = false
+guest_memory_dump_path = ''
+image = '/share/kata-containers.img'
+initrd = '/share/kata-initrd.zst'
+kernel = '/share/kata-kernel'
+kernel_params = ''
+kernel_verity_params = ''
+machine_accelerators = ''
+machine_type = 'q35'
+memory_offset = 0
+memory_slots = 10
+network_queues = 1
+path = '/bin/qemu-system-x86_64'
+pcie_root_port = 0
+pflashes = []
+reclaim_guest_freed_memory = false
+rootfs_type = 'erofs'
+rootless = false
+rx_rate_limiter_max_rate = 0
+seccomp_sandbox = ''
+sev_snp_guest = false
+shared_fs = 'none'
+snp_guest_policy = 196608
+snp_id_auth = ''
+snp_id_block = ''
+tx_rate_limiter_max_rate = 0
+valid_entropy_sources = ['/dev/urandom', '/dev/random', '']
+valid_file_mem_backends = ['']
+valid_hypervisor_paths = ['/bin/qemu-system-x86_64']
+valid_vhost_user_store_paths = ['/var/run/kata-containers/vhost-user']
+valid_virtio_fs_daemon_paths = ['/opt/kata/libexec/virtiofsd']
+vhost_user_store_path = '/var/run/kata-containers/vhost-user'
+virtio_fs_cache = 'auto'
+virtio_fs_cache_size = 0
+virtio_fs_daemon = '/opt/kata/libexec/virtiofsd'
+virtio_fs_extra_args = ['--thread-pool-size=1', '-o', 'announce_submounts']
+virtio_fs_queue_size = 1024
+vm_rootfs_driver = 'virtio-blk-pci'
+
+[hypervisor.qemu.factory]
+enable_template = false
+template_path = '/run/vc/vm/template'
+
+[agent]
+[agent.kata]
+create_container_timeout = 120
+debug_console_enabled = false
+dial_timeout_ms = 1000
+enable_debug = false
+enable_tracing = false
+kernel_modules = []
+launch_process_timeout = 6
+reconnect_timeout_ms = 60000
+
+[runtime]
+agent_name = 'kata'
+dan_conf = '/run/kata-containers/dans'
+disable_guest_empty_dir = false
+disable_guest_seccomp = true
+disable_new_netns = false
+enable_debug = false
+enable_pprof = false
+enable_tracing = false
+enable_vcpus_pinning = false
+experimental = ['force_guest_pull']
+hypervisor_name = 'qemu'
+internetworking_model = 'tcfilter'
+jaeger_endpoint = ''
+jaeger_password = ''
+jaeger_user = ''
+name = 'virt_container'
+sandbox_bind_mounts = []
+sandbox_cgroup_only = true
+static_sandbox_resource_mgmt = true
+vfio_mode = 'guest-kernel'

--- a/nodeinstaller/internal/kataconfig/update-testdata/main.go
+++ b/nodeinstaller/internal/kataconfig/update-testdata/main.go
@@ -46,6 +46,20 @@ func main() {
 			config:   "qemu-tdx",
 			testdata: "qemu-tdx-gpu",
 		},
+		// We intentionally take the CC upstream configs for the
+		// insecure platforms and then drop the CC-specific parameters
+		// ourselves in the `kataconfig` package to keep the CC and
+		// non-CC configurations as close as possible.
+		platforms.MetalQEMUInsecure: {
+			upstream: "qemu-snp",
+			config:   "qemu-snp",
+			testdata: "qemu-insecure",
+		},
+		platforms.MetalQEMUInsecureGPU: {
+			upstream: "qemu-snp",
+			config:   "qemu-snp",
+			testdata: "qemu-insecure-gpu",
+		},
 	}
 
 	for platform, platformConfig := range platforms {

--- a/nodeinstaller/internal/targetconfig/targetconfig.go
+++ b/nodeinstaller/internal/targetconfig/targetconfig.go
@@ -35,10 +35,10 @@ func NewTargetConfig(hostMount, runtimeBase string, pl platforms.Platform) (*Tar
 		hostMount:            hostMount,
 		fs:                   &afero.Afero{Fs: afero.NewOsFs()},
 	}
-	switch {
-	case platforms.IsQEMU(pl) && platforms.IsSNP(pl):
+	switch pl {
+	case platforms.MetalQEMUSNP, platforms.MetalQEMUSNPGPU, platforms.MetalQEMUInsecure, platforms.MetalQEMUInsecureGPU:
 		conf.kataConfigPath = filepath.Join(runtimeBase, "etc", "configuration-qemu-snp.toml")
-	case platforms.IsQEMU(pl) && platforms.IsTDX(pl):
+	case platforms.MetalQEMUTDX, platforms.MetalQEMUTDXGPU:
 		conf.kataConfigPath = filepath.Join(runtimeBase, "etc", "configuration-qemu-tdx.toml")
 	default:
 		return nil, fmt.Errorf("unsupported platform %q", pl)

--- a/nodeinstaller/internal/targetconfig/targetconfig_test.go
+++ b/nodeinstaller/internal/targetconfig/targetconfig_test.go
@@ -44,6 +44,18 @@ func TestNewTargetConfig(t *testing.T) {
 				hostMount:            "/host",
 			},
 		},
+		"valid config for metal qemu insecure": {
+			hostMount:   "/host",
+			runtimeBase: "/opt/edgeless/qemu",
+			platform:    platforms.MetalQEMUInsecure,
+			wantErr:     false,
+			wantConfig: &TargetConfig{
+				containerdConfigPath: "etc/containerd/config.toml",
+				systemdUnitNames:     []string{"containerd.service"},
+				kataConfigPath:       "/opt/edgeless/qemu/etc/configuration-qemu-snp.toml",
+				hostMount:            "/host",
+			},
+		},
 		"invalid platform": {
 			hostMount:   "/host",
 			runtimeBase: "/opt/edgeless/unknown",

--- a/packages/by-name/contrast/reference-values/package.nix
+++ b/packages/by-name/contrast/reference-values/package.nix
@@ -10,13 +10,14 @@
 
 let
   runtimeHandler =
-    platform: hashFile:
-    "contrast-cc-${platform}-${builtins.substring 0 8 (builtins.readFile hashFile)}";
+    platform: hashFile: "contrast-${platform}-${builtins.substring 0 8 (builtins.readFile hashFile)}";
 
-  metal-qemu-tdx-handler = runtimeHandler "metal-qemu-tdx" node-installer-image.runtimeHash;
-  metal-qemu-snp-handler = runtimeHandler "metal-qemu-snp" node-installer-image.runtimeHash;
-  metal-qemu-snp-gpu-handler = runtimeHandler "metal-qemu-snp-gpu" node-installer-image.runtimeHash;
-  metal-qemu-tdx-gpu-handler = runtimeHandler "metal-qemu-tdx-gpu" node-installer-image.runtimeHash;
+  cc-metal-qemu-tdx-handler = runtimeHandler "cc-metal-qemu-tdx" node-installer-image.runtimeHash;
+  cc-metal-qemu-snp-handler = runtimeHandler "cc-metal-qemu-snp" node-installer-image.runtimeHash;
+  cc-metal-qemu-snp-gpu-handler = runtimeHandler "cc-metal-qemu-snp-gpu" node-installer-image.runtimeHash;
+  cc-metal-qemu-tdx-gpu-handler = runtimeHandler "cc-metal-qemu-tdx-gpu" node-installer-image.runtimeHash;
+  insecure-metal-qemu-handler = runtimeHandler "insecure-metal-qemu" node-installer-image.runtimeHash;
+  insecure-metal-qemu-gpu-handler = runtimeHandler "insecure-metal-qemu-gpu" node-installer-image.runtimeHash;
 
   snpRefValsWith = os-image: {
     snp =
@@ -98,13 +99,18 @@ let
     };
     withGPU = true;
   };
+  insecureRefVals = {
+    snp = [ { } ];
+  };
 in
 
 builtins.toFile "reference-values.json" (
   builtins.toJSON {
-    "${metal-qemu-tdx-handler}" = tdxRefVals;
-    "${metal-qemu-snp-handler}" = snpRefVals;
-    "${metal-qemu-snp-gpu-handler}" = snpGpuRefVals;
-    "${metal-qemu-tdx-gpu-handler}" = tdxGpuRefVals;
+    "${cc-metal-qemu-tdx-handler}" = tdxRefVals;
+    "${cc-metal-qemu-snp-handler}" = snpRefVals;
+    "${cc-metal-qemu-snp-gpu-handler}" = snpGpuRefVals;
+    "${cc-metal-qemu-tdx-gpu-handler}" = tdxGpuRefVals;
+    "${insecure-metal-qemu-handler}" = insecureRefVals;
+    "${insecure-metal-qemu-gpu-handler}" = insecureRefVals;
   }
 )


### PR DESCRIPTION
Reopened after reordering the stack: this PR now comes before initdata-processor.