### PR TITLE
e2e: collect logs synchronously to fix namespace teardown race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,10 +439,6 @@ jobs:
             --platform "${{ matrix.platform.name }}" \
             --node-installer-target-conf "${{ matrix.platform.node-installer-target-conf }}" \
             --namespace-file workspace/just.namespace
-      - name: Download logs
-        if: always()
-        run: |
-          nix run ".#${SET}.scripts.get-logs" download workspace/just.namespace
       - name: Cleanup
         if: always()
         run: |

--- a/e2e/internal/logcollect/logcollect.go
+++ b/e2e/internal/logcollect/logcollect.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package logcollect provides a thin Go wrapper around the get-logs script
+// for e2e tests that want to collect cluster + host logs synchronously,
+// before any test cleanup tears down the namespaces being collected from.
+package logcollect
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Download invokes `get-logs download` against namespaceFile, blocking until
+// log collection completes or ctx is canceled.
+//
+// If sinceFloor is non-zero, it is passed to get-logs as a lower bound for
+// the host-log --since timestamp via the LOG_COLLECT_SINCE_FLOOR env var.
+func Download(ctx context.Context, namespaceFile string, sinceFloor time.Time) error {
+	cmd := exec.CommandContext(ctx, "get-logs", "download", namespaceFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if !sinceFloor.IsZero() {
+		cmd.Env = append(os.Environ(), "LOG_COLLECT_SINCE_FLOOR="+sinceFloor.UTC().Format(time.RFC3339))
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running get-logs download %s: %w", namespaceFile, err)
+	}
+	return nil
+}

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
+	"github.com/edgelesssys/contrast/e2e/internal/logcollect"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
@@ -51,6 +52,7 @@ var (
 // TestRelease downloads a release from Github, sets up the coordinator, installs the demo
 // deployment and runs some simple smoke tests.
 func TestRelease(t *testing.T) {
+	testStart := time.Now()
 	ctx := t.Context()
 	k := kubeclient.NewForTest(t)
 
@@ -100,6 +102,18 @@ func TestRelease(t *testing.T) {
 
 	// Write namespaces to trigger log collection.
 	require.NoError(t, os.WriteFile(*namespaceFile, []byte("contrast-system\ndefault\n"), 0o644))
+
+	// Download logs synchronously before the resource-deletion cleanup above
+	// runs (t.Cleanup runs LIFO; this is registered second, so runs first).
+	// Otherwise the namespace teardown races against log collection.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		if err := logcollect.Download(ctx, *namespaceFile, testStart); err != nil {
+			t.Logf("log collection failed: %v", err)
+		}
+	})
 
 	require.True(t, t.Run("apply-runtime", func(t *testing.T) {
 		require := require.New(t)

--- a/justfile
+++ b/justfile
@@ -194,7 +194,6 @@ e2e-release version platform=default_platform set=default_set: soft-clean
             --node-installer-target-conf ${node_installer_target_conf_type} \
             --namespace-file ./{{ workspace_dir }}/just.namespace \
             --use-loadbalancer=true
-    nix run .#{{ set }}.scripts.get-logs download ./{{ workspace_dir }}/just.namespace
 
 # Generate policies, apply Kubernetes manifests.
 deploy target=default_deploy_target cli=default_cli platform=default_platform: (populate target platform) (runtime target platform) (write-namespace target) (apply "runtime" platform) (generate cli platform) (apply target platform)

--- a/justfile
+++ b/justfile
@@ -549,8 +549,13 @@ CONTRAST_LOG_LEVEL=""
 # A Github token with read access to the Contrast ghcr.io packages.
 # Should be set by running just get-ghcr-read-token.
 contrast_ghcr_read=""
-# A Github token with contents:write permissions for accessing draft releases.
-# Set this manually if you want to use the e2e-release target on a draft release.
+# A GitHub token with `Contents: Read and write` on edgelesssys/contrast.
+# Create a fine-grained PAT scoped to the repo.
+#
+# Used by:
+#   - e2e-release: write permission is needed to see DRAFT releases
+#   - just fmt / treefmt: zizmor calls the GitHub API; errors out
+#     without a token.
 GH_TOKEN=""
 '''
 

--- a/justfile
+++ b/justfile
@@ -181,7 +181,7 @@ e2e-ci target platforms="all" post="false" set="testcase-default" debug_shell="f
         echo "Posted comment to PR #$pr_number"
     fi
 
-e2e-release version platform=default_platform set=default_set: soft-clean
+e2e-release version platform=default_platform set=default_set: soft-clean k8s-log-collector
     #!/usr/bin/env bash
     set -euo pipefail
     nix build .#{{ set }}.scripts.get-logs

--- a/packages/by-name/contrast/e2e/package.nix
+++ b/packages/by-name/contrast/e2e/package.nix
@@ -8,6 +8,7 @@
   cli,
   makeWrapper,
   openssl,
+  scripts,
 }:
 
 buildGoModule {
@@ -94,6 +95,7 @@ buildGoModule {
 
   postInstall = ''
     wrapProgram "$out/bin/coordinator.test" --prefix PATH : "${openssl}/bin"
+    wrapProgram "$out/bin/release.test" --prefix PATH : "${scripts.get-logs}/bin"
   '';
 
   # Skip fixup as binaries are already stripped and we don't

--- a/packages/by-name/scripts/get-logs/get-logs.sh
+++ b/packages/by-name/scripts/get-logs/get-logs.sh
@@ -82,8 +82,15 @@ download)
   fi
   mkdir -p "./workspace/logs"
   log_pods_missing=false
+  # Optional floor for host-log --since. Set by callers (e.g. e2e tests) to
+  # the test start time so we don't pull months of journals for pre-existing
+  # namespaces like `default`. Expected RFC3339 (e.g. 2026-05-06T11:33:25Z).
+  since_floor="${LOG_COLLECT_SINCE_FLOOR:-}"
   while read -r namespace; do
     start_time=$(kubectl get ns "$namespace" -o jsonpath='{.metadata.creationTimestamp}')
+    if [[ -n $since_floor && $start_time < $since_floor ]]; then
+      start_time="$since_floor"
+    fi
 
     pods="$(kubectl get pods -o name -n "$namespace" | grep log-collector | cut -c 5- || true)"
     if [[ -z $pods ]]; then


### PR DESCRIPTION
This was prompted by the failure in https://github.com/edgelesssys/contrast/actions/runs/25005789022/job/73530829709 which was mitigated by https://github.com/edgelesssys/contrast/pull/2363 but the root cause is actually a race condition that this PR fixes.

The release test (`TestRelease` in `e2e/release/release_test.go`) deletes the `contrast-system` namespace in a `t.Cleanup` callback at test exit. Previously, the workflow's separate `Download logs` step ran *after* the test process exited, racing the cluster's namespace teardown.

When the deployed log-collector image was newer than the SHA pinned in `packages/log-collector.yaml`, the `kubectl exec collect-host-logs` retry loop ate ~25 seconds of the 30-second teardown grace period. The subsequent `kubectl exec ... tar` step then hit "task not found" because the log-collector pod and its container were already gone, and the workflow failed despite the test itself passing.

# Fix

Move log download inside the test process and remove the extra "Download logs" action step.

I've also fixed 2 adjacent issues and another drive-by fix:

- The `default` namespace's `creationTimestamp` in the testing cluster is months old, which made `journalctl --since` pull a year of host logs. The new `LOG_COLLECT_SINCE_FLOOR` env var allows configuring that.
- also the `e2e-release` target had the same issue like the original mitigation PR, it needs to push a fresh `k8s-log-collector` image. I plan to push a follow-up PR that will refactor k8s-log-collector a bit so this is not needed.
- clarified the comment for the `GH_TOKEN` use

# Test

- [x] Tested with `just e2e-release v1.20.0` in the dev cluster.
- [ ] CI release workflow