### PR TITLE
just: don't attempt to kill log-collector twice

### DIFF
--- a/justfile
+++ b/justfile
@@ -113,9 +113,8 @@ _e2e target=default_deploy_target platform=default_platform set=default_set: sof
         just containerd-reproducer
     fi
     get_logs=$(nix build .#{{ set }}.scripts.get-logs --no-link --print-out-paths)
+    # get-logs start waits until the namespace file is created, then spawns self-cleaning background tasks and exits.
     "$get_logs/bin/get-logs" start ./{{ workspace_dir }}/just.namespace &
-    get_logs_pid=$!
-    trap 'kill $get_logs_pid || true' EXIT
     nix shell .#{{ set }}.contrast.e2e --command {{ target }}.test -test.v \
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
             --genpolicy-cache-path ./{{ workspace_dir }}/layers-cache.json \


### PR DESCRIPTION
The `get-logs start` command itself spawns background processes and exits early. 

> You can not kill that which is already dead.