### PR TITLE
justfile: clean up background-process shutdown

### DIFF
--- a/justfile
+++ b/justfile
@@ -113,9 +113,8 @@ _e2e target=default_deploy_target platform=default_platform set=default_set: sof
         just containerd-reproducer
     fi
     get_logs=$(nix build .#{{ set }}.scripts.get-logs --no-link --print-out-paths)
+    # get-logs start waits until the namespace file is created, then spawns self-cleaning background tasks and exits.
     "$get_logs/bin/get-logs" start ./{{ workspace_dir }}/just.namespace &
-    get_logs_pid=$!
-    trap 'kill $get_logs_pid || true' EXIT
     nix shell .#{{ set }}.contrast.e2e --command {{ target }}.test -test.v \
             --image-replacements ./{{ workspace_dir }}/just.containerlookup \
             --genpolicy-cache-path ./{{ workspace_dir }}/layers-cache.json \
@@ -186,6 +185,7 @@ e2e-release version platform=default_platform set=default_set: soft-clean k8s-lo
     set -euo pipefail
     nix build .#{{ set }}.scripts.get-logs
     mkdir -p ./{{ workspace_dir }}
+    # get-logs start waits until the namespace file is created, then spawns self-cleaning background tasks and exits.
     nix run .#{{ set }}.scripts.get-logs start ./{{ workspace_dir }}/just.namespace &
     trap "kubectl delete -f ./{{ workspace_dir }}/log-collector.yaml; rm -f ./{{ workspace_dir }}/just.namespace" EXIT
     nix shell .#{{ set }}.contrast.e2e --command release.test -test.v \

--- a/justfile
+++ b/justfile
@@ -354,7 +354,7 @@ set cli=default_cli set=default_set:
     nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns port-forwarder-coordinator
     kubectl -n $ns port-forward pod/port-forwarder-coordinator 1313 &
     PID=$!
-    trap "kill $PID" EXIT
+    trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null || true' EXIT
     nix run -L .#{{ set }}.scripts.wait-for-port-listen -- 1313
     nix run -L .#{{ set }}.{{ cli }} -- set \
         --workspace-dir ./{{ workspace_dir }} \
@@ -370,7 +370,7 @@ verify cli=default_cli set=default_set:
     nix run -L .#{{ set }}.scripts.kubectl-wait-coordinator -- $ns
     kubectl -n $ns port-forward pod/port-forwarder-coordinator 1314:1313 &
     PID=$!
-    trap "kill $PID" EXIT
+    trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null || true' EXIT
     nix run -L .#{{ set }}.scripts.wait-for-port-listen -- 1314
     nix run -L .#{{ set }}.{{ cli }} -- verify \
         --workspace-dir ./{{ workspace_dir }} \
@@ -385,7 +385,7 @@ recover cli=default_cli set=default_set:
     nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns port-forwarder-coordinator
     kubectl -n $ns port-forward pod/port-forwarder-coordinator 1313 &
     PID=$!
-    trap "kill $PID" EXIT
+    trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null || true' EXIT
     nix run -L .#{{ set }}.scripts.wait-for-port-listen -- 1313
     nix run -L .#{{ set }}.{{ cli }} -- recover \
         --workspace-dir ./{{ workspace_dir }} \


### PR DESCRIPTION
Use `kill PID 2>/dev/null; wait PID 2>/dev/null` consistently for the EXIT trap of every backgrounded helper (`get-logs start` and the various `kubectl port-forward` invocations). The `wait` collects the bg process before bash exits, so its dying-breath stderr (e.g. "Terminated: 15") and the shell's own job-control notice no longer leak to the user's prompt after the recipe returns.

Also capture the PID of `get-logs start` in `e2e-release` (which was previously fire-and-forget) so the trap can clean it up the same way.