### PR TITLE
kata.genpolicy: drop unused libiconv load command on darwin

### DIFF
--- a/overlays/runtimepkgs.nix
+++ b/overlays/runtimepkgs.nix
@@ -13,7 +13,43 @@ else
         contrastPkgsStatic = final.runtimePkgs.contrastPkgsStatic.overrideScope (
           _: _: {
             kata = final.runtimePkgs.contrastPkgsStatic.kata.overrideScope (
-              _: _: { inherit (cPrev.kata) genpolicy; }
+              _: _: {
+                # On darwin, strip dylib load commands the linker leaves
+                # behind but no symbol references, and assert the binary
+                # has no /nix/store dylib paths in its load commands.
+                # The instance prompting this is libc 0.2.x's
+                # `#[link(name = "iconv")]` on the apple FFI bindings:
+                # rustc emits `-liconv` for every Rust binary that links
+                # libc, which the macOS linker resolves to a build-host
+                # nix-store path inside LC_LOAD_DYLIB. See
+                # https://github.com/rust-lang/libc/issues/2870.
+                #
+                # TODO(sespiros): drop once kata's Cargo.lock pins a libc
+                # that no longer emits the directive (libc 1.0 milestone).
+                genpolicy = cPrev.kata.genpolicy.overrideAttrs (oldAttrs: {
+                  env =
+                    (oldAttrs.env or { })
+                    // prev.lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+                      RUSTFLAGS = "-C link-arg=-Wl,-dead_strip_dylibs";
+                    };
+
+                  # Regression guard: assert the darwin binary has no
+                  # /nix/store dylib load commands. `otool -L`'s first line
+                  # is the binary's own path (itself under /nix/store), so
+                  # skip it. Catches anything new dyld-linked from nixpkgs,
+                  # not just iconv.
+                  postInstall =
+                    (oldAttrs.postInstall or "")
+                    + prev.lib.optionalString prev.stdenv.hostPlatform.isDarwin ''
+                      nixstore_deps=$(otool -L "$out/bin/genpolicy" | tail -n +2 | grep '/nix/store' || true)
+                      if [[ -n "$nixstore_deps" ]]; then
+                        echo "error: genpolicy has /nix/store paths in its dyld load commands:" >&2
+                        echo "$nixstore_deps" >&2
+                        exit 1
+                      fi
+                    '';
+                });
+              }
             );
           }
         );

--- a/packages/by-name/kata/genpolicy/package.nix
+++ b/packages/by-name/kata/genpolicy/package.nix
@@ -8,7 +8,6 @@
   openssl,
   pkg-config,
   protobuf,
-  libiconv,
   zlib,
   cmake,
   stdenv,
@@ -50,7 +49,6 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     openssl
     openssl.dev
-    libiconv
     zlib
   ];
 


### PR DESCRIPTION
genpolicy's Cargo.lock (via kata) pins libc 0.2.183, which still emits `#[link(name = "iconv")]` on apple targets even though genpolicy never calls iconv. rustc therefore adds `-liconv` to the darwin link command, and under nix the macOS linker resolves it against the nix-store libiconv, baking a closure-specific path into LC_LOAD_DYLIB. The released CLI's embedded genpolicy then only loads on machines whose nix store contains that exact path, which is why it dyld-aborts on github-hosted macos-latest runners.

Pass `-Wl,-dead_strip_dylibs` so the linker drops dylib load commands with no referenced symbols. genpolicy uses no iconv symbols (`nm` confirms), so the libiconv command is removed cleanly and the binary becomes closure-portable.

The flag can be removed once kata's Cargo.lock points at a libc that no longer emits the iconv `#[link]` attribute. The attribute is already gone on libc `main` and is part of the 1.0 milestone (https://github.com/rust-lang/libc/issues/3248, background in issue #2870), so this should become unnecessary when kata moves to libc 1.0.

Also drop libiconv from buildInputs. It was added at package init (95135913ab, Nov 2023) without rationale, nothing here calls iconv, and the build still succeeds (transitive inputs satisfy the linker's `-liconv` request). Independent cleanup, not part of the portability fix.

Verified on aarch64-darwin:
  $ otool -L result/bin/genpolicy
    /usr/lib/libobjc.A.dylib
    /System/Library/Frameworks/IOKit.framework/...
    /System/Library/Frameworks/CoreFoundation.framework/...
    /System/Library/Frameworks/Security.framework/...
    /usr/lib/libSystem.B.dylib

No /nix/store references; only shared-cache-resident libraries.