### PR TITLE
ci: repoint cachix-action v17 pin to current tag head

### DIFF
--- a/.github/actions/setup_nix/action.yml
+++ b/.github/actions/setup_nix/action.yml
@@ -36,7 +36,7 @@ runs:
       with:
         github_access_token: ${{ inputs.githubToken }}
         extra_nix_config: ${{ runner.os == 'Linux' && 'build-dir = /nix/bld' || '' }}
-    - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+    - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
       with:
         name: edgelesssys
         authToken: ${{ inputs.cachixToken }}


### PR DESCRIPTION
cachix-action rewrote its v17 tag on 2026-05-09 (release record published_at 2026-03-18 vs created_at 2026-05-09; intervening commits include "update tags" and "use regular tags"), so the previously pinned SHA 1eb2ef64 no longer matches v17 (now 5f2d7c52). zizmor's ref-version-mismatch audit catches this in `nix fmt`.

```bash
# Rewrite indicator
$ gh api repos/cachix/cachix-action/releases/tags/v17 --jq '{published_at, created_at, target_commitish}'

{
  "created_at": "2026-05-09T00:29:17Z",
  "published_at": "2026-03-18T19:01:53Z",
  "target_commitish": "master"
}

# Current SHA of the v17 tag (value zizmor compares against)
$ git ls-remote --tags https://github.com/cachix/cachix-action refs/tags/v17^{}

5f2d7c5294214f71b873db4b969586b980625e71	refs/tags/v17^{}

# Commits between the old pin (1eb2ef64) and the new tag head (5f2d7c52), showing the maintainer's tag-rewriting commits
$ gh api repos/cachix/cachix-action/compare/1eb2ef646ac0255473d23a5907ad7b04ce94065c...5f2d7c5294214f71b873db4b969586b980625e71 \
    --jq '.commits[] | "\(.sha[0:12]) \(.commit.message | split("\n")[0])"'

80a630b9fcc1 update tags
5941c261999f use regular tags
6505427c13f0 Merge pull request #213 from jleroux98/update-readme
8d6d4b9006df docs: add release and contributing docs
a593539ec5b1 ci: add a workflow to auto-bump version in README
9f82c7e3322d fix: ensure that the post-build hook never fails
4ee54539d706 rebuilt dist
5f2d7c529421 fix: await main functions
```