### PR TITLE
e2e: dont remove labeled resource during release e2e test

### DIFF
--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -97,6 +97,10 @@ func TestRelease(t *testing.T) {
 
 		// Delete resources 1-by-1 so that we don't stop on errors.
 		for _, resource := range resources {
+			if resource.GetLabels()["ci.contrast.edgeless.systems/keep"] == "true" {
+				continue
+			}
+
 			if err := k.Delete(ctx, resource); err != nil {
 				t.Logf("deleting resource %s: %v", resource.GetName(), err)
 			}


### PR DESCRIPTION
The release e2e test kept removing RuntimeClasses that were still in use by other deployments.
Update the test to respect the `ci.contrast.edgeless.systems/keep` label