### PR TITLE
.github: do not attempt to delete nonexistent tag

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -62,7 +62,7 @@ jobs:
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}$' \
             | while IFS= read -r tag; do
                 echo "Deleting nightly draft release: ${tag}"
-                gh release delete "${tag}" --repo "${GH_REPO}" --yes --cleanup-tag
+                gh release delete "${tag}" --repo "${GH_REPO}" --yes
               done
 
   release-x86_64-linux:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -60,9 +60,9 @@ jobs:
           gh release list --repo "${GH_REPO}" --limit 10 --json tagName,isDraft \
             | jq -r '.[] | select(.isDraft == true) | .tagName' \
             | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}$' \
-            | while IFS= read -r tag; do
-                echo "Deleting nightly draft release: ${tag}"
-                gh release delete "${tag}" --repo "${GH_REPO}" --yes
+            | while IFS= read -r nightly_version; do
+                echo "Deleting nightly draft release: ${nightly_version}"
+                gh release delete "${nightly_version}" --repo "${GH_REPO}" --yes
               done
 
   release-x86_64-linux:

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -148,7 +148,7 @@ jobs:
           NIGHTLY_TAG: ${{ needs.prepare.outputs.nightly_tag }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release delete "${NIGHTLY_TAG}" --repo "${GH_REPO}" --yes --cleanup-tag
+          gh release delete "${NIGHTLY_TAG}" --repo "${GH_REPO}" --yes
 
   prepare-github-release:
     name: Create backport label and milestone

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -37,7 +37,7 @@ jobs:
       NEXT_MINOR_PRE_WITHOUT_V: ${{ steps.version-info.outputs.next_minor_pre_without_v }}
       PREVIOUS_MINOR_TAG: ${{ steps.version-info.outputs.previous_minor_tag }}
       nightly_ref: ${{ steps.nightly-info.outputs.nightly_ref }}
-      nightly_tag: ${{ steps.nightly-info.outputs.nightly_tag }}
+      nightly_version: ${{ steps.nightly-info.outputs.nightly_version }}
       nightly_run_id: ${{ steps.nightly-info.outputs.nightly_run_id }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,10 +62,10 @@ jobs:
           fi
           nightly_ref=$(gh run view "${nightly_run_id}" --repo "${GH_REPO}" --json headSha --jq '.headSha')
           nightly_date=$(gh run view "${nightly_run_id}" --repo "${GH_REPO}" --json createdAt --jq '.createdAt | .[0:10]')
-          nightly_tag="${FULL_VERSION}-${nightly_date}"
+          nightly_version="${FULL_VERSION}-${nightly_date}"
           echo "nightly_run_id=${nightly_run_id}" | tee -a "$GITHUB_OUTPUT"
           echo "nightly_ref=${nightly_ref}" | tee -a "$GITHUB_OUTPUT"
-          echo "nightly_tag=${nightly_tag}" | tee -a "$GITHUB_OUTPUT"
+          echo "nightly_version=${nightly_version}" | tee -a "$GITHUB_OUTPUT"
       - name: Verify nightly tests passed
         env:
           NIGHTLY_RUN_ID: ${{ steps.nightly-info.outputs.nightly_run_id }}
@@ -80,15 +80,15 @@ jobs:
           fi
       - name: Verify nightly draft release has artifacts
         env:
-          NIGHTLY_TAG: ${{ steps.nightly-info.outputs.nightly_tag }}
+          NIGHTLY_VERSION: ${{ steps.nightly-info.outputs.nightly_version }}
           GH_REPO: ${{ github.repository }}
         run: |
-          asset_count=$(gh release view "${NIGHTLY_TAG}" --repo "${GH_REPO}" --json assets --jq '.assets | length' 2>/dev/null || echo "0")
+          asset_count=$(gh release view "${NIGHTLY_VERSION}" --repo "${GH_REPO}" --json assets --jq '.assets | length' 2>/dev/null || echo "0")
           if [[ "${asset_count}" -eq 0 ]]; then
-            echo "::error::No assets found on nightly draft release ${NIGHTLY_TAG}. Expected artifacts from the build."
+            echo "::error::No assets found on nightly draft release ${NIGHTLY_VERSION}. Expected artifacts from the build."
             exit 1
           fi
-          echo "Found ${asset_count} assets on ${NIGHTLY_TAG}."
+          echo "Found ${asset_count} assets on ${NIGHTLY_VERSION}."
       - name: Don't overwrite published releases
         run: |
           is_draft=$(gh release view "${FULL_VERSION}" --json isDraft -q .isDraft 2>/dev/null || true)
@@ -145,10 +145,10 @@ jobs:
             ./darwin-artifacts/contrast-aarch64-darwin
       - name: Delete nightly draft release
         env:
-          NIGHTLY_TAG: ${{ needs.prepare.outputs.nightly_tag }}
+          NIGHTLY_VERSION: ${{ needs.prepare.outputs.nightly_version }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release delete "${NIGHTLY_TAG}" --repo "${GH_REPO}" --yes
+          gh release delete "${NIGHTLY_VERSION}" --repo "${GH_REPO}" --yes
 
   prepare-github-release:
     name: Create backport label and milestone


### PR DESCRIPTION
https://github.com/edgelesssys/contrast/actions/runs/25761363482/job/75663107538

The tag deletion was a mistake, we only create tags after/during release promotion, so the deletion fails.

(The actual draft deletion worked like a charm, the error comes from then trying to clean up the tag.)