### PR TITLE
kata: use modern syntax for error message policy

### DIFF
--- a/packages/by-name/initdata-processor/package.nix
+++ b/packages/by-name/initdata-processor/package.nix
@@ -15,15 +15,15 @@ let
   deny-with-message = runCommand "deny-with-message" { } ''
     awk '
       # header
-      BEGIN { print "package agent_policy\n" }
+      BEGIN { print "package agent_policy\nimport future.keywords.if\n" }
 
       # default deny rule for the request
       /^message.*Request/ { print "default",$2,":= false" }
       # denying rule that calls print_message
-      /^message.*Request/ { print $2,"{ print_message }" }
+      /^message.*Request/ { print $2,"if { print_message }" }
 
       # implementation of print_message (`message := "foo"` needs to be appended by the user)
-      END { print "\nprint_message {\n  print(\"Internal error:\", message)\n  false\n}" }
+      END { print "\nprint_message if {\n  print(\"Internal error:\", message)\n  false\n}" }
       ' \
       ${kata.runtime.src}/src/libs/protocols/protos/agent.proto >$out
   '';

--- a/packages/by-name/kata/runtime/0026-agent-don-t-abort-in-case-of-policy-problems.patch
+++ b/packages/by-name/kata/runtime/0026-agent-don-t-abort-in-case-of-policy-problems.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Tue, 12 May 2026 17:39:12 +0200
+Subject: [PATCH] agent: don't abort in case of policy problems
+
+Calling abort() is a rather drastic measure, as it immediately
+terminates the process without cleaning up, and causes systemd to invoke
+an unnecessary core dump handler instead of terminating directly. The
+abrupt termination also leads to missing logs, which are crucial for
+debugging the situation causing the abort.
+
+This commit changes the failure handling to first wait, in order to give
+the logger time to flush, and then to panic, which does call all the
+finalizers.
+
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/agent/src/main.rs | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/agent/src/main.rs b/src/agent/src/main.rs
+index aee7984212d1040632e896f6fb5fc8272a70f9d2..51acf09e234960b79583eea62b4c4cb90738d972 100644
+--- a/src/agent/src/main.rs
++++ b/src/agent/src/main.rs
+@@ -383,7 +383,8 @@ async fn start_sandbox(
+     if let Err(e) = initialize_policy().await {
+         error!(logger, "Failed to initialize agent policy: {:?}", e);
+         // Continuing execution without a security policy could be dangerous.
+-        std::process::abort();
++        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
++        panic!("Failed to initialize agent policy: {:?}", e)
+     }
+ 
+     let sandbox = Arc::new(Mutex::new(s));

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -165,6 +165,11 @@ buildGoModule (finalAttrs: {
       # The provided config should only be used as an override and not as a replacement, so the kernel cmdline is still respected
       # when we don't have any overrides.
       ./0025-agent-use-config-file-as-override.patch
+
+      # Terminate the agent gracefully when it encounters problems with the policy. This allows
+      # error messages to propagate to the runtime.
+      # Upstream issue: https://github.com/kata-containers/kata-containers/issues/13031.
+      ./0026-agent-don-t-abort-in-case-of-policy-problems.patch
     ];
   };
 

--- a/packages/nixos/kata.nix
+++ b/packages/nixos/kata.nix
@@ -60,6 +60,8 @@ in
         Type = "oneshot";
         RemainAfterExit = "yes";
         ExecStart = lib.getExe pkgs.contrastPkgs.initdata-processor;
+        StandardOutput = "journal+console";
+        StandardError = "inherit";
       };
     };
 


### PR DESCRIPTION
The `regorus` crate was bumped in the last Kata update, and the new version does not support the older Rego syntax anymore. Add `if` keywords to the synthetic rules we create for propagating error messages from initdata-processor to runtime.

Included are two commits without which debugging the situation was harder than necessary. 