### PR TITLE
ci/release_e2e_test: scope fifo ticket to GPU platforms only

### DIFF
--- a/.github/actions/release_e2e_test/action.yml
+++ b/.github/actions/release_e2e_test/action.yml
@@ -123,7 +123,7 @@ runs:
 
     # --- common steps ---
     - name: Request fifo ticket
-      if: inputs.self_hosted != 'true' || inputs.platform_name == 'Metal-QEMU-SNP-GPU' || inputs.platform_name == 'Metal-QEMU-TDX-GPU'
+      if: inputs.platform_name == 'Metal-QEMU-SNP-GPU' || inputs.platform_name == 'Metal-QEMU-TDX-GPU'
       shell: bash
       run: |
         just request-fifo-ticket
@@ -165,7 +165,7 @@ runs:
         path: workspace/logs
         if-no-files-found: error
     - name: Release fifo ticket
-      if: always() && (inputs.self_hosted != 'true' || inputs.platform_name == 'Metal-QEMU-SNP-GPU' || inputs.platform_name == 'Metal-QEMU-TDX-GPU')
+      if: always() && (inputs.platform_name == 'Metal-QEMU-SNP-GPU' || inputs.platform_name == 'Metal-QEMU-TDX-GPU')
       shell: bash
       run: |
         just release-fifo-ticket


### PR DESCRIPTION
## Summary

Non-GPU darwin entries of the nightly release matrix were failing at `just request-fifo-ticket` with `services "sync" not found`.

The condition gating the ticket step matched every darwin job because `inputs.self_hosted` is `'false'` for darwin (it is derived from `cli-arch == 'x86_64-linux'` in `release_nightly.yml`), so the first clause of the OR short-circuited the rest.
The sync fifo only exists on GPU clusters (see `bm_maintenance.yml`), so the platform name is the only signal that matters.

## Test plan

- [ ] Re-run the failing nightly release job and confirm non-GPU darwin entries skip the ticket step.
- [ ] Confirm GPU entries (both darwin and linux) still acquire and release a ticket.