### PR TITLE
genpolicy: support pod-level resource limits

### DIFF
--- a/packages/by-name/kata/runtime/0027-genpolicy-support-pod-level-resource-limits.patch
+++ b/packages/by-name/kata/runtime/0027-genpolicy-support-pod-level-resource-limits.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: davidweisse <98460960+davidweisse@users.noreply.github.com>
+Date: Mon, 18 May 2026 12:57:48 +0200
+Subject: [PATCH] genpolicy: support pod level resource limits
+
+---
+ src/tools/genpolicy/src/pod.rs | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/tools/genpolicy/src/pod.rs b/src/tools/genpolicy/src/pod.rs
+index 7091472222ab94481f84d4b70dc0c70cc5d3a754..30faed16c24c729a7ecb7bb80dd9953dfa114b36 100644
+--- a/src/tools/genpolicy/src/pod.rs
++++ b/src/tools/genpolicy/src/pod.rs
+@@ -98,6 +98,9 @@ pub struct PodSpec {
+ 
+     #[serde(skip_serializing_if = "Option::is_none")]
+     priorityClassName: Option<String>,
++
++    #[serde(skip_serializing_if = "Option::is_none")]
++    resources: Option<ResourceRequirements>,
+ }
+ 
+ /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -170,6 +170,11 @@ buildGoModule (finalAttrs: {
       # error messages to propagate to the runtime.
       # Upstream issue: https://github.com/kata-containers/kata-containers/issues/13031.
       ./0026-agent-don-t-abort-in-case-of-policy-problems.patch
+
+      # Pod-level resource limits are a beta feature since K8s 1.34, but not supported by Kata yet.
+      # We need this to automatically configure memory limits for the entire VM and not on container basis.
+      # Upstream issue: https://github.com/kata-containers/kata-containers/issues/12816
+      ./0027-genpolicy-support-pod-level-resource-limits.patch
     ];
   };
 


### PR DESCRIPTION
This enables support for [pod-level resource limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#pod-level-resource-specification). This is a prerequisite for automatically configuring the memory limits for pods based on the image sizes.