### PR TITLE
ci: embed image-replacements in darwin CLI assets

### DIFF
--- a/.github/actions/release_build_darwin/action.yml
+++ b/.github/actions/release_build_darwin/action.yml
@@ -27,6 +27,14 @@ runs:
       with:
         version: ${{ inputs.without_v }}
         commit: false
+    - name: Download image-replacements
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: image-replacements
+        path: workspace/image-replacements
+    - name: Embed image-replacements in CLI assets
+      shell: bash
+      run: cp workspace/image-replacements/image-replacements.txt cli/cmd/assets/image-replacements.txt
     - uses: ./.github/actions/build_cli
       with:
         system: aarch64-darwin


### PR DESCRIPTION
The x86_64-linux build commits cli/cmd/assets/image-replacements.txt locally before building the CLI. The darwin build runs on a fresh macos-latest checkout that never sees that commit and embeds the placeholder comment instead, so `contrast generate` passes `initializer:latest` to genpolicy and trips ManifestUnknown.

Pull the image-replacements artifact (already uploaded by the linux build, gated via needs:) and drop it into cli/cmd/assets/ before the Nix build, mirroring what the linux job does in-tree.