### PR TITLE
justfile: auto-enable debug shell for badaml e2e tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ collect-platforms platform=default_platform set=default_set:
         --deployment "$deployment" \
         collect-platforms
 
-# Some e2e tests require a specific Nix package set to build correctly. Auto-select the correct set based on the test name.
+# Some e2e tests require a specific Nix package set and/or debug to build correctly. Auto-select these based on the test name.
 e2e target=default_deploy_target platform=default_platform set=default_set:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -88,12 +88,20 @@ e2e target=default_deploy_target platform=default_platform set=default_set:
         [badaml-vuln]=badaml-vuln
         [badaml-sandbox]=badaml-sandbox
     )
+    declare -A required_debug=(
+        [badaml-vuln]=true
+        [badaml-sandbox]=true
+    )
     RESOLVED_SET="{{ set }}"
     if [[ -v "required_sets[{{ target }}]" ]]; then
         RESOLVED_SET="${required_sets[{{ target }}]}"
     fi
-    echo "Using set=$RESOLVED_SET for test '{{ target }}'"
-    set="$RESOLVED_SET" just _e2e {{ target }} {{ platform }}
+    RESOLVED_DEBUG="${debug:-false}"
+    if [[ -v "required_debug[{{ target }}]" ]]; then
+        RESOLVED_DEBUG="${required_debug[{{ target }}]}"
+    fi
+    echo "Using set=$RESOLVED_SET, debug=$RESOLVED_DEBUG for test '{{ target }}'"
+    set="$RESOLVED_SET" debug="$RESOLVED_DEBUG" just _e2e {{ target }} {{ platform }}
 
 _e2e target=default_deploy_target platform=default_platform set=default_set: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy memdump debugshell k8s-log-collector (node-installer platform)
     #!/usr/bin/env bash


### PR DESCRIPTION
BadAMLTest's first action is `require.True(t, Flags.InsecureEnableDebugShell, ...)` (`e2e/badaml-vuln/badaml.go:27`), so `just e2e badaml-vuln` on a fresh checkout aborts immediately with the default `debug=false`. There is no discoverability today: users find the requirement by hitting the assert.

Mirror the existing `required_sets` pattern with a `required_debug` map that unconditionally overrides `debug` for the two affected targets. Same semantics, same silent-override trade-off, no caller-side changes. CI workflows already pass `debug-shell=true` for badaml runs.