### PR TITLE
.github: run nightly tests from per-platform sub-workflow for better grouping

### DIFF
--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -27,104 +27,35 @@ jobs:
       contents: read
       packages: write
 
-  test_matrix:
-    needs: "maintenance"
+  platform:
+    needs: maintenance
     strategy:
+      fail-fast: false
       matrix:
-        debug-shell: [true, false]
         platform:
           - name: Metal-QEMU-SNP
             runner: SNP
             self-hosted: true
+            debug-set-test-name: openssl
           - name: Metal-QEMU-TDX
             runner: TDX
             self-hosted: true
+            debug-set-test-name: openssl
           - name: Metal-QEMU-SNP-GPU
             runner: SNP-GPU
             self-hosted: true
+            debug-set-test-name: gpu
           - name: Metal-QEMU-TDX-GPU
             runner: TDX-GPU
             self-hosted: true
-        test-name:
-          # keep-sorted start
-          - atls
-          - attestation
-          - badaml-sandbox
-          - badaml-vuln
-          - containerd-11644-reproducer
-          - coordinator
-          - genpolicy-unsupported
-          - gpu
-          - imagepuller-auth
-          - imagestore
-          - kds-pcs-downtime
-          - memdump
-          - multi-runtime-class
-          - openssl
-          - peerrecovery
-          - policy
-          - proxy
-          - regression
-          - servicemesh
-          - vault
-          - volumestatefulset
-          - workloadsecret
-          # keep-sorted end
-        set: [""]
-        exclude:
-          - platform:
-              name: Metal-QEMU-SNP
-            test-name: gpu
-          - platform:
-              name: Metal-QEMU-TDX
-            test-name: gpu
-          - debug-shell: false
-            test-name: badaml-vuln
-          - debug-shell: false
-            test-name: badaml-sandbox
-        include:
-          # Exercise the debug set on every platform with the cheapest
-          # per-platform test, to catch regressions in the debug overlay
-          # that the base-set matrix cannot surface.
-          - set: debug
-            debug-shell: false
-            test-name: openssl
-            platform:
-              name: Metal-QEMU-SNP
-              runner: SNP
-              self-hosted: true
-          - set: debug
-            debug-shell: false
-            test-name: gpu
-            platform:
-              name: Metal-QEMU-SNP-GPU
-              runner: SNP-GPU
-              self-hosted: true
-          - set: debug
-            debug-shell: false
-            test-name: openssl
-            platform:
-              name: Metal-QEMU-TDX
-              runner: TDX
-              self-hosted: true
-          - set: debug
-            debug-shell: false
-            test-name: gpu
-            platform:
-              name: Metal-QEMU-TDX-GPU
-              runner: TDX-GPU
-              self-hosted: true
-      fail-fast: false
+            debug-set-test-name: gpu
     name: "${{ matrix.platform.name }}"
-    uses: ./.github/workflows/e2e.yml
+    uses: ./.github/workflows/e2e_nightly_platform.yml
     with:
-      skip-undeploy: false
-      test-name: ${{ matrix.test-name }}
-      platform: ${{ matrix.platform.name }}
+      platform-name: ${{ matrix.platform.name }}
       runner: ${{ matrix.platform.runner }}
       self-hosted: ${{ matrix.platform.self-hosted }}
-      debug-shell: ${{ matrix.debug-shell }}
-      set: ${{ matrix.set }}
+      debug-set-test-name: ${{ matrix.platform.debug-set-test-name }}
     secrets:
       GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN_IN || secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/e2e_nightly_platform.yml
+++ b/.github/workflows/e2e_nightly_platform.yml
@@ -1,0 +1,99 @@
+name: e2e test nightly (per platform)
+
+on:
+  workflow_call:
+    inputs:
+      platform-name:
+        description: "Platform name (e.g. Metal-QEMU-SNP)"
+        type: string
+        required: true
+      runner:
+        description: "Self-hosted runner label"
+        type: string
+        required: true
+      self-hosted:
+        description: "Whether the runner is self-hosted"
+        type: boolean
+        required: true
+      debug-set-test-name:
+        description: "Test used to exercise the debug package set on this platform."
+        type: string
+        required: true
+    secrets:
+      GITHUB_TOKEN_IN:
+        required: true
+      CACHIX_AUTH_TOKEN:
+        required: true
+      NUNKI_CI_COMMIT_PUSH_PR:
+        required: true
+      TEAMS_CI_WEBHOOK:
+        required: true
+      CONTRAST_GHCR_READ:
+        required: true
+
+jobs:
+  test_matrix:
+    strategy:
+      matrix:
+        debug-shell: [true, false]
+        test-name:
+          # keep-sorted start
+          - atls
+          - attestation
+          - badaml-sandbox
+          - badaml-vuln
+          - containerd-11644-reproducer
+          - coordinator
+          - genpolicy-unsupported
+          - gpu
+          - imagepuller-auth
+          - imagestore
+          - kds-pcs-downtime
+          - memdump
+          - multi-runtime-class
+          - openssl
+          - peerrecovery
+          - policy
+          - proxy
+          - regression
+          - servicemesh
+          - vault
+          - volumestatefulset
+          - workloadsecret
+          # keep-sorted end
+        set: [""]
+        exclude:
+          - debug-shell: false
+            test-name: badaml-vuln
+          - debug-shell: false
+            test-name: badaml-sandbox
+          # If the platform is GPU, exclude the (non-existent) sentinel test, otherwise, exclude the (existing) "gpu" test.
+          # matrix context is not available here, so instead, this workaround.
+          - test-name: ${{ contains(inputs.platform-name, 'GPU') && 'gpu-on-gpu-platform-noop' || 'gpu' }}
+        include:
+          # Exercise the debug set on this platform with the cheapest
+          # per-platform test, to catch regressions in the debug overlay
+          # that the base-set matrix cannot surface.
+          - set: debug
+            debug-shell: false
+            test-name: ${{ inputs.debug-set-test-name }}
+      fail-fast: false
+    name: "${{ matrix.test-name }}${{ matrix.debug-shell && ' (with debug shell)' || '' }}${{ matrix.set != '' && format(' [{0}]', matrix.set) || '' }}"
+    uses: ./.github/workflows/e2e.yml
+    with:
+      skip-undeploy: false
+      test-name: ${{ matrix.test-name }}
+      platform: ${{ inputs.platform-name }}
+      runner: ${{ inputs.runner }}
+      self-hosted: ${{ inputs.self-hosted }}
+      debug-shell: ${{ matrix.debug-shell }}
+      set: ${{ matrix.set }}
+    secrets:
+      GITHUB_TOKEN_IN: ${{ secrets.GITHUB_TOKEN_IN }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      NUNKI_CI_COMMIT_PUSH_PR: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+      TEAMS_CI_WEBHOOK: ${{ secrets.TEAMS_CI_WEBHOOK }}
+      CONTRAST_GHCR_READ: ${{ secrets.CONTRAST_GHCR_READ }}
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
This moves per-platform tests into a reusable workflow. *Calling* that workflow should group the jobs similar to how they were before.

TBH I'd like to hold off on merging this until we've had a successful release, since it's just cosmetic for us and I don't want to risk new unforeseen failures tonight.