### PR TITLE
sets: factor shared badaml machinery into _badaml.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,13 +47,17 @@
 
         # setsFromDirectory reads overlays from a directory and creates a set of pkgs instances for each.
         # The filename is used as attribute name in the resulting set, the .nix extension is stripped.
+        # Files starting with `_` are treated as private helpers (e.g. shared scope-override functions
+        # imported by the set overlays) and are not loaded as sets themselves.
         setsFromDirectory =
           dir:
           builtins.listToAttrs (
-            map (file: rec {
-              name = builtins.substring 0 (builtins.stringLength file - 4) (baseNameOf file);
-              value = mkSet ((defaultOverlays name) ++ [ (import (dir + "/${file}")) ]);
-            }) (builtins.attrNames (builtins.readDir dir))
+            map
+              (file: rec {
+                name = builtins.substring 0 (builtins.stringLength file - 4) (baseNameOf file);
+                value = mkSet ((defaultOverlays name) ++ [ (import (dir + "/${file}")) ]);
+              })
+              (builtins.filter (n: builtins.substring 0 1 n != "_") (builtins.attrNames (builtins.readDir dir)))
           );
 
         # reverseContrastNesting takes a pkgs instance and reverses the nesting by moving the

--- a/overlays/sets/_badaml.nix
+++ b/overlays/sets/_badaml.nix
@@ -1,0 +1,66 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+# Shared BadAML test machinery for the badaml-vuln and badaml-sandbox sets.
+{ withAMLSandbox }:
+contrastPkgsFinal: contrastPkgsPrev: {
+  kata = contrastPkgsPrev.kata.overrideScope (
+    _kataFinal: kataPrev: {
+      kernel-uvm = kataPrev.kernel-uvm.override {
+        inherit withAMLSandbox;
+        # Enable ACPI debug logging to make it easier to verify that the attack is working,
+        # or debug it if it isn't.
+        withACPIDebug = true;
+      };
+      image = kataPrev.image.override {
+        withBadAMLTarget = true;
+      };
+    }
+  );
+  # The override will also take effect in the static version used below.
+  qemu-wrapped = contrastPkgsPrev.qemu-wrapped.override {
+    withACPITable = true;
+  };
+  contrast = contrastPkgsPrev.contrast.overrideScope (
+    _contrastFinal: contrastPrev: {
+      node-installer-image = contrastPrev.node-installer-image.override {
+        withExtraLayers = [
+          (contrastPkgsFinal.ociLayerTar {
+            files = [
+              {
+                # The wrapper script that replaces the original qemu binary.
+                source = "${contrastPkgsFinal.contrastPkgsStatic.qemu-wrapped}/bin/qemu-system-x86_64";
+                destination = "/opt/edgeless/bin/qemu-system-x86_64";
+              }
+              {
+                # The actual qemu binary that is wrapped by qemu-wrapped.
+                source = "${contrastPkgsFinal.contrastPkgsStatic.qemu-wrapped}/bin/qemu-system-x86_64-wrapped";
+                destination = "/opt/edgeless/bin/qemu-system-x86_64-wrapped";
+              }
+              {
+                # The AML payload injected by the wrapper script.
+                source = "${contrastPkgsFinal.badaml-payload}/deadbeef-file.aml"; # Modify payload here.
+                destination = "/opt/edgeless/bin/payload.aml";
+              }
+            ];
+          })
+        ];
+        withExtraInstallFilesConfig = [
+          {
+            # qemu-wrapped is a wrapper script that invokes the real qemu-cc binary.
+            # The original install entry for qemu-cc will only install the wrapper scripts,
+            # so we need to add an additional step to install the actual, wrapped qemu binary.
+            url = "file:///opt/edgeless/bin/qemu-system-x86_64-wrapped";
+            path = "/opt/edgeless/@@runtimeName@@/bin/qemu-system-x86_64-wrapped";
+            executable = true;
+          }
+          {
+            # The AML payload injected by the wrapper script.
+            url = "file:///opt/edgeless/bin/payload.aml";
+            path = "/opt/edgeless/@@runtimeName@@/bin/payload.aml";
+          }
+        ];
+      };
+    }
+  );
+}

--- a/overlays/sets/badaml-sandbox.nix
+++ b/overlays/sets/badaml-sandbox.nix
@@ -1,70 +1,11 @@
 # Copyright 2026 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-# TODO(katexochen): This is currently a near-copy of badaml-vuln.nix, without the disabling of the AML sandbox in the image.
-# Refactor it to reuse the code between both sets.
-
+let
+  badamlScope = import ./_badaml.nix;
+in
 _final: prev: {
-  contrastPkgs = prev.contrastPkgs.overrideScope (
-    contrastPkgsFinal: contrastPkgsPrev: {
-      kata = contrastPkgsPrev.kata.overrideScope (
-        _kataFinal: kataPrev: {
-          kernel-uvm = kataPrev.kernel-uvm.override {
-            # Enable ACPI debug logging to make it easier to verify that the attack is working,
-            # or debug it if it isn't.
-            withACPIDebug = true;
-          };
-          image = kataPrev.image.override {
-            withBadAMLTarget = true;
-          };
-        }
-      );
-      # The override will also take effect in the static version used below.
-      qemu-wrapped = contrastPkgsPrev.qemu-wrapped.override {
-        withACPITable = true;
-      };
-      contrast = contrastPkgsPrev.contrast.overrideScope (
-        _contrastFinal: contrastPrev: {
-          node-installer-image = contrastPrev.node-installer-image.override {
-            withExtraLayers = [
-              (contrastPkgsFinal.ociLayerTar {
-                files = [
-                  {
-                    # The wrapper script that replaces the original qemu binary.
-                    source = "${contrastPkgsFinal.contrastPkgsStatic.qemu-wrapped}/bin/qemu-system-x86_64";
-                    destination = "/opt/edgeless/bin/qemu-system-x86_64";
-                  }
-                  {
-                    # The actual qemu binary that is wrapped by qemu-wrapped.
-                    source = "${contrastPkgsFinal.contrastPkgsStatic.qemu-wrapped}/bin/qemu-system-x86_64-wrapped";
-                    destination = "/opt/edgeless/bin/qemu-system-x86_64-wrapped";
-                  }
-                  {
-                    # The AML payload injected by the wrapper script.
-                    source = "${contrastPkgsFinal.badaml-payload}/deadbeef-file.aml"; # Modify payload here.
-                    destination = "/opt/edgeless/bin/payload.aml";
-                  }
-                ];
-              })
-            ];
-            withExtraInstallFilesConfig = [
-              {
-                # qemu-wrapped is a wrapper script that invokes the real qemu-cc binary.
-                # The original install entry for qemu-cc will only install the wrapper scripts,
-                # so we need to add an additional step to install the actual, wrapped qemu binary.
-                url = "file:///opt/edgeless/bin/qemu-system-x86_64-wrapped";
-                path = "/opt/edgeless/@@runtimeName@@/bin/qemu-system-x86_64-wrapped";
-                executable = true;
-              }
-              {
-                # The AML payload injected by the wrapper script.
-                url = "file:///opt/edgeless/bin/payload.aml";
-                path = "/opt/edgeless/@@runtimeName@@/bin/payload.aml";
-              }
-            ];
-          };
-        }
-      );
-    }
-  );
+  contrastPkgs = prev.contrastPkgs.overrideScope (badamlScope {
+    withAMLSandbox = true;
+  });
 }

--- a/overlays/sets/badaml-vuln.nix
+++ b/overlays/sets/badaml-vuln.nix
@@ -1,69 +1,12 @@
 # Copyright 2026 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
+let
+  badamlScope = import ./_badaml.nix;
+in
 _final: prev: {
-  contrastPkgs = prev.contrastPkgs.overrideScope (
-    contrastPkgsFinal: contrastPkgsPrev: {
-      kata = contrastPkgsPrev.kata.overrideScope (
-        _kataFinal: kataPrev: {
-          kernel-uvm = kataPrev.kernel-uvm.override {
-            # Deactivate the AML sandbox so the guest is vulnerable to BadAML attack.
-            withAMLSandbox = false;
-            # Enable ACPI debug logging to make it easier to verify that the attack is working,
-            # or debug it if it isn't.
-            withACPIDebug = true;
-          };
-          image = kataPrev.image.override {
-            withBadAMLTarget = true;
-          };
-        }
-      );
-      # The override will also take effect in the static version used below.
-      qemu-wrapped = contrastPkgsPrev.qemu-wrapped.override {
-        withACPITable = true;
-      };
-      contrast = contrastPkgsPrev.contrast.overrideScope (
-        _contrastFinal: contrastPrev: {
-          node-installer-image = contrastPrev.node-installer-image.override {
-            withExtraLayers = [
-              (contrastPkgsFinal.ociLayerTar {
-                files = [
-                  {
-                    # The wrapper script that replaces the original qemu binary.
-                    source = "${contrastPkgsFinal.contrastPkgsStatic.qemu-wrapped}/bin/qemu-system-x86_64";
-                    destination = "/opt/edgeless/bin/qemu-system-x86_64";
-                  }
-                  {
-                    # The actual qemu binary that is wrapped by qemu-wrapped.
-                    source = "${contrastPkgsFinal.contrastPkgsStatic.qemu-wrapped}/bin/qemu-system-x86_64-wrapped";
-                    destination = "/opt/edgeless/bin/qemu-system-x86_64-wrapped";
-                  }
-                  {
-                    # The AML payload injected by the wrapper script.
-                    source = "${contrastPkgsFinal.badaml-payload}/deadbeef-file.aml"; # Modify payload here.
-                    destination = "/opt/edgeless/bin/payload.aml";
-                  }
-                ];
-              })
-            ];
-            withExtraInstallFilesConfig = [
-              {
-                # qemu-wrapped is a wrapper script that invokes the real qemu-cc binary.
-                # The original install entry for qemu-cc will only install the wrapper scripts,
-                # so we need to add an additional step to install the actual, wrapped qemu binary.
-                url = "file:///opt/edgeless/bin/qemu-system-x86_64-wrapped";
-                path = "/opt/edgeless/@@runtimeName@@/bin/qemu-system-x86_64-wrapped";
-                executable = true;
-              }
-              {
-                # The AML payload injected by the wrapper script.
-                url = "file:///opt/edgeless/bin/payload.aml";
-                path = "/opt/edgeless/@@runtimeName@@/bin/payload.aml";
-              }
-            ];
-          };
-        }
-      );
-    }
-  );
+  # Deactivate the AML sandbox so the guest is vulnerable to BadAML attack.
+  contrastPkgs = prev.contrastPkgs.overrideScope (badamlScope {
+    withAMLSandbox = false;
+  });
 }


### PR DESCRIPTION
An idea for addressing the TODO in `badaml-sandbox.nix`: the BadAML test machinery (qemu-wrapped, kata kernel-uvm + image, node-installer-image payload) lives in `_badaml.nix`, taking `withAMLSandbox` so vuln and sandbox share one source of truth.

`setsFromDirectory` skips underscore-prefixed files so the helper sits with its consumers without being loaded as a set.

For more ideas, this is an example combined set I was using to test the `badaml-vuln` failures with a debug firmware on top of the `badaml-vuln` set changes:

```nix
# overlays/sets/_debug.nix
_contrastPkgsFinal: contrastPkgsPrev: {
  OVMF-SNP = contrastPkgsPrev.OVMF-SNP.override { debug = true; };
  OVMF-TDX = contrastPkgsPrev.OVMF-TDX.override { debug = true; };
  contrast = contrastPkgsPrev.contrast.overrideScope (
    _contrastFinal: contrastPrev: {
      node-installer-image = contrastPrev.node-installer-image.override {
        withDebug = true;
      };
    }
  );
}

# overlays/sets/badaml-vuln-debug.nix
let
  debugScope = import ./_debug.nix;
  badamlScope = import ./_badaml.nix;   # added in this PR
in
_final: prev: {
  contrastPkgs =
    (prev.contrastPkgs.overrideScope debugScope).overrideScope (badamlScope {
      withAMLSandbox = false;
    });
}

# then ovelrays/sets/debug.nix becomes
let
  debugScope = import ./_debug.nix;
in
_final: prev: {
  contrastPkgs = prev.contrastPkgs.overrideScope debugScope;
}
```