### PR TITLE
genpolicy: save layer sizes to extra file

### DIFF
--- a/packages/by-name/kata/runtime/0026-genpolicy-cache-un-compressed-layer-sizes.patch
+++ b/packages/by-name/kata/runtime/0026-genpolicy-cache-un-compressed-layer-sizes.patch
@@ -1,0 +1,224 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: davidweisse <98460960+davidweisse@users.noreply.github.com>
+Date: Mon, 18 May 2026 14:42:01 +0200
+Subject: [PATCH] genpolicy: cache (un-)compressed layer sizes
+
+---
+ src/tools/genpolicy/src/layers_cache.rs       |  4 +-
+ src/tools/genpolicy/src/registry.rs           | 29 +++++++------
+ .../genpolicy/src/registry_containerd.rs      | 42 +++++++++++--------
+ 3 files changed, 44 insertions(+), 31 deletions(-)
+
+diff --git a/src/tools/genpolicy/src/layers_cache.rs b/src/tools/genpolicy/src/layers_cache.rs
+index 15db565c4caeb22b6d482ceb0d5215d572d3fc78..864f4bee788ccc689f184213b474609b2b8a54f7 100644
+--- a/src/tools/genpolicy/src/layers_cache.rs
++++ b/src/tools/genpolicy/src/layers_cache.rs
+@@ -59,11 +59,11 @@ impl ImageLayersCache {
+         }
+     }
+ 
+-    pub fn get_layer(&self, diff_id: &str) -> Option<ImageLayer> {
++    pub fn get_layer(&self, layer_digest: &str) -> Option<ImageLayer> {
+         let layers = self.inner.lock().unwrap();
+         layers
+             .iter()
+-            .find(|layer| layer.diff_id == diff_id)
++            .find(|layer| layer.layer_digest == layer_digest)
+             .cloned()
+     }
+ 
+diff --git a/src/tools/genpolicy/src/registry.rs b/src/tools/genpolicy/src/registry.rs
+index 60c7599842c9d3b0600077c24e6e354ffc6352c5..51a688439cb46ac92b7f3eeacd09ed9120a11969 100644
+--- a/src/tools/genpolicy/src/registry.rs
++++ b/src/tools/genpolicy/src/registry.rs
+@@ -69,9 +69,11 @@ pub struct DockerRootfs {
+ /// This application's image layer properties.
+ #[derive(Clone, Debug, Serialize, Deserialize)]
+ pub struct ImageLayer {
+-    pub diff_id: String,
++    pub layer_digest: String,
+     pub passwd: String,
+     pub group: String,
++    pub compressed_size: u64,
++    pub uncompressed_size: u64,
+ }
+ 
+ /// See https://docs.docker.com/reference/dockerfile/#volume.
+@@ -535,15 +537,15 @@ async fn get_image_layers(
+             || layer.media_type.eq(manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE)
+         {
+             if layer_index < config_layer.rootfs.diff_ids.len() {
+-                let mut imageLayer = get_users_from_layer(
++                let compressed_size = u64::try_from(layer.size).map_err(|e| anyhow!(e))?;
++                let imageLayer = get_users_from_layer(
+                     layers_cache,
+                     client,
+                     reference,
+                     &layer.digest,
+-                    &config_layer.rootfs.diff_ids[layer_index].clone(),
++                    compressed_size,
+                 )
+                 .await?;
+-                imageLayer.diff_id = config_layer.rootfs.diff_ids[layer_index].clone();
+                 layers.push(imageLayer);
+             } else {
+                 return Err(anyhow!("Too many Docker gzip layers"));
+@@ -561,9 +563,9 @@ async fn get_users_from_layer(
+     client: &mut Client,
+     reference: &Reference,
+     layer_digest: &str,
+-    diff_id: &str,
++    compressed_size: u64,
+ ) -> Result<ImageLayer> {
+-    if let Some(layer) = layers_cache.get_layer(diff_id) {
++    if let Some(layer) = layers_cache.get_layer(layer_digest) {
+         info!("get_users_from_layer: using cache file");
+         return Ok(layer);
+     }
+@@ -578,7 +580,7 @@ async fn get_users_from_layer(
+     let mut compressed_path = decompressed_path.clone();
+     compressed_path.set_extension("gz");
+ 
+-    if let Err(e) = create_decompressed_layer_file(
++    let uncompressed_size = match create_decompressed_layer_file(
+         client,
+         reference,
+         layer_digest,
+@@ -587,7 +589,8 @@ async fn get_users_from_layer(
+     )
+     .await
+     {
+-        bail!(format!("Failed to decompress image layer, error {e}"));
++        Ok(size) => size,
++        Err(e) => bail!(format!("Failed to decompress image layer, error {e}")),
+     };
+ 
+     match get_users_from_decompressed_layer(&decompressed_path) {
+@@ -597,7 +600,9 @@ async fn get_users_from_layer(
+         }
+         Ok((passwd, group)) => {
+             let layer = ImageLayer {
+-                diff_id: diff_id.to_string(),
++                layer_digest: layer_digest.to_string(),
++                compressed_size,
++                uncompressed_size,
+                 passwd,
+                 group,
+             };
+@@ -613,7 +618,7 @@ async fn create_decompressed_layer_file(
+     layer_digest: &str,
+     decompressed_path: &Path,
+     compressed_path: &Path,
+-) -> Result<()> {
++) -> Result<u64> {
+     info!(
+         "create_decompressed_layer_file: pulling layer {:?}",
+         layer_digest
+@@ -636,10 +641,10 @@ async fn create_decompressed_layer_file(
+         .truncate(true)
+         .open(decompressed_path)?;
+     let mut gz_decoder = flate2::read::GzDecoder::new(compressed_file);
+-    std::io::copy(&mut gz_decoder, &mut decompressed_file).map_err(|e| anyhow!(e))?;
++    let uncompressed_size = std::io::copy(&mut gz_decoder, &mut decompressed_file).map_err(|e| anyhow!(e))?;
+ 
+     decompressed_file.flush().map_err(|e| anyhow!(e))?;
+-    Ok(())
++    Ok(uncompressed_size)
+ }
+ 
+ pub fn get_users_from_decompressed_layer(path: &Path) -> Result<(String, String)> {
+diff --git a/src/tools/genpolicy/src/registry_containerd.rs b/src/tools/genpolicy/src/registry_containerd.rs
+index e8c267ff0fdacbf6dd759f1d35b8e42f03d37e31..95a1975b06e46df04ece2212317aa2193f4144da 100644
+--- a/src/tools/genpolicy/src/registry_containerd.rs
++++ b/src/tools/genpolicy/src/registry_containerd.rs
+@@ -301,14 +301,13 @@ pub async fn get_image_layers(
+             || layer_media_type.eq("application/vnd.oci.image.layer.v1.tar+gzip")
+         {
+             if layer_index < config_layer.rootfs.diff_ids.len() {
+-                let mut imageLayer = get_users_from_layer(
++                let imageLayer = get_users_from_layer(
+                     layers_cache,
+                     layer["digest"].as_str().unwrap(),
+                     client,
+-                    &config_layer.rootfs.diff_ids[layer_index].clone(),
++                    layer["size"].as_u64().unwrap(),
+                 )
+                 .await?;
+-                imageLayer.diff_id = config_layer.rootfs.diff_ids[layer_index].clone();
+                 layersVec.push(imageLayer);
+             } else {
+                 return Err(anyhow!("Too many Docker gzip layers"));
+@@ -324,9 +323,9 @@ async fn get_users_from_layer(
+     layers_cache: &ImageLayersCache,
+     layer_digest: &str,
+     client: &containerd_client::Client,
+-    diff_id: &str,
++    size: u64,
+ ) -> Result<ImageLayer> {
+-    if let Some(layer) = layers_cache.get_layer(diff_id) {
++    if let Some(layer) = layers_cache.get_layer(layer_digest) {
+         info!("Using cache file");
+         return Ok(layer);
+     }
+@@ -342,15 +341,22 @@ async fn get_users_from_layer(
+     compressed_path.set_extension("gz");
+ 
+     // go find verity hash if not found in cache
+-    if let Err(e) =
+-        create_decompressed_layer_file(client, layer_digest, &decompressed_path, &compressed_path)
+-            .await
++    let uncompressed_size = match create_decompressed_layer_file(
++        client,
++        layer_digest,
++        &decompressed_path,
++        &compressed_path,
++    )
++    .await
+     {
+-        temp_dir.close()?;
+-        bail!(format!(
+-            "Failed to create verity hash for {layer_digest}, error {e}"
+-        ));
+-    }
++        Ok(size) => size,
++        Err(e) => {
++            temp_dir.close()?;
++            bail!(format!(
++                "Failed to create verity hash for {layer_digest}, error {e}"
++            ));
++        }
++    };
+ 
+     match get_users_from_decompressed_layer(&decompressed_path) {
+         Err(e) => {
+@@ -359,7 +365,9 @@ async fn get_users_from_layer(
+         }
+         Ok((passwd, group)) => {
+             let layer = ImageLayer {
+-                diff_id: diff_id.to_string(),
++                layer_digest: layer_digest.to_string(),
++                compressed_size: size,
++                uncompressed_size,
+                 passwd,
+                 group,
+             };
+@@ -374,7 +382,7 @@ async fn create_decompressed_layer_file(
+     layer_digest: &str,
+     decompressed_path: &Path,
+     compressed_path: &Path,
+-) -> Result<()> {
++) -> Result<u64> {
+     info!("Pulling layer {layer_digest}");
+     let mut file = tokio::fs::File::create(&compressed_path)
+         .await
+@@ -412,8 +420,8 @@ async fn create_decompressed_layer_file(
+         .truncate(true)
+         .open(decompressed_path)?;
+     let mut gz_decoder = flate2::read::GzDecoder::new(compressed_file);
+-    std::io::copy(&mut gz_decoder, &mut decompressed_file).map_err(|e| anyhow!(e))?;
++    let uncompressed_size = std::io::copy(&mut gz_decoder, &mut decompressed_file).map_err(|e| anyhow!(e))?;
+ 
+     decompressed_file.flush().map_err(|e| anyhow!(e))?;
+-    Ok(())
++    Ok(uncompressed_size)
+ }

--- a/packages/by-name/kata/runtime/0027-genpolicy-write-processed-layer-information-to-file.patch
+++ b/packages/by-name/kata/runtime/0027-genpolicy-write-processed-layer-information-to-file.patch
@@ -1,0 +1,172 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: davidweisse <98460960+davidweisse@users.noreply.github.com>
+Date: Wed, 27 May 2026 13:04:23 +0200
+Subject: [PATCH] genpolicy: write processed layer information to file
+
+---
+ src/tools/genpolicy/src/layers_cache.rs        | 10 ++++++++++
+ src/tools/genpolicy/src/policy.rs              | 17 +++++++++++++++++
+ src/tools/genpolicy/src/registry.rs            |  5 +++++
+ src/tools/genpolicy/src/registry_containerd.rs | 11 +++++++++--
+ src/tools/genpolicy/src/utils.rs               |  9 +++++++++
+ 5 files changed, 50 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/genpolicy/src/layers_cache.rs b/src/tools/genpolicy/src/layers_cache.rs
+index 864f4bee788ccc689f184213b474609b2b8a54f7..c272387c915b5c3814a35f98766a8b203ce674a8 100644
+--- a/src/tools/genpolicy/src/layers_cache.rs
++++ b/src/tools/genpolicy/src/layers_cache.rs
+@@ -8,6 +8,7 @@ use crate::registry::ImageLayer;
+ use fs2::FileExt;
+ use log::{debug, warn};
+ use std::fs::OpenOptions;
++use std::collections::BTreeSet;
+ use std::sync::{Arc, Mutex};
+ 
+ #[derive(Debug, Clone)]
+@@ -72,6 +73,15 @@ impl ImageLayersCache {
+         layers.push(layer.clone());
+     }
+ 
++    pub fn get_layers_by_digests(&self, digests: &BTreeSet<String>) -> Vec<ImageLayer> {
++        let layers = self.inner.lock().unwrap();
++        layers
++            .iter()
++            .filter(|layer| digests.contains(&layer.layer_digest))
++            .cloned()
++            .collect()
++    }
++
+     pub fn persist(&self) {
+         if let Err(e) = self.try_persist() {
+             warn!("Could not persist image layers cache: {e}");
+diff --git a/src/tools/genpolicy/src/policy.rs b/src/tools/genpolicy/src/policy.rs
+index ca62127d31c36a098c82e07128fb484f42ebd26b..72e31f28b42bb63c3d4ddf6aee7fa1e4840dd7f8 100644
+--- a/src/tools/genpolicy/src/policy.rs
++++ b/src/tools/genpolicy/src/policy.rs
+@@ -618,9 +618,13 @@ impl AgentPolicy {
+ 
+     pub fn export_policy(&mut self) {
+         let mut yaml_string = String::new();
++        let mut used_layer_digests: BTreeSet<String> = BTreeSet::new();
+         for i in 0..self.resources.len() {
+             let annotation = self.resources[i].generate_initdata_anno(self);
+             yaml_string += &self.resources[i].serialize(&annotation);
++            for container in self.resources[i].get_containers() {
++                used_layer_digests.extend(container.registry.layer_digests.iter().cloned());
++            }
+         }
+ 
+         if let Some(yaml_file) = &self.config.yaml_file {
+@@ -635,6 +639,19 @@ impl AgentPolicy {
+         } else if !self.config.base64_out && !self.config.raw_out {
+             std::io::stdout().write_all(yaml_string.as_bytes()).unwrap();
+         }
++
++        if let Some(path) = &self.config.pod_layers_file_path {
++            let layers = self
++                .config
++                .layers_cache
++                .get_layers_by_digests(&used_layer_digests);
++            let path = std::path::Path::new(path);
++            let parent = path.parent().unwrap_or(std::path::Path::new("."));
++            let mut tmp_file = tempfile::NamedTempFile::new_in(parent).unwrap();
++            serde_json::to_writer(tmp_file.as_file_mut(), &layers).unwrap();
++            tmp_file.as_file_mut().sync_all().unwrap();
++            tmp_file.persist(path).unwrap();
++        }
+     }
+ 
+     pub fn generate_initdata_anno(&self, resource: &dyn yaml::K8sResource) -> String {
+diff --git a/src/tools/genpolicy/src/registry.rs b/src/tools/genpolicy/src/registry.rs
+index 51a688439cb46ac92b7f3eeacd09ed9120a11969..6a282ae98c82667537593b0d555fe17352369fcf 100644
+--- a/src/tools/genpolicy/src/registry.rs
++++ b/src/tools/genpolicy/src/registry.rs
+@@ -37,6 +37,7 @@ pub struct Container {
+     pub config_layer: DockerConfigLayer,
+     pub passwd: String,
+     pub group: String,
++    pub layer_digests: Vec<String>,
+ }
+ 
+ /// Image config layer properties.
+@@ -237,6 +238,10 @@ impl Container {
+             config_layer,
+             passwd,
+             group,
++            layer_digests: image_layers
++                .iter()
++                .map(|layer| layer.layer_digest.clone())
++                .collect(),
+         })
+     }
+ 
+diff --git a/src/tools/genpolicy/src/registry_containerd.rs b/src/tools/genpolicy/src/registry_containerd.rs
+index 95a1975b06e46df04ece2212317aa2193f4144da..170346b745593449b71a8ce49aaf70fd0ab2866c 100644
+--- a/src/tools/genpolicy/src/registry_containerd.rs
++++ b/src/tools/genpolicy/src/registry_containerd.rs
+@@ -72,8 +72,9 @@ impl Container {
+         // Nydus/guest_pull doesn't make available passwd/group files from layers properly.
+         // See issue https://github.com/kata-containers/kata-containers/issues/11162
+         let v1_policy = config.settings.cluster_config.pause_container_id_policy == "v1";
+-        if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
++        let image_layers = if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
+             info!("Guest pull is enabled, skipping passwd/group file parsing");
++            Vec::new()
+         } else {
+             let image_layers =
+                 get_image_layers(&config.layers_cache, &manifest, &config_layer, &ctrd_client)
+@@ -95,13 +96,19 @@ impl Container {
+                     group = layer.group.clone();
+                 }
+             }
+-        }
++
++            image_layers
++        };
+ 
+         Ok(Container {
+             image: image_str,
+             config_layer,
+             passwd,
+             group,
++            layer_digests: image_layers
++                .iter()
++                .map(|layer| layer.layer_digest.clone())
++                .collect(),
+         })
+     }
+ }
+diff --git a/src/tools/genpolicy/src/utils.rs b/src/tools/genpolicy/src/utils.rs
+index e3f5143f418ad82f85fc2c1f261ddc5be8fc02e8..3fe96581632312043dcf77f85be9754db1696053 100644
+--- a/src/tools/genpolicy/src/utils.rs
++++ b/src/tools/genpolicy/src/utils.rs
+@@ -104,6 +104,13 @@ struct CommandLineOptions {
+         require_equals = true
+     )]
+     layers_cache_file_path: Option<String>,
++
++    #[clap(
++        long,
++        help = "Path to the pod layers file. This file stores a subset of the layers cache for the processed images.",
++    )]
++    pod_layers_file_path: Option<String>,
++
+     #[clap(short, long, help = "Print version information and exit")]
+     version: bool,
+ 
+@@ -138,6 +145,7 @@ pub struct Config {
+     pub base64_out: bool,
+     pub containerd_socket_path: Option<String>,
+     pub layers_cache: layers_cache::ImageLayersCache,
++    pub pod_layers_file_path: Option<String>,
+     pub version: bool,
+     pub initdata: kata_types::initdata::InitData,
+     pub max_pull_attempts: u8,
+@@ -190,6 +198,7 @@ impl Config {
+             base64_out: args.base64_out,
+             containerd_socket_path: args.containerd_socket_path,
+             layers_cache: layers_cache::ImageLayersCache::new(&layers_cache_file_path),
++            pod_layers_file_path: args.pod_layers_file_path,
+             version: args.version,
+             initdata,
+             max_pull_attempts: args.max_pull_attempts,

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -172,6 +172,10 @@ buildGoModule (finalAttrs: {
       # The layers-cache.json file is no longer indexed by diffID, but by the layer digest,
       # which is the only stable identifier for the compressed layer size.
       ./0026-genpolicy-cache-un-compressed-layer-sizes.patch
+
+      # This writes a subset of the layers-cache.json file into a separate file containing only the processed layers.
+      # We need the layer information to calculate the memory overhead for the VM during generate.
+      ./0027-genpolicy-write-processed-layer-information-to-file.patch
     ];
   };
 

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -166,6 +166,12 @@ buildGoModule (finalAttrs: {
       # We need this to automatically configure memory limits for the entire VM and not on container basis.
       # Upstream issue: https://github.com/kata-containers/kata-containers/issues/12816
       ./0025-genpolicy-support-pod-level-resource-limits.patch
+
+      # We need the layer sizes to compute the overhead of pulling the images into the VM.
+      # This caches the compressed and uncompressed layer sizes in the layers-cache.json file during genpolicy.
+      # The layers-cache.json file is no longer indexed by diffID, but by the layer digest,
+      # which is the only stable identifier for the compressed layer size.
+      ./0026-genpolicy-cache-un-compressed-layer-sizes.patch
     ];
   };
 

--- a/packages/by-name/ociLayerTar/package.nix
+++ b/packages/by-name/ociLayerTar/package.nix
@@ -71,6 +71,7 @@ runCommandLocal "ociLayer"
     # Calculate the layer tarball's diffID (hash of the uncompressed tarball)
     echo "Calculating layer tarball hash..."
     diffID=$(sha256sum $out/layer.tar | cut -d' ' -f1)
+    uncompressed_size=$(stat -c %s $out/layer.tar)
     # Compress the layer tarball
     echo "Compressing layer tarball..."
     if [[ "$compression" = "gzip" ]]; then
@@ -85,7 +86,8 @@ runCommandLocal "ociLayer"
     # Calculate the blob's sha256 hash and write the media descriptor
     echo "Calculating layer blob hash..."
     sha256=$(sha256sum $out/$outPath | cut -d' ' -f1)
-    echo -n "{\"mediaType\": \"$mediaType\", \"size\": $(stat -c %s $out/$outPath), \"digest\": \"sha256:$sha256\"}" > $out/media-descriptor.json
+    compressed_size=$(stat -c %s $out/$outPath)
+    echo -n "{\"mediaType\": \"$mediaType\", \"size\": $compressed_size, \"digest\": \"sha256:$sha256\"}" > $out/media-descriptor.json
     echo -n "sha256:$diffID" > $out/DiffID
 
     if [[ -f ./root/etc/passwd ]]; then
@@ -94,7 +96,7 @@ runCommandLocal "ociLayer"
     if [[ -f ./root/etc/group ]]; then
       group=$(cat ./root/etc/group)
     fi
-    echo -n "{\"diff_id\": \"sha256:$diffID\", \"passwd\": \"$passwd\", \"group\": \"$group\"}" > $out/layers-cache.json
+    echo -n "{\"layer_digest\": \"sha256:$sha256\", \"passwd\": \"$passwd\", \"group\": \"$group\", \"compressed_size\": $compressed_size, \"uncompressed_size\": $uncompressed_size}" > $out/layers-cache.json
 
     # Move the compressed layer tarball to the blobs directory and create a symlink
     mkdir -p $out/blobs/sha256


### PR DESCRIPTION
To configure the pod memory requests automatically during `contrast generate`, we need access to the compressed and uncompressed layer sizes used within the pod. The sensible place to do this is during `genpolicy`, since the layers are pulled here anyway. This also means we should use the `layers-cache.json` file to cache the sizes.

The layers cache in `genpolicy` is indexed by the `diffID`, i.e., the hash over the uncompressed layer. If we want to store the compressed layer sizes as well, it only makes sense to change this to the `layer_digest` instead (hash over the compressed layer). Consider the same layer that has been compressed with different compressing options: compressed layer size would differ, but `diffID` would be the same. We have to adjust our precomputation of the layers cache file during the OCI image build accordingly.

Migrating from an old `layers-cache.json` is done automatically by `genpolicy` by discarding an invalid file.

The second step is to get the information of which layer is needed for which pod to Contrast. The layers cache file is a bad place to store this, because
1. we would need some form of unique identifier per pod resource and
2. if the deployment changes, the layers cache file contains stale data (since this is a global cache file, putting any deployment specific data in here wouldn't make much sense anyway).

Since we only ever invoke `genpolicy` on one pod-generating resource at a time, I decided to add another file output, that basically outputs a subset of the layers cache file, containing only the layers used in the processed resource. On Contrast side, we can then parse this file after running `genpolicy` and add up the memory requirements.