### PR TITLE
ci: keep release_promote actions on workflow ref

### DIFF
--- a/.github/actions/prepare_post_release_pr/action.yml
+++ b/.github/actions/prepare_post_release_pr/action.yml
@@ -55,6 +55,17 @@ runs:
         ref: ${{ inputs.checkout_main_ref }}
         path: contrast-main
         persist-credentials: false
+    - name: Verify main version matches release
+      shell: bash
+      working-directory: contrast-main
+      env:
+        EXPECTED_VERSION: ${{ inputs.without_v }}
+      run: |
+        actual=$(sed 's/-.*$//' version.txt)
+        if [[ "${actual}" != "${EXPECTED_VERSION}" ]]; then
+          echo "::error::checkout_main_ref version.txt base version is ${actual}, expected ${EXPECTED_VERSION}."
+          exit 1
+        fi
     - uses: ./.github/actions/setup_nix
       with:
         githubToken: ${{ inputs.github_token }}

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -183,7 +183,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ needs.prepare.outputs.nightly_ref }}
           persist-credentials: false
       - uses: ./.github/actions/prepare_github_release
         with:
@@ -226,7 +225,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ needs.prepare.outputs.nightly_ref }}
           persist-credentials: true
           # edgelessci's token is required to push to the protected release/* branch.
           token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
@@ -235,6 +233,7 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.EFFECTIVE_VERSION }}
           REF: ${{ needs.prepare.outputs.nightly_ref }}
         run: |
+          git fetch origin "${REF}"
           git tag "${VERSION}" "${REF}"
           git push origin "${VERSION}"
       - name: Update release branch to nightly ref


### PR DESCRIPTION
Promotion should use the nightly commit as release data, but the promotion machinery must come from the dispatched workflow ref so fixes on main are not bypassed. Keep the remaining local composite actions on that ref and fetch the nightly commit explicitly before tagging it.

Also guard the post-release PR flow by checking that checkout_main_ref still carries the release version being promoted.