### PR TITLE
ci: cap bm-maintenance jobs at 15m

### DIFF
--- a/.github/workflows/bm_maintenance.yml
+++ b/.github/workflows/bm_maintenance.yml
@@ -135,6 +135,7 @@ jobs:
     name: "Cleanup ${{ matrix.platform.name }}"
     runs-on: ${{ matrix.platform.runner }}
     needs: build-image
+    timeout-minutes: 15
     outputs:
       snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
       tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
@@ -185,6 +186,7 @@ jobs:
     name: "Cleanup Containerd ${{ matrix.platform.name }}"
     runs-on: ${{ matrix.platform.runner }}
     needs: build-image
+    timeout-minutes: 15
     outputs:
       snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
       tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}
@@ -233,6 +235,7 @@ jobs:
     name: "Nix gc ${{ matrix.platform.name }}"
     runs-on: ${{ matrix.platform.runner }}
     needs: build-image
+    timeout-minutes: 15
     outputs:
       snp: ${{ steps.update.outputs.Metal-QEMU-SNP }}
       tdx: ${{ steps.update.outputs.Metal-QEMU-TDX }}


### PR DESCRIPTION
Jobs had no timeout, so they inherited GHA's 360m default. If a step hangs (e.g. the cleanup step's kubectl delete on a stuck Terminating namespace), the job wastes 6h before being reaped.