### PR TITLE
grpc: retry aTLS handshake failures caused by connection resets

### DIFF
--- a/internal/grpc/retry/retry.go
+++ b/internal/grpc/retry/retry.go
@@ -6,14 +6,15 @@ package retry
 
 import (
 	"regexp"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 var (
-	authenticationHandshakeRE = regexp.MustCompile(`transport: authentication handshake failed: ((?:\s|\w)+)`)
-	retriableCauses           = map[string]struct{}{"EOF": {}, "context deadline exceeded": {}}
+	authenticationHandshakeRE = regexp.MustCompile(`transport: authentication handshake failed: (.+)`)
+	retriableCauses           = []string{"EOF", "context deadline exceeded", "connection reset by peer"}
 )
 
 // ServiceIsUnavailable checks if the error is a grpc status with code Unavailable.
@@ -34,6 +35,10 @@ func ServiceIsUnavailable(err error) (ret bool) {
 		return true
 	}
 
-	_, isRetriable := retriableCauses[matches[1]]
-	return isRetriable
+	for _, cause := range retriableCauses {
+		if strings.Contains(matches[1], cause) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -40,6 +40,10 @@ func TestServiceIsUnavailable(t *testing.T) {
 			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: EOF"`),
 			wantUnavailable: true,
 		},
+		"handshake connection reset by peer error": {
+			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: read tcp 192.0.2.1:49240->198.51.100.1:1313: read: connection reset by peer"`),
+			wantUnavailable: true,
+		},
 		"wrapped error": {
 			err:             fmt.Errorf("some wrapping: %w", status.Error(codes.Unavailable, "error")),
 			wantUnavailable: true,


### PR DESCRIPTION
https://github.com/edgelesssys/contrast/actions/runs/26252518697/job/77319263422#step:3:1634 points to a transient failure that triggered a CI failure instead of being autoretried.

The root cause was traced back to our grpc/retry logic which only auto-retries on "EOF" or "context deadline exceeded" but not on "connection reset by peer". 