### PR TITLE
ci: put all docs deploys in one concurrency group

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -27,8 +27,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: docs-deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
-  cancel-in-progress: true
+  group: docs-deploy
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
This is a follow-up improvement to the first PR that uncovered another very rare race. The docs are up-to-date now and I also verified that workflow_dispatch works.

Merging a PR fires two events at once, push to main (production deploy) and pull_request closed (preview cleanup). Both write to gh-pages. The previous per-event grouping put them in different groups so they raced. One shared group makes every write to gh-pages serialize.

cancel-in-progress is only true for push to main: a fresh push should cancel a stale production deploy because only the latest tip matters. Other events (PR sync, PR close, dispatch) queue, so a push doesn't cancel an in-flight PR-preview cleanup (which would orphan the preview dir on gh-pages) and a PR sync doesn't cancel another PR's deploy now that they share a group.

The race was always latent. Historically the production build took 2-3 min because nix had to rebuild the docusaurus site, while preview cleanups finished sooner, so the cleanup commit landed on gh-pages before the production deploy step even started. The PR that added the previous concurrency fix only touched a workflow file, so the docs derivation was unchanged and got substituted from cachix in 16s. Both runs reached the git push step at the same instant and the cleanup won by 3 seconds.