### PR TITLE
ci: cleanup old containerd backups

### DIFF
--- a/packages/cleanup-bare-metal.sh
+++ b/packages/cleanup-bare-metal.sh
@@ -24,6 +24,9 @@ if [[ ${configVersion} != "2" && ${configVersion} != "3" ]]; then
 fi
 echo "Containerd config version: ${configVersion}"
 
+echo "Deleting old containernd config backups ..."
+find "$(dirname "${configFile}")" -maxdepth 1 -type f -name "$(basename "${configFile}").*.bak" -mtime +5 -delete
+
 resourcesToCheck=(
   "pods"
   "deployments"


### PR DESCRIPTION
Cleans up all `config.toml.*.bak` or `config.toml.tmpl.*.bak` in the containerd directory that are older than 5 days.

Workflow run:  https://github.com/edgelesssys/contrast/actions/runs/26757480960