### PR TITLE
flake: bump go to 1.26.4 to fix `govulncheck` findings

### DIFF
--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -15,10 +15,10 @@ final: prev:
 
   go_1_26 = prev.go_1_26.overrideAttrs (
     finalAttrs: _prevAttrs: {
-      version = "1.26.3";
+      version = "1.26.4";
       src = final.fetchurl {
         url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-        hash = "sha256-HGRoddCqh5kTMYTtV895/yS97+jIggRwYCqdPW2Rkrg=";
+        hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
       };
     }
   );


### PR DESCRIPTION
<img width="461" height="263" alt="xkcd" src="https://github.com/user-attachments/assets/7f4cc7a4-7ebf-4c73-ba86-b2dbe1ab35b2" />
