### PR TITLE
kata: propagate (some) early VM errors to k8s

### DIFF
--- a/docs/docs/howto/cluster-setup/bare-metal.md
+++ b/docs/docs/howto/cluster-setup/bare-metal.md
@@ -8,6 +8,10 @@
 - A supported CPU:
   - AMD Epyc 7003 series (Milan)
   - AMD Epyc 9004 series (Genoa)
+- A Linux distribution for the Kubernetes nodes:
+  - Kernel version must be at least 6.11.
+  - The OS must be systemd-based.
+  - The Kernel must be configured to just use cgroupsv2.
 
 </TabItem>
 <TabItem value="intel" label="Intel TDX">
@@ -16,6 +20,10 @@
   - 5th Gen Intel Xeon Scalable Processor
   - Intel Xeon 6 Processors
 - Platform must fulfill the [DIMM requirements](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/03/hardware_selection/#dimm-ie-main-memory-requirements).
+- A Linux distribution for the Kubernetes nodes:
+  - Kernel version must be at least 6.16.
+  - The OS must be systemd-based.
+  - The Kernel must be configured to just use cgroupsv2.
 
 </TabItem>
 </Tabs>

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -121,8 +122,10 @@ func (s StatefulSet) getPods(ctx context.Context, client *Kubeclient, namespace,
 	return client.PodsFromOwner(ctx, namespace, s.kind(), name)
 }
 
-// IsStartingBlocked checks whether the FailedCreatePodSandBox Event occurred which indicates that the SetPolicy request is rejected and the Kata Shim fails to start the Pod sandbox.
-func (c *Kubeclient) IsStartingBlocked(name string, namespace string, resource ResourceWaiter, evt watch.Event, startingPoint time.Time) (bool, error) {
+// IsBlockedByMissingInitdata checks whether a FailedCreatePodSandBox Event occurred that was caused by a missing initdata device.
+//
+// This condition is useful for checking that missing initdata leads to VM failures.
+func (c *Kubeclient) IsBlockedByMissingInitdata(name string, namespace string, resource ResourceWaiter, evt watch.Event, startingPoint time.Time) (bool, error) {
 	switch evt.Type {
 	case watch.Error:
 		return false, fmt.Errorf("watcher of %s %s/%s received an error event", resource.kind(), namespace, name)
@@ -135,13 +138,18 @@ func (c *Kubeclient) IsStartingBlocked(name string, namespace string, resource R
 			return false, fmt.Errorf("watcher received unexpected type %T", evt.Object)
 		}
 
-		// Expected event: Reason: FailedCreatePodSandBox
-		// TODO(jmxnzo): Add patch to the existing error message in Kata Shim, to specifically allow detecting start-up of containers without policy annotation.
-		if (event.LastTimestamp.After(startingPoint)) && event.Reason == "FailedCreatePodSandBox" {
-			logger.Debug("Pod did not start", "name", name, "reason", event.Reason, "timestamp of failure", event.LastTimestamp.String())
-			return true, nil
+		if !event.LastTimestamp.After(startingPoint) {
+			return false, nil
 		}
-		return false, nil
+		if event.Reason != "FailedCreatePodSandBox" {
+			return false, nil
+		}
+		// The message we check for here is written by the initdata-processor.
+		if !strings.Contains(event.Message, "no initdata device found") {
+			return false, nil
+		}
+		logger.Debug("Pod did not start", "name", name, "reason", event.Reason, "message", event.Message, "timestamp of failure", event.LastTimestamp.String())
+		return true, nil
 	default:
 		return false, fmt.Errorf("unexpected watch event while waiting for %s %s/%s: type=%s, object=%#v", resource.kind(), namespace, name, evt.Type, evt.Object)
 	}
@@ -270,7 +278,7 @@ retryLoop:
 			}
 			switch condition {
 			case StartingBlocked:
-				blocked, err := c.IsStartingBlocked(name, namespace, resource, evt, startingPoint)
+				blocked, err := c.IsBlockedByMissingInitdata(name, namespace, resource, evt, startingPoint)
 				if err != nil {
 					return err
 				}

--- a/packages/by-name/kata/runtime/0029-runtime-don-t-attempt-to-clean-up-cgroup-scope.patch
+++ b/packages/by-name/kata/runtime/0029-runtime-don-t-attempt-to-clean-up-cgroup-scope.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Markus Rudy <mr@edgeless.systems>
+Date: Tue, 9 Jun 2026 12:57:42 +0200
+Subject: [PATCH] runtime: don't attempt to clean up cgroup scope
+
+The cleanup (a systemctl stop) is asynchronous by nature, but the
+containerd cgroup code always waits for its completion without
+considering context cancellation etc. This can lead to errors not being
+visible at the Kubernetes level if the scope unit is not stopped before
+the shim is terminated. The result is just a "create container timeout"
+message.
+
+It turns out that removing the scope is optional: containerd will remove
+the parent scope when cleaning up, which results in our scope being
+cleaned up, too.
+
+Included in this commit are two error propagation fixes which should
+make problems with cgroups apparent much earlier. The cgroupv1 code path
+has a similar error, but is not checked because we can't test it.
+Furthermore, the error message mentioned above is improved such that
+it's clearer why we're returning.
+
+Signed-off-by: Markus Rudy <mr@edgeless.systems>
+---
+ src/runtime/pkg/containerd-shim-v2/service.go |  2 +-
+ src/runtime/pkg/resourcecontrol/cgroups.go    | 11 ++++++-----
+ src/runtime/virtcontainers/sandbox.go         |  4 ++++
+ 3 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/src/runtime/pkg/containerd-shim-v2/service.go b/src/runtime/pkg/containerd-shim-v2/service.go
+index c93ebc277d75c057a205dc8cfc4be6aaea901235..46706e72cb8c5885690be786a7aa844b4dd8bb72 100644
+--- a/src/runtime/pkg/containerd-shim-v2/service.go
++++ b/src/runtime/pkg/containerd-shim-v2/service.go
+@@ -431,7 +431,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
+ 
+ 	select {
+ 	case <-ctx.Done():
+-		return nil, errors.Errorf("create container timeout: %v", r.ID)
++		return nil, errors.Errorf("create container RPC expired: %v (id: %s)", ctx.Err(), r.ID)
+ 	case res := <-ch:
+ 		if res.err != nil {
+ 			return nil, res.err
+diff --git a/src/runtime/pkg/resourcecontrol/cgroups.go b/src/runtime/pkg/resourcecontrol/cgroups.go
+index deb472904b82b663213c33e9e567b87f5b7b6363..88f3618072a78fd6f302a465c43bd5a54d817e87 100644
+--- a/src/runtime/pkg/resourcecontrol/cgroups.go
++++ b/src/runtime/pkg/resourcecontrol/cgroups.go
+@@ -213,8 +213,8 @@ func NewSandboxResourceController(path string, resources *specs.LinuxResources,
+ 	//v1 and v2 cgroups against systemd, the following interacts directly with systemd
+ 	//to create the cgroup and then load it using containerd's api.
+ 	//adding runtime process, it makes calling setupCgroups redundant
+-	if createCgroupsSystemd(slice, unit, os.Getpid()); err != nil {
+-		return nil, err
++	if err := createCgroupsSystemd(slice, unit, os.Getpid()); err != nil {
++		return nil, fmt.Errorf("creating systemd cgroup: %w", err)
+ 	}
+ 
+ 	// Create systemd cgroup
+@@ -236,9 +236,10 @@ func NewSandboxResourceController(path string, resources *specs.LinuxResources,
+ 		// load created cgroup and update with resources
+ 		cg, err := cgroupsv2.LoadSystemd(slice, unit)
+ 		if err != nil {
+-			if cg.Update(cgroupsv2.ToResources(&sandboxResources)); err != nil {
+-				return nil, err
+-			}
++			return nil, fmt.Errorf("loading systemd cgroupv2: %w", err)
++		}
++		if err := cg.Update(cgroupsv2.ToResources(&sandboxResources)); err != nil {
++			return nil, fmt.Errorf("updating systemd cgroupv2: %w", err)
+ 		}
+ 		cgroup = cg
+ 	} else {
+diff --git a/src/runtime/virtcontainers/sandbox.go b/src/runtime/virtcontainers/sandbox.go
+index 6ceae42de927cfb1dd5337b45ce2222ed0b8e42b..a4559660222d6ee202bfe7391b17886780ecce01 100644
+--- a/src/runtime/virtcontainers/sandbox.go
++++ b/src/runtime/virtcontainers/sandbox.go
+@@ -2695,6 +2695,10 @@ func (s *Sandbox) resourceControllerUpdate(ctx context.Context) error {
+ // resourceControllerDelete will move the running processes in the sandbox resource
+ // cvontroller to the parent and then delete the sandbox controller.
+ func (s *Sandbox) resourceControllerDelete() error {
++	if resCtrl.IsSystemdCgroup(s.state.SandboxCgroupPath) {
++		s.Logger().Debug("Skipping resource controller deletion on systemd platform")
++		return nil
++	}
+ 	s.Logger().Debugf("Deleting sandbox %s resource controler", s.sandboxController)
+ 	if s.state.SandboxCgroupPath == "" {
+ 		s.Logger().Warnf("sandbox %s resource controler path is empty", s.sandboxController)

--- a/packages/by-name/kata/runtime/package.nix
+++ b/packages/by-name/kata/runtime/package.nix
@@ -184,6 +184,13 @@ buildGoModule (finalAttrs: {
       # Upstream issue: https://github.com/kata-containers/kata-containers/issues/11328.
       # TODO(sse): retire this carry once contrast migrates to runtime-rs.
       ./0028-runtime-stop-shim-cleanup-from-hanging-on-a-dead-kat.patch
+
+      # Don't clean up the Kata cgroup when cleaning up a failed pod. It's unnecessary because it
+      # will be cleaned up by containerd, and it may hide problems if the cleanup takes too long.
+      # No upstream issue because this is unlikely to be accepted upstream as is, and developing a
+      # full fix for all potential configurations is not a good investment of time.
+      # TODO(burgerdev): drop patch after migrating to runtime-rs
+      ./0029-runtime-don-t-attempt-to-clean-up-cgroup-scope.patch
     ];
   };
 


### PR DESCRIPTION
This allows error messages to propagate to the RPC caller (i.e., containerd). 

As an example, I removed the `initdata` annotation from a Contrast pod. Before this change, we saw messages like this in `kubectl describe`:

```
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox "f0e9f9deec7732c28b8f69f9ba6e09fdf7a59da04701dff0f12f74dbfe8aa76a": failed to create containerd task: failed to create shim task: create container timeout: f0e9f9deec7732c28b8f69f9ba6e09fdf7a59da04701dff0f12f74dbfe8aa76a
```

After the change, the error messages show correctly:

```
Failed to create pod sandbox: rpc error: code = PermissionDenied desc = failed to start sandbox "29130d147c4784857969ea65cc2f294a2386367dbdf55b5674a88ddda9d20833": failed to create containerd task: failed to create shim task: "UpdateInterfaceRequest is blocked by policy: /run/measured-cfg/policy.rego:84: Internal error: no initdata device found"
```

---

See the patch commit message for details on what we're doing in Kata, and why it's ok. This PR is probably insufficient to deal with all sorts of VM creation failures. For example, it's unlikely to help if the VM suddenly crashed, or if the agent never started.

Fixes CON-27.