### PR TITLE
kubeclient: simplify waiting logic

### DIFF
--- a/e2e/internal/kubeclient/wait.go
+++ b/e2e/internal/kubeclient/wait.go
@@ -13,10 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	listerscorev1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 )
 
 // WaitForDeployment waits until the Deployment is ready.
@@ -151,68 +147,55 @@ type PodCondition interface {
 	//
 	// It receives a namespaced pod lister and returns true if the desired condition is satisfied,
 	// false if waiting should continue, or an error if something went wrong.
-	Check(listerscorev1.PodLister) (bool, error)
+	Check(PodLister) (bool, error)
+}
+
+// PodLister can list pods in a namespace.
+type PodLister interface {
+	// List all pods matching the label selector.
+	List(selector labels.Selector) (ret []*corev1.Pod, err error)
+}
+
+// ListerFunc is a convenience wrapper to construct a PodLister from a func.
+type ListerFunc func(selector labels.Selector) (ret []*corev1.Pod, err error)
+
+// List implements PodLister.
+func (f ListerFunc) List(selector labels.Selector) (ret []*corev1.Pod, err error) {
+	return f(selector)
 }
 
 // WaitForPodCondition waits until the pods in the given namespace satisfy the given condition or the context expires.
 func (c *Kubeclient) WaitForPodCondition(ctx context.Context, namespace string, podCondition PodCondition) error {
-	logger := c.log.With("namespace", namespace)
-	factory := informers.NewSharedInformerFactoryWithOptions(c.Client, 5*time.Second, informers.WithNamespace(namespace))
+	logger := c.log.With("namespace", namespace).With("condition", podCondition)
 
-	// The notifications channel will be written to whenever the informer records a pod change.
-	notifications := make(chan struct{}, 256)
-	registration, err := factory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(any) {
-			notifications <- struct{}{}
-		},
-		UpdateFunc: func(any, any) {
-			notifications <- struct{}{}
-		},
-		DeleteFunc: func(any) {
-			notifications <- struct{}{}
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("registering informer event handler: %w", err)
-	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	factory.Start(ctx.Done())
-
-	// Prevent the cache from logging "Waiting for caches to sync"/"Caches are synced".
-	ctxLessLogs := klog.NewContext(ctx, klog.Logger{}.V(5))
-	if ok := cache.WaitForNamedCacheSyncWithContext(ctxLessLogs, registration.HasSynced); !ok {
-		return fmt.Errorf("pod informer did not sync")
-	}
-	podLister := factory.Core().V1().Pods().Lister()
-
-loop:
-	for {
-		select {
-		case <-notifications:
-			done, err := podCondition.Check(podLister)
+	poll := func(ctx context.Context) (done bool, err error) {
+		return podCondition.Check(ListerFunc(func(selector labels.Selector) (ret []*corev1.Pod, err error) {
+			podList, err := c.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 			if err != nil {
-				logger.Warn("error checking pods", "error", err)
-				continue
+				logger.Warn("ignoring error encountered while waiting", "err", err)
+				return nil, nil
 			}
-			if done {
-				logger.Debug("done waiting", "condition", podCondition)
-				return nil
+			var out []*corev1.Pod
+			for i := range podList.Items {
+				out = append(out, &podList.Items[i])
 			}
-		case <-ctx.Done():
-			break loop
-		}
+			return out, nil
+		}))
 	}
 
-	logger.Debug("context expired while waiting", "condition", podCondition)
+	err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, poll)
+	if err == nil {
+		return nil
+	}
+
+	logger.Debug("context expired while waiting")
 	// Fetch and print debug information.
-	pods, listPodsErr := podLister.List(labels.Everything())
+	podList, listPodsErr := c.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if listPodsErr != nil {
 		logger.Error("could not fetch pods", "error", listPodsErr)
 		return err
 	}
-	for _, pod := range pods {
+	for _, pod := range podList.Items {
 		logger.Debug("pod status", "name", pod.Name, "status", c.toJSON(pod.Status))
 	}
 	return fmt.Errorf("context expired while waiting: %w", ctx.Err())
@@ -224,7 +207,7 @@ type numReady struct {
 	n  int
 }
 
-func (nm *numReady) Check(lister listerscorev1.PodLister) (bool, error) {
+func (nm *numReady) Check(lister PodLister) (bool, error) {
 	pods, err := lister.List(nm.ls)
 	if err != nil {
 		return false, err
@@ -248,7 +231,7 @@ type numSucceeded struct {
 	n  int
 }
 
-func (ns *numSucceeded) Check(lister listerscorev1.PodLister) (bool, error) {
+func (ns *numSucceeded) Check(lister PodLister) (bool, error) {
 	pods, err := lister.List(ns.ls)
 	if err != nil {
 		return false, err
@@ -271,7 +254,7 @@ type singlePodReady struct {
 	name string
 }
 
-func (f *singlePodReady) Check(lister listerscorev1.PodLister) (bool, error) {
+func (f *singlePodReady) Check(lister PodLister) (bool, error) {
 	pods, err := lister.List(labels.Everything())
 	if err != nil {
 		return false, err
@@ -295,7 +278,7 @@ type containerReady struct {
 	containerName string
 }
 
-func (cr *containerReady) Check(lister listerscorev1.PodLister) (bool, error) {
+func (cr *containerReady) Check(lister PodLister) (bool, error) {
 	pods, err := lister.List(labels.Everything())
 	if err != nil {
 		return false, err
@@ -316,7 +299,7 @@ type containerRunning struct {
 	containerName string
 }
 
-func (cr *containerRunning) Check(lister listerscorev1.PodLister) (bool, error) {
+func (cr *containerRunning) Check(lister PodLister) (bool, error) {
 	pods, err := lister.List(cr.ls)
 	if err != nil {
 		return false, err

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	listerscorev1 "k8s.io/client-go/listers/core/v1"
 )
 
 const (
@@ -259,7 +258,7 @@ type initContainerRunningCondition struct {
 	name string
 }
 
-func (c *initContainerRunningCondition) Check(lister listerscorev1.PodLister) (bool, error) {
+func (c *initContainerRunningCondition) Check(lister kubeclient.PodLister) (bool, error) {
 	pods, err := lister.List(labels.Everything())
 	if err != nil {
 		return false, err

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
-	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 )
 
@@ -69,7 +68,6 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-configfs-tsm v0.3.3 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -101,6 +99,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/packages/by-name/contrast/contrast/package.nix
+++ b/packages/by-name/contrast/contrast/package.nix
@@ -53,7 +53,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-JhEQPZ9wow8beG24m3jW3H9Q5TGOjLBAaH2fDJtdp7U=";
+  vendorHash = "sha256-JIp9Dn+i/6Ac3SqH8YuK97OKUQom55WxPcGXVKovKdE=";
 
   subPackages = packageOutputs;
 


### PR DESCRIPTION
The notification-based waiting logic was implemented when we did not know about the wait package yet. Since we saw a couple of CI flakes that can be explained by missed notifications (pod was ready, but test logic said it wasn't), moving to a polling model might be more robust, albeit a bit wasteful. In any case, the polling logic is much easier to reason about.

Fixes CON-33.