### PR TITLE
packages: fix scripts not propagating from packages to scripts.nix

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -17,7 +17,9 @@ in
 byName.overrideScope (
   _final: prev: {
     contrastPkgsStatic = pkgs.pkgsStatic.contrastPkgs;
-    scripts = prev.scripts.overrideScope (_: _: pkgs.callPackages ./scripts.nix { });
+    scripts = prev.scripts.overrideScope (
+      final: _: pkgs.callPackages ./scripts.nix { scripts = final; }
+    );
     containers = pkgs.callPackages ./containers.nix { };
     container-scripts = pkgs.callPackages ./container-scripts.nix { };
     contrast-releases = pkgs.callPackages ./contrast-releases.nix { };

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -6,9 +6,10 @@
   pkgs,
   contrastPkgs,
   writeShellApplication,
+  scripts,
 }:
 
-lib.makeScope pkgs.newScope (scripts: {
+{
   generate = writeShellApplication {
     name = "generate";
     runtimeInputs = with pkgs; [
@@ -764,4 +765,4 @@ lib.makeScope pkgs.newScope (scripts: {
       mdsh --inputs "$@"
     '';
   };
-})
+}


### PR DESCRIPTION
Noticed during #2440. Scripts defined in `by-name` were not accessible in `scripts.nix`.