### PR TITLE
overlays/runtimepkgs: fix outdated package references

### DIFF
--- a/overlays/runtimepkgs.nix
+++ b/overlays/runtimepkgs.nix
@@ -57,7 +57,6 @@ else
         kata = cPrev.kata.overrideScope (
           _: _: {
             inherit (final.runtimePkgs.kata)
-              contrast-node-installer-image
               agent
               image
               kernel-uvm
@@ -75,7 +74,7 @@ else
               node-installer-image
               nodeinstaller
               reference-values
-              snp-id-blocks
+              snp-launch-digests
               ;
           }
         );


### PR DESCRIPTION
Noticed in #2034. Not great that this was able to happen unnoticed, but hey, at least these things should now always be caught with the matrix output.