### PR TITLE
.github: bump sev-snp-measure-consistency timeout

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -184,7 +184,7 @@ jobs:
 
   sev-snp-measure-consistency:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
     env:


### PR DESCRIPTION
I don't think this completed in-time even once 😄 