### PR TITLE
ci: wait for contrast-system deletion in release e2e cleanup

### DIFF
--- a/.github/actions/release_e2e_test/action.yml
+++ b/.github/actions/release_e2e_test/action.yml
@@ -167,6 +167,11 @@ runs:
       shell: bash
       run: |
         kubectl delete -f workspace/log-collector.yaml
+        # Wait for contrast-system to be fully gone so the next same-cluster
+        # matrix entry doesn't race this job's async namespace teardown.
+        if kubectl get namespace contrast-system >/dev/null 2>&1; then
+          kubectl wait --for=delete namespace/contrast-system --timeout=3m
+        fi
         rm -f workspace/just.namespace
     - name: Upload logs
       if: always()


### PR DESCRIPTION
Same-cluster matrix entries are serialized, but the namespace delete finalizes asynchronously, so the next entry could race a still-Terminating contrast-system. Block until it's gone.

Fix for  https://github.com/edgelesssys/contrast/actions/runs/27235297604/job/80462312665