### PR TITLE
e2e/release: restrict node-installers to their intended nodes

### DIFF
--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/internal/userapi"
 	"github.com/google/go-github/v85/github"
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,10 @@ func TestRelease(t *testing.T) {
 		require.NoError(err)
 		resources, err := kuberesource.UnmarshalUnstructuredK8SResource(yaml)
 		require.NoError(err)
+
+		platform, err := platforms.FromString(*platformStr)
+		require.NoError(err)
+		require.NoError(patchNodeInstallers(resources, platform))
 
 		require.NoError(k.Apply(ctx, resources...))
 
@@ -357,6 +362,44 @@ func fetchRelease(ctx context.Context, t *testing.T) string {
 	}
 
 	return dir
+}
+
+// patchNodeInstallers restricts the node-installer DaemonSets to the intended nodes.
+func patchNodeInstallers(resources []*unstructured.Unstructured, platform platforms.Platform) error {
+	matchExpressions := []any{
+		map[string]any{
+			"key":      kuberesource.MainRunnerNodeLabel,
+			"operator": "In",
+			"values":   []any{"true"},
+		},
+	}
+	if platform == platforms.MetalQEMUTDXGPU {
+		matchExpressions = append(matchExpressions, map[string]any{
+			"key":      kuberesource.TDXEnabledNodeLabel,
+			"operator": "In",
+			"values":   []any{"true"},
+		})
+	}
+	affinity := map[string]any{
+		"nodeAffinity": map[string]any{
+			"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+				"nodeSelectorTerms": []any{
+					map[string]any{
+						"matchExpressions": matchExpressions,
+					},
+				},
+			},
+		},
+	}
+	for _, r := range resources {
+		if r.GetKind() != "DaemonSet" {
+			continue
+		}
+		if err := unstructured.SetNestedMap(r.Object, affinity, "spec", "template", "spec", "affinity"); err != nil {
+			return fmt.Errorf("setting node affinity on DaemonSet %q: %w", r.GetName(), err)
+		}
+	}
+	return nil
 }
 
 func TestMain(m *testing.M) {

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -32,6 +32,12 @@ const (
 	securePVAnnotationKey         = "contrast.edgeless.systems/secure-pv"
 	workloadSecretIDAnnotationKey = "contrast.edgeless.systems/workload-secret-id"
 	imageStoreSizeAnnotationKey   = "contrast.edgeless.systems/image-store-size"
+
+	// TDXEnabledNodeLabel is the node-feature-discovery label that marks a node as TDX-capable.
+	TDXEnabledNodeLabel = "feature.node.kubernetes.io/tdx.enabled"
+
+	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
+	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"
 )
 
 // contrastRuntimeClassPrefixes lists runtime class prefixes that identify Contrast pods.
@@ -620,7 +626,7 @@ func PatchNodeInstallers(resources []any, platform platforms.Platform) ([]any, e
 					applycorev1.NodeSelector().WithNodeSelectorTerms(
 						applycorev1.NodeSelectorTerm().WithMatchExpressions(
 							applycorev1.NodeSelectorRequirement().
-								WithKey("feature.node.kubernetes.io/tdx.enabled").
+								WithKey(TDXEnabledNodeLabel).
 								WithOperator(corev1.NodeSelectorOpIn).
 								WithValues("true"),
 						),
@@ -750,7 +756,7 @@ func PatchNodeSelector(resources []any) []any {
 				return spec
 			}
 			spec = spec.WithNodeSelector(map[string]string{
-				"ci.contrast.edgeless.systems/main-runner": "true",
+				MainRunnerNodeLabel: "true",
 			})
 			return spec
 		}))


### PR DESCRIPTION
Mirrors what the "normal" e2es are doing with `PatchNodeInstallers`. Not reused sadly, because it requires typed args, and converting the yaml into something typed and then back goes against the intention of using the "raw" released yaml.