### PR TITLE
imagepuller: reclaim storage from unreferenced containers

### DIFF
--- a/imagepuller/internal/service/mount_linux.go
+++ b/imagepuller/internal/service/mount_linux.go
@@ -15,7 +15,10 @@ import (
 )
 
 func (s *ImagePullerService) createAndMountContainer(log *slog.Logger, imageID, bundlePath string) (string, error) {
-	container, err := s.Store.CreateContainer("", nil, imageID, "", "", nil)
+	rootfs := filepath.Join(bundlePath, "rootfs")
+
+	// Store the rootfs path as the container's metadata so that orphaned containers can be reclaimed later (see cleanupOrphanedContainers)
+	container, err := s.Store.CreateContainer("", nil, imageID, "", rootfs, nil)
 	if err != nil {
 		return "", fmt.Errorf("creating container: %w", err)
 	}
@@ -27,7 +30,6 @@ func (s *ImagePullerService) createAndMountContainer(log *slog.Logger, imageID, 
 	}
 	log.Debug("Mounted in store", "mountPoint", mountPoint)
 
-	rootfs := filepath.Join(bundlePath, "rootfs")
 	if err := os.MkdirAll(rootfs, 0o755); err != nil {
 		return "", fmt.Errorf("creating bundle path: %w", err)
 	}

--- a/imagepuller/internal/service/service.go
+++ b/imagepuller/internal/service/service.go
@@ -5,7 +5,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -72,6 +74,8 @@ func (s *ImagePullerService) PullImage(
 	}
 	s.Store = store
 
+	s.cleanupOrphanedContainers(log, store)
+
 	cachedID, err := s.Store.Lookup(r.ImageUrl)
 	if err == nil {
 		rootfs, err := s.createAndMountContainer(log, cachedID, r.BundlePath)
@@ -97,7 +101,8 @@ func (s *ImagePullerService) PullImage(
 		return nil, fmt.Errorf("determining available storage: %w", err)
 	}
 	if availableStorage < requiredStorage {
-		return nil, fmt.Errorf("insufficient storage: pulling %q would require at least %s, but only %s are currently available. Increase the memory limit or image store size",
+		return nil, fmt.Errorf(
+			"insufficient storage: pulling %q would require at least %s, but only %s are currently available. Increase the memory limit or image store size",
 			r.ImageUrl,
 			formatBytes(requiredStorage),
 			formatBytes(availableStorage),
@@ -130,6 +135,39 @@ func (s *ImagePullerService) PullImage(
 	log.Info("Pulled and mounted image", "mount_path", rootfs)
 
 	return &katacomponents.ImagePullResponse{}, nil
+}
+
+// cleanupOrphanedContainers removes store containers whose bundle has been torn down by the kata agent.
+// Image pulls always create new store containers with their own read-write layer. The agent only unmounts and removes the bundle rootfs on teardown.
+// We use the rootfs path recorded as the container's metadata to check if the store container is orphaned and its layer can be reclaimed.
+func (s *ImagePullerService) cleanupOrphanedContainers(log *slog.Logger, store storage.Store) {
+	containers, err := store.Containers()
+	if err != nil {
+		log.Warn("listing containers for cleanup", "err", err)
+		return
+	}
+
+	for _, c := range containers {
+		rootfs := c.Metadata
+		if rootfs == "" {
+			continue
+		}
+		if _, err := os.Stat(rootfs); err == nil {
+			continue // rootfs still present -> container is in use.
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			log.Warn("checking container rootfs", "id", c.ID, "rootfs", rootfs, "err", err)
+			continue
+		}
+
+		if _, err := store.Unmount(c.ID, true); err != nil {
+			log.Warn("unmounting orphaned container", "id", c.ID, "err", err)
+		}
+		if err := store.DeleteContainer(c.ID); err != nil {
+			log.Warn("deleting orphaned container", "id", c.ID, "err", err)
+			continue
+		}
+		log.Info("Reclaimed orphaned container rw layers", "id", c.ID, "rootfs", rootfs)
+	}
 }
 
 func (s *ImagePullerService) minimumRequiredStorage(remoteImg gcr.Image) (uint64, error) {

--- a/imagepuller/internal/service/service_test.go
+++ b/imagepuller/internal/service/service_test.go
@@ -5,10 +5,37 @@ package service
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.podman.io/storage"
 )
+
+func TestCleanupOrphanedContainers(t *testing.T) {
+	require := require.New(t)
+
+	// live rootfs exists on disk, orphan and gone do not.
+	tmp := t.TempDir()
+	liveRootfs := filepath.Join(tmp, "live", "rootfs")
+	require.NoError(os.MkdirAll(liveRootfs, 0o755))
+
+	store := &stubStore{
+		containers: []storage.Container{
+			{ID: "live", Metadata: liveRootfs},
+			{ID: "orphan", Metadata: filepath.Join(tmp, "orphan", "rootfs")},
+			{ID: "no-metadata"},
+		},
+	}
+	s := &ImagePullerService{Logger: slog.New(slog.DiscardHandler)}
+
+	s.cleanupOrphanedContainers(s.Logger, store)
+
+	require.Equal([]string{"orphan"}, store.deleted)
+	require.Equal([]string{"orphan"}, store.unmounted)
+}
 
 func Test_formatBytes(t *testing.T) {
 	tests := []struct {

--- a/imagepuller/internal/service/stubs_test.go
+++ b/imagepuller/internal/service/stubs_test.go
@@ -19,6 +19,11 @@ type stubStore struct {
 	putLayerDigest digest.Digest
 	putLayerErr    error
 
+	containers    []storage.Container
+	containersErr error
+	unmounted     []string
+	deleted       []string
+
 	storage.Store
 }
 
@@ -27,6 +32,20 @@ func (s *stubStore) PutLayer(_, _ string, _ []string, _ string, _ bool, _ *stora
 		return nil, 0, s.putLayerErr
 	}
 	return &storage.Layer{CompressedDigest: s.putLayerDigest}, 0, nil
+}
+
+func (s *stubStore) Containers() ([]storage.Container, error) {
+	return s.containers, s.containersErr
+}
+
+func (s *stubStore) Unmount(id string, _ bool) (bool, error) {
+	s.unmounted = append(s.unmounted, id)
+	return true, nil
+}
+
+func (s *stubStore) DeleteContainer(id string) error {
+	s.deleted = append(s.deleted, id)
+	return nil
 }
 
 type stubRemote struct {


### PR DESCRIPTION
Multiple restarts of a container could lead to the pod VM storage filling up, esp. if the container wrote to disk during its lifetime.
While the imagepuller does reuse cached images, the image store did not clean up the store container's unreferenced layers.
This is now fixed, and the imagepuller cleans the store of unreferenced containers before creating a new container.

Reproducer:
1. run `just` on main
2. run 
    ```
    n=0
    while [ "$n" -lt 8 ]; do
      id=$(crictl ps -q --name openssl-backend | head -n1)
      [ -z "$id" ] && { sleep 2; continue; }
      echo "round $n: $id"
      crictl exec "$id" sh -c 'dd if=/dev/zero of=/leak.bin bs=1M count=200' || echo "  write failed (store full?)"
      crictl stop "$id" >/dev/null 2>&1 || true
      n=$((n+1))
      # wait for the replacement container before the next round
      for _ in $(seq 1 30); do
        new=$(crictl ps -q --name openssl-backend | head -n1)
        [ -n "$new" ] && [ "$new" != "$id" ] && break
        sleep 1
      done
    done
    ```
    from the node
3. see that eventually, new containers fail to come up due to lack of storage
4. do the same on this branch, containers continue to come up and the journalctl log for the imagepuller contains cleanup messages