### PR TITLE
e2e/policy: accept any running init container

### DIFF
--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -267,12 +267,15 @@ func (c *initContainerRunningCondition) Check(lister kubeclient.PodLister) (bool
 		if pod.Name != c.name {
 			continue
 		}
+		// Any running init container suffices: in debug shell mode a second
+		// init container waits behind contrast-initializer, which never
+		// completes for a pod removed from the manifest.
 		for _, container := range pod.Status.InitContainerStatuses {
-			if container.State.Running == nil {
-				return false, nil
+			if container.State.Running != nil {
+				return true, nil
 			}
 		}
-		return true, nil
+		return false, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
initContainerRunningCondition required all of a pod's init containers to be running. In the debug shell variant a second init container waits behind contrast-initializer, which never completes for a pod removed from the manifest, so the condition was unsatisfiable and the subtest hung until its deadline.

Return success on the first running init container, matching the condition's intent ("has a running initContainer").

This flaw was masked until now. The earlier pods[0] bug meant the condition inspected an arbitrary pod rather than the pinned one, so the all-must-run loop never ran against the debug shell pod. That bug was in turn hidden by the informer's randomised list order, which usually landed on a pod that satisfied the check, leaving only an occasional flake. Switching to a polling API List (a253b4e97e) made the order deterministic and the failure constant, and fixing pod selection (7e15fb00e4) fixed the normal variant while finally exposing the all-vs-any flaw on the four metal policy (with debug shell) jobs.

Closes CON-172.