### PR TITLE
e2e: add IPSec test

### DIFF
--- a/.github/workflows/e2e_manual.yml
+++ b/.github/workflows/e2e_manual.yml
@@ -19,6 +19,7 @@ on:
           - gpu
           - imagepuller-auth
           - imagestore
+          - ipsec
           - kds-pcs-downtime
           - memdump
           - multi-runtime-class

--- a/.github/workflows/e2e_nightly_platform.yml
+++ b/.github/workflows/e2e_nightly_platform.yml
@@ -48,6 +48,7 @@ jobs:
           - gpu
           - imagepuller-auth
           - imagestore
+          - ipsec
           - kds-pcs-downtime
           - memdump
           - multi-runtime-class

--- a/e2e/ipsec/ipsec_test.go
+++ b/e2e/ipsec/ipsec_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build e2e
+
+package ipsec
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	initiatorVIP = "192.0.2.1"
+	responderVIP = "192.0.2.2"
+)
+
+// TestIPSec ensures that Contrast guests can use kernel-managed IPSec with mesh certificates.
+//
+// The test spawns two mostly symmetric pods, both using strongSwan. Since the IP addresses are
+// dynamic, the test first fetches these and then continues with the IPSec configuration. One pod,
+// the initiator, initiates an IKEv2 handshake, while the responder just waits until the handshake
+// arrives. Afterwards, both pods are connected via IPSec tunnel and can reach each other on their
+// respective tunnel IPs (192.0.2.0/24, which would normally not be routed).
+func TestIPSec(t *testing.T) {
+	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
+	require.NoError(t, err)
+	ct := contrasttest.New(t)
+
+	runtimeHandler, err := manifest.RuntimeHandler(platform)
+	require.NoError(t, err)
+
+	resources := kuberesource.IPSec()
+	coordinator := kuberesource.CoordinatorBundle()
+
+	resources = append(resources, coordinator...)
+
+	resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
+
+	resources = kuberesource.AddPortForwarders(resources)
+
+	ct.Init(t, resources)
+	require.True(t, t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+
+	require.True(t, t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
+
+	require.True(t, t.Run("contrast verify", ct.Verify), "contrast verify needs to succeed for subsequent tests")
+
+	t.Run("ipsec tunnel", func(t *testing.T) {
+		require := require.New(t)
+
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(5*time.Minute))
+		defer cancel()
+
+		require.NoError(ct.Kubeclient.WaitForDeployment(ctx, ct.Namespace, "ipsec"))
+
+		pods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, "ipsec")
+		require.NoError(err)
+		require.Len(pods, 2)
+
+		initiator := pods[0]
+		responder := pods[1]
+
+		// Configure the responder first so that it's ready when the initiator initiates.
+		configureCmd := configurationScript(responder.Status.PodIP, initiator.Status.PodIP, responderVIP, initiatorVIP, "none")
+		stdout, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, pods[1].Name, []string{"/bin/sh", "-c", configureCmd})
+		t.Logf("responder configure stdout:\n%s", stdout)
+		require.NoError(err, "responder configure stderr:\n%s", stderr)
+
+		configureCmd = configurationScript(initiator.Status.PodIP, responder.Status.PodIP, initiatorVIP, responderVIP, "start")
+		stdout, stderr, err = ct.Kubeclient.Exec(ctx, ct.Namespace, pods[0].Name, []string{"/bin/sh", "-c", configureCmd})
+		t.Logf("initiator configure stdout:\n%s", stdout)
+		require.NoError(err, "initiator configure stderr:\n%s", stderr)
+
+		// Wait until the tunnel is ready.
+		require.EventuallyWithT(func(t *assert.CollectT) {
+			// ping will return 0 if at least one reply was received. Let's be generous and try
+			// three times, with 5s timeout.
+			pingCmd := fmt.Sprintf("ping -c 3 -W 5 %s", responderVIP)
+			stdout, stderr, err = ct.Kubeclient.Exec(ctx, ct.Namespace, initiator.Name, []string{"/bin/sh", "-c", pingCmd})
+			assert.NoError(t, err, "ping failed:\nstdout:%s\nstderr:%s", stdout, stderr)
+		}, time.Minute, 3*time.Second)
+	})
+}
+
+const swanctlConfTemplate = `
+connections {
+    ipsec {
+        version = 2
+
+        local_addrs = %s
+        remote_addrs = %s
+
+        encap = yes
+
+        local {
+            auth = pubkey
+        }
+
+        remote {
+            auth = pubkey
+            id = %%any
+        }
+
+        children {
+            ipsec {
+                local_ts = %s/32
+                remote_ts = %s/32
+                start_action = %s
+            }
+        }
+    }
+}`
+
+func configurationScript(localAddr, remoteAddr, localVIP, remoteVIP string, startAction string) string {
+	return strings.Join([]string{
+		fmt.Sprintf("ip addr add %s/32 dev lo", localVIP),
+		"cat > /etc/swanctl/swanctl.conf << 'EOF'",
+		fmt.Sprintf(swanctlConfTemplate, localAddr, remoteAddr, localVIP, remoteVIP, startAction),
+		"EOF",
+		"swanctl --load-all",
+	}, "\n")
+}
+
+func TestMain(m *testing.M) {
+	contrasttest.RegisterFlags()
+	flag.Parse()
+
+	os.Exit(m.Run())
+}

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -1189,6 +1189,33 @@ func Containerd11644ReproducerTesters(name string) (*applyappsv1.DeploymentApply
 	return runc, cc
 }
 
+// IPSec returns the resources for testing IPSec tunnels with strongSwan.
+func IPSec() []any {
+	deploy := Deployment("ipsec", "").
+		WithSpec(DeploymentSpec().
+			WithReplicas(2).
+			WithSelector(LabelSelector().
+				WithMatchLabels(map[string]string{"app.kubernetes.io/name": "ipsec"}),
+			).
+			WithTemplate(PodTemplateSpec().
+				WithLabels(map[string]string{"app.kubernetes.io/name": "ipsec"}).
+				WithSpec(PodSpec().
+					WithContainers(
+						Container().
+							WithName("ipsec").
+							WithImage("ghcr.io/edgelesssys/contrast/strongswan:latest").
+							WithSecurityContext(SecurityContext().WithPrivileged(true).SecurityContextApplyConfiguration).
+							WithResources(ResourceRequirements().
+								WithMemoryLimitAndRequest(800),
+							),
+					),
+				),
+			),
+		)
+
+	return []any{deploy}
+}
+
 // DeploymentWithRuntimeClass returns a example with the given runtimeClassName.
 func DeploymentWithRuntimeClass(name, runtimeClassName string) any {
 	return Deployment(name, "").

--- a/justfile
+++ b/justfile
@@ -105,7 +105,7 @@ e2e target=default_deploy_target platform=default_platform set=default_set:
     echo "Using set=$RESOLVED_SET, debug=$RESOLVED_DEBUG for test '{{ target }}'"
     set="$RESOLVED_SET" debug="$RESOLVED_DEBUG" just _e2e {{ target }} {{ platform }}
 
-_e2e target=default_deploy_target platform=default_platform set=default_set: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy memdump debugshell k8s-log-collector (node-installer platform)
+_e2e target=default_deploy_target platform=default_platform set=default_set: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy memdump debugshell k8s-log-collector strongswan (node-installer platform)
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ {{ platform }} == "Metal-QEMU-SNP-GPU" || {{ platform }} == "Metal-QEMU-TDX-GPU" ]] ; then

--- a/justfile
+++ b/justfile
@@ -31,6 +31,8 @@ debugshell: (push "debugshell")
 
 k8s-log-collector: (push "k8s-log-collector")
 
+strongswan: (push "strongswan")
+
 # Download all logs (pod logs + host journal). Deploys the log-collector if not already running.
 download-logs set=default_set:
     #!/usr/bin/env bash

--- a/packages/by-name/contrast/e2e/package.nix
+++ b/packages/by-name/contrast/e2e/package.nix
@@ -74,6 +74,7 @@ buildGoModule {
     "e2e/gpu"
     "e2e/imagepuller-auth"
     "e2e/imagestore"
+    "e2e/ipsec"
     "e2e/kds-pcs-downtime"
     "e2e/memdump"
     "e2e/multi-runtime-class"

--- a/packages/by-name/strongswan-image/package.nix
+++ b/packages/by-name/strongswan-image/package.nix
@@ -1,0 +1,21 @@
+# Copyright 2024 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{
+  runCommand,
+}:
+
+runCommand "strongswan-rootfs" { } ''
+  mkdir -p \
+    $out/etc/strongswan.d \
+    $out/etc/swanctl/x509 \
+    $out/etc/swanctl/private \
+    $out/etc/swanctl/x509ca \
+    $out/var/run
+
+  cp -r ${./strongswan.conf} $out/etc/strongswan.conf
+
+  ln -s /contrast/tls-config/certChain.pem $out/etc/swanctl/x509/certChain.pem
+  ln -s /contrast/tls-config/key.pem $out/etc/swanctl/private/key.pem
+  ln -s /contrast/tls-config/mesh-ca.pem $out/etc/swanctl/x509ca/mesh-ca.pem
+''

--- a/packages/by-name/strongswan-image/strongswan.conf
+++ b/packages/by-name/strongswan-image/strongswan.conf
@@ -1,0 +1,21 @@
+charon {
+    # Log to stderr with increased verbosity for important subsystems.
+    filelog {
+        stderr {
+            path = stderr
+            flush_line = yes
+
+            ike_name = yes
+
+            default = 1
+            ike = 2
+            cfg = 2
+            enc = 2
+            net = 2
+        }
+    }
+
+    # Disable syslog.
+    syslog {
+    }
+}

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -171,4 +171,20 @@
       Volumes."/logs" = { };
     };
   };
+
+  strongswan = contrastPkgs.buildOciImage {
+    name = "strongswan";
+    tag = "0.1.0";
+    copyToRoot = with pkgs; [
+      bash
+      coreutils
+      iproute2
+      iputils
+      strongswan
+      contrastPkgs.strongswan-image
+    ];
+    config = {
+      Cmd = [ "${pkgs.strongswan}/libexec/ipsec/charon" ];
+    };
+  };
 }


### PR DESCRIPTION
This PR adds an e2e test that ensures our image supports IPSec.

* Publish a container image with strongswan and some basic configuration tailored to Contrast.
* Spawn two strongswan pods that establish a VPN tunnel between them.

Fixes CON-38.

- [x] [ipsec test](https://github.com/edgelesssys/contrast/actions/runs/27758704295)