### PR TITLE
e2e: drop the OpenBao liveness probe from the vault e2e test

### DIFF
--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -892,15 +892,6 @@ seal "transit" {
 									WithPeriodSeconds(1).
 									WithFailureThreshold(10),
 								).
-								WithLivenessProbe(applycorev1.Probe().
-									WithHTTPGet(applycorev1.HTTPGetAction().
-										WithPort(intstr.FromInt(8200)).
-										WithScheme(corev1.URISchemeHTTPS).
-										WithPath("/v1/sys/seal-status"),
-									).
-									WithPeriodSeconds(5).
-									WithFailureThreshold(3),
-								).
 								WithReadinessProbe(applycorev1.Probe().
 									WithHTTPGet(applycorev1.HTTPGetAction().
 										WithPort(intstr.FromInt(8200)).


### PR DESCRIPTION
`bao operator init` is a one-time setup that is normally sub-second, but it
occasionally blocks for ~10s, and while it runs the server stops answering
its seal-status health check. The liveness probe read that as a hang, so the
kubelet restarted the container in the middle of init and the test failed.
(The restart kills the init command; kata reports it as a confusing "exit
code 9", see kata-containers#13251.)

The liveness probe's only job is to restart a wedged container, which on
this deployment is low value: the startupProbe already gates boot and the
readinessProbe gates traffic, and a genuinely hung vault is rare and
operator-recoverable. Removing it eliminates the mid-init restart entirely
rather than just widening the window. The stall is a blocking wait, not CPU
starvation (the guest stays scheduled throughout); the likely cause is a
transient slow disk, but that was not confirmed.

Closes CON-175