### PR TITLE
kata: do not build standalone crate2nix packages 

### DIFF
--- a/lib/matrix.nix
+++ b/lib/matrix.nix
@@ -61,6 +61,7 @@ rec {
           "contrastPkgsStatic"
           "contrast-releases"
           "matrix"
+          "cargoNixPackage" # crate2nix standalone outputs
         ] pkgs.contrastPkgs
       )
     );

--- a/packages/by-name/boot-microvm/package.nix
+++ b/packages/by-name/boot-microvm/package.nix
@@ -3,7 +3,7 @@
 
 {
   writeShellApplication,
-  qemu,
+  qemu-cc,
   OVMF,
 }:
 
@@ -13,11 +13,7 @@
 writeShellApplication {
   name = "boot-microvm";
   runtimeInputs = [
-    (qemu.override {
-      minimal = true;
-      hostCpuOnly = true;
-      enableBlobs = true;
-    })
+    qemu-cc
   ];
   text = ''
     if [[ $# -ne 4 ]]; then

--- a/packages/by-name/qemu-cc/package.nix
+++ b/packages/by-name/qemu-cc/package.nix
@@ -6,6 +6,7 @@
   qemu,
   libaio,
   dtc,
+  libtasn1,
   python3Packages,
   gpuSupport ? false,
 }:
@@ -26,7 +27,14 @@
     # The upstream derivation removes the dtc dependency when minimal is set,
     # but QEMU needs it when not only building usermode emulators.
     # TODO(freax13): Fix this upstream.
-    buildInputs = previousAttrs.buildInputs ++ [ dtc ];
+    #
+    # libtasn1 is also dropped by the minimal build, which leaves CONFIG_TASN1 unset.
+    # QEMU 11.0.0's tests/qtest/migration/tls-tests.c references its x509 helpers without guarding them on CONFIG_TASN1.
+    # We don't even run that test.
+    buildInputs = previousAttrs.buildInputs ++ [
+      dtc
+      libtasn1
+    ];
 
     nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [ python3Packages.packaging ];
 


### PR DESCRIPTION
- [x] [build and cache](https://github.com/edgelesssys/contrast/actions/runs/27954090262)

This removes the `cargoNixPackage.*` standalone rust dependency packages generated by `crate2nix` from the matrix. Those actually required by the subset of crates we build and the features we enable are still built as part of those crates, of course.

As far as I can tell this was a perfect storm of runtime-rs and the crate2nix and matrix PRs all contributing their individual bits of the puzzle for this error to occur 😂 