### PR TITLE
e2e: scale node-installer installation timeout with platform

### DIFF
--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -484,7 +484,7 @@ func (ct *ContrastTest) commonArgs() []string {
 func (ct *ContrastTest) installRuntime(t *testing.T, resources []any) {
 	require := require.New(t)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(3*time.Minute))
 	defer cancel()
 
 	var nodeInstallerDeps []any


### PR DESCRIPTION
22:35:38: started pulling node-installer img
22:38:48, 2m49s later: installer starts
22:38:57: node-installer is done
22:38:58: 3m context deadline expires, failure
22:38:59: pause container we've been waiting for comes up

This was just unlucky timing / slow pull speed. But since we're scaling almost all our timeouts for the GPU platforms, I think scaling the pull timeout for the larger node-installer images is justified.