### PR TITLE
manifest: allow more than one Coordinator policy

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -250,13 +250,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	mnf.Policies = policyMap
 	// Existing manifests are already validated above, but newly generated manifests may be missing reference values or a coordinator.
-	var ce *manifest.CoordinatorCountError
 	var ve *manifest.ValidationError
-	if err := mnf.Validate(); errors.As(err, &ce) {
-		if ce.Count == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "  No Coordinator resource found, did you forget to add it to your resources?")
-		}
-		return ce
+	if err := mnf.Validate(); errors.Is(err, manifest.ErrMissingCoordinator) {
+		fmt.Fprintln(cmd.OutOrStdout(), "  No Coordinator resource found, did you forget to add it to your resources?")
+		return err
 	} else if errors.As(err, &ve) && ve.OnlyExpectedMissingReferenceValues() {
 		for _, e := range ve.Unwrap() {
 			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", e)

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -42,7 +42,6 @@ import (
 const (
 	annotationPrefix              = "contrast.edgeless.systems/"
 	kataAnnotationPrefix          = "io.katacontainers.config.hypervisor."
-	contrastRoleAnnotationKey     = annotationPrefix + "pod-role"
 	workloadSecretIDAnnotationKey = annotationPrefix + "workload-secret-id"
 	idBlockAnnotation             = kataAnnotationPrefix + "snp_id_block_"
 	idAuthAnnotationKey           = kataAnnotationPrefix + "snp_id_auth_"
@@ -350,7 +349,7 @@ func isCoordinator(resource any) bool {
 		r.Spec.Template != nil &&
 		r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 		r.Spec.Template.Annotations != nil &&
-		r.Spec.Template.Annotations[contrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
+		r.Spec.Template.Annotations[kuberesource.ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
 		return true
 	}
 	return false

--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -73,7 +73,7 @@ func policiesFromKubeResources(fileMap map[string][]*unstructured.Unstructured) 
 				return meta, spec
 			}
 			annotation = meta.Annotations[initdata.InitdataAnnotationKey]
-			role = manifest.Role(meta.Annotations[contrastRoleAnnotationKey])
+			role = manifest.Role(meta.Annotations[kuberesource.ContrastRoleAnnotationKey])
 			workloadSecretID = meta.Annotations[workloadSecretIDAnnotationKey]
 			return meta, spec
 		})

--- a/cli/cmd/policies_test.go
+++ b/cli/cmd/policies_test.go
@@ -35,8 +35,8 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
 							WithAnnotations(map[string]string{
-								initdata.InitdataAnnotationKey: anno,
-								contrastRoleAnnotationKey:      "coordinator",
+								initdata.InitdataAnnotationKey:         anno,
+								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
 							}).
 							WithSpec(kuberesource.PodSpec().
 								WithRuntimeClassName("contrast-cc"),
@@ -83,8 +83,8 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
 							WithAnnotations(map[string]string{
-								initdata.InitdataAnnotationKey: anno,
-								contrastRoleAnnotationKey:      "coordinator",
+								initdata.InitdataAnnotationKey:         anno,
+								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
 							}).
 							WithSpec(kuberesource.PodSpec().
 								WithRuntimeClassName("contrast-cc"),

--- a/cli/verifier/versions_match.go
+++ b/cli/verifier/versions_match.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/regclient/regclient/types/ref"
 
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -40,7 +41,7 @@ func (v *VersionsMatch) Verify(toVerify any) error {
 
 		var podRole string
 		if meta != nil && meta.Annotations != nil {
-			podRole = meta.Annotations["contrast.edgeless.systems/pod-role"]
+			podRole = meta.Annotations[kuberesource.ContrastRoleAnnotationKey]
 		}
 		for _, container := range spec.Containers {
 			if !needsImageVersionCheck(*container.Name, podRole) {
@@ -74,7 +75,7 @@ func needsImageVersionCheck(containerName string, podRole string) bool {
 	if slices.Contains([]string{"contrast-initializer", "contrast-service-mesh"}, containerName) {
 		return true
 	}
-	if containerName == "coordinator" && podRole == "coordinator" {
+	if containerName == "coordinator" && podRole == string(manifest.RoleCoordinator) {
 		return true
 	}
 	return false

--- a/cli/verifier/versions_match_test.go
+++ b/cli/verifier/versions_match_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/edgelesssys/contrast/cli/verifier"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ kind: Pod
 metadata:
   name: test
   annotations:
-    contrast.edgeless.systems/pod-role: %s
+    %s: %s
 spec:
   runtimeClassName: contrast-cc
   containers:
@@ -65,7 +66,7 @@ func TestVerifyVersionsMatch(t *testing.T) {
 			version:       "v1.13.0",
 		},
 		"versions match with pod-role": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "coordinator", "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleCoordinator, "v1.13.0"),
 			version:       "v1.13.0",
 		},
 		"cli version newer": {
@@ -79,12 +80,12 @@ func TestVerifyVersionsMatch(t *testing.T) {
 			wantErr:       true,
 		},
 		"cli version mismatch with pod-role": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "coordinator", "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleCoordinator, "v1.13.0"),
 			version:       "v1.12.0",
 			wantErr:       true,
 		},
 		"cli version mismatch with differing pod-role unaffected": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "not-coordinator", "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleNone, "v1.13.0"),
 			version:       "v1.12.0",
 		},
 		"resource missing version skipped": {

--- a/coordinator/internal/peerdiscovery/peerdiscovery.go
+++ b/coordinator/internal/peerdiscovery/peerdiscovery.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,7 +41,7 @@ func (d *Discovery) GetPeers(ctx context.Context) ([]string, error) {
 	}
 	var peers []string
 	for _, pod := range pods.Items {
-		if pod.Annotations["contrast.edgeless.systems/pod-role"] != "coordinator" ||
+		if pod.Annotations[kuberesource.ContrastRoleAnnotationKey] != string(manifest.RoleCoordinator) ||
 			pod.Name == os.Getenv("HOSTNAME") {
 			continue
 		}

--- a/coordinator/internal/peerdiscovery/peerdiscovery_test.go
+++ b/coordinator/internal/peerdiscovery/peerdiscovery_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,13 +80,13 @@ func TestGetPeers(t *testing.T) {
 	}
 }
 
-func newPod(name, namespace, labelName, role, ip string, isReady bool) runtime.Object {
+func newPod(name, namespace, labelName string, role manifest.Role, ip string, isReady bool) runtime.Object {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Labels:      map[string]string{"app.kubernetes.io/name": labelName},
-			Annotations: map[string]string{"contrast.edgeless.systems/pod-role": role},
+			Annotations: map[string]string{kuberesource.ContrastRoleAnnotationKey: string(role)},
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},

--- a/e2e/atls/atls_test.go
+++ b/e2e/atls/atls_test.go
@@ -79,9 +79,9 @@ func TestATLS(t *testing.T) {
 		require.NoError(json.Unmarshal(manifestBytes, &manifestParsed))
 		require.NoError(manifestParsed.Validate())
 
-		coordPolicyHash, err := manifestParsed.CoordinatorPolicyHash()
-		require.NoError(err, "getting coordinator policy hash")
-		coordPolicyHashBytes, err = coordPolicyHash.Bytes()
+		coordPolicyHashes := manifestParsed.CoordinatorPolicyHashes()
+		require.NotEmpty(coordPolicyHashes, "getting coordinator policy hash")
+		coordPolicyHashBytes, err = coordPolicyHashes[0].Bytes()
 		require.NoError(err, "converting coordinator policy hash to bytes")
 	}))
 

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -183,8 +183,9 @@ func TestPolicy(t *testing.T) {
 		require.NoError(json.Unmarshal(manifestBytes, &m))
 
 		// Change expected coordinator policy hash.
-		policyHash, err := m.CoordinatorPolicyHash()
-		require.NoError(err)
+		policyHashes := m.CoordinatorPolicyHashes()
+		require.NotEmpty(policyHashes)
+		policyHash := policyHashes[0]
 		policy := m.Policies[policyHash]
 		delete(m.Policies, policyHash)
 		policyHashBytes, err := policyHash.Bytes()

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	exposeServiceAnnotation       = "contrast.edgeless.systems/expose-service"
-	contrastRoleAnnotationKey     = "contrast.edgeless.systems/pod-role"
 	skipInitializerAnnotationKey  = "contrast.edgeless.systems/skip-initializer"
 	smIngressConfigAnnotationKey  = "contrast.edgeless.systems/servicemesh-ingress"
 	smEgressConfigAnnotationKey   = "contrast.edgeless.systems/servicemesh-egress"
@@ -40,6 +39,11 @@ const (
 
 	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
 	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"
+
+	// ContrastRoleAnnotationKey assigns a role to the annotated pod.
+	//
+	// This is used to determine whether a given pod may act as Coordinator.
+	ContrastRoleAnnotationKey = "contrast.edgeless.systems/pod-role"
 )
 
 // CollateralProxyDefaultService is the default in-cluster URL of the collateral-proxy.
@@ -320,7 +324,7 @@ func SetCollateralProxyEnv(resources []any, proxyURL string) []any {
 	out := make([]any, 0, len(resources))
 	for _, resource := range resources {
 		out = append(out, MapPodSpecWithMeta(resource, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
-			if meta == nil || meta.Annotations[contrastRoleAnnotationKey] != "coordinator" {
+			if meta == nil || meta.Annotations[ContrastRoleAnnotationKey] != string(manifest.RoleCoordinator) {
 				return meta, spec
 			}
 			for i := range spec.Containers {
@@ -515,7 +519,7 @@ func AddLogging(resources []any, level, subsystem string) []any {
 		switch r := resource.(type) {
 		case *applyappsv1.StatefulSetApplyConfiguration:
 			if r.Spec != nil && r.Spec.Template != nil &&
-				r.Spec.Template.Annotations["contrast.edgeless.systems/pod-role"] == "coordinator" {
+				r.Spec.Template.Annotations[ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
 				r.Spec.Template.Spec.Containers[0].WithEnv(
 					NewEnvVar("CONTRAST_LOG_LEVEL", level),
 					NewEnvVar("CONTRAST_LOG_SUBSYSTEMS", subsystem),
@@ -744,7 +748,7 @@ func PatchCoordinatorMetrics(resources []any) []any {
 		case *applyappsv1.StatefulSetApplyConfiguration:
 			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.Spec != nil &&
 				len(r.Spec.Template.Spec.Containers) > 0 &&
-				r.Spec.Template.Annotations[contrastRoleAnnotationKey] == "coordinator" {
+				r.Spec.Template.Annotations[ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
 				r.Spec.Template.Spec.Containers[0].WithEnv(NewEnvVar("CONTRAST_METRICS", "1"))
 				r.Spec.Template.Spec.Containers[0].WithPorts(
 					ContainerPort().

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -789,7 +789,7 @@ func TestSetCollateralProxyEnv(t *testing.T) {
 	assert := assert.New(t)
 
 	coordinatorPod := applycorev1.Pod("coordinator", "default").
-		WithAnnotations(map[string]string{contrastRoleAnnotationKey: "coordinator"}).
+		WithAnnotations(map[string]string{ContrastRoleAnnotationKey: "coordinator"}).
 		WithSpec(applycorev1.PodSpec().
 			WithRuntimeClassName("contrast-cc-foo").
 			WithContainers(applycorev1.Container().WithName("coordinator").WithImage("coordinator")))

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -88,8 +88,8 @@ func (m *Manifest) Validate() error {
 			coordinatorCount++
 		}
 	}
-	if coordinatorCount != 1 {
-		return &CoordinatorCountError{Count: coordinatorCount}
+	if coordinatorCount == 0 {
+		return ErrMissingCoordinator
 	}
 
 	if err := m.ReferenceValues.Validate(); err != nil {
@@ -110,14 +110,15 @@ func (m *Manifest) Validate() error {
 	return errors.Join(errs...)
 }
 
-// CoordinatorPolicyHash returns the hash of the coordinator policy.
-func (m *Manifest) CoordinatorPolicyHash() (HexString, error) {
+// CoordinatorPolicyHashes returnsa slice of all initdata hashes that correspond to Coordinators.
+func (m *Manifest) CoordinatorPolicyHashes() []HexString {
+	var out []HexString
 	for policyHash, policy := range m.Policies {
 		if policy.Role == RoleCoordinator {
-			return policyHash, nil
+			out = append(out, policyHash)
 		}
 	}
-	return "", errors.New("no coordinator found in manifest")
+	return out
 }
 
 // SNPValidateOpts returns validate options generators populated with the manifest's
@@ -536,12 +537,8 @@ func (e *ValidationError) OnlyExpectedMissingReferenceValues() bool {
 	return true
 }
 
-// CoordinatorCountError occurs during manifest validation when either zero, or more than one coordinators have been defined.
-type CoordinatorCountError struct{ Count uint }
-
-func (e *CoordinatorCountError) Error() string {
-	return fmt.Sprintf("expected exactly 1 policy with role 'coordinator', got %d", e.Count)
-}
+// ErrMissingCoordinator is returned when the manifest does not contain at least one policy for a Coordinator.
+var ErrMissingCoordinator = errors.New("expected at least 1 policy with role 'coordinator'")
 
 func toPtr[T any](v T) *T {
 	return &v

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -392,6 +392,8 @@ const (
 	RoleNone Role = ""
 	// RoleCoordinator is the coordinator role.
 	RoleCoordinator Role = "coordinator"
+	// RoleNodeInstaller is the node installer DaemonSet.
+	RoleNodeInstaller Role = "contrast-node-installer"
 )
 
 // Validate checks the validity of the role.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -224,7 +224,6 @@ func TestValidate(t *testing.T) {
 					Role: "coordinator",
 				}
 			},
-			wantErr: true,
 		},
 		"no chip IDs": {
 			m: newTestManifestSNP(),

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -24,46 +24,51 @@ import (
 // Originally an unexported function in the contrast CLI.
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
 // Validators MUST NOT be used concurrently.
+// The returned validators only allow COordinators.
 func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) ([]atls.Validator, error) {
 	var validators []atls.Validator
 
-	coordPolicyHash, err := m.CoordinatorPolicyHash()
-	if err != nil {
-		return nil, fmt.Errorf("getting coordinator policy hash: %w", err)
-	}
-	coordPolicyHashBytes, err := coordPolicyHash.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("converting coordinator policy hash to bytes: %w", err)
+	coordPolicyHashes := m.CoordinatorPolicyHashes()
+	if len(coordPolicyHashes) < 1 {
+		return nil, fmt.Errorf("the manifest does not contain a policy with role %q", manifest.RoleCoordinator)
 	}
 	opts, err := m.SNPValidateOpts(kdsGetter)
 	if err != nil {
 		return nil, fmt.Errorf("getting SNP validate options: %w", err)
 	}
-	for i, opt := range opts {
-		opt.ValidateOpts.HostData = coordPolicyHashBytes
-		name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
-		validatorLog := logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name})
-		var v atls.Validator
-		if len(opt.APEIP) == 4 {
-			seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
-			apEIP := binary.BigEndian.Uint32(opt.APEIP)
-			v = snp.NewIterativeValidator(opt.VerifyOpts, opt.ValidateOpts, seed, apEIP, opt.VCPUSig, opt.AllowedChipIDs, validatorLog, name)
-		} else {
-			v = snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, name)
+	// TODO(burgerdev): reduce the amount of individual validators through accepting a slice of HOSTDATA entries.
+	for _, coordPolicyHash := range coordPolicyHashes {
+		coordPolicyHashBytes, err := coordPolicyHash.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("converting coordinator policy hash %q to bytes: %w", coordPolicyHash, err)
 		}
-		validators = append(validators, v)
-	}
 
-	tdxOpts, err := m.TDXValidateOpts(kdsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("generating TDX validation options: %w", err)
-	}
-	var mrConfigID [48]byte
-	copy(mrConfigID[:], coordPolicyHashBytes)
-	for i, opt := range tdxOpts {
-		name := fmt.Sprintf("tdx-%d", i)
-		opt.ValidateOpts.TdQuoteBodyOptions.MrConfigID = mrConfigID[:]
-		validators = append(validators, tdx.NewValidator(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), name))
+		for i, opt := range opts {
+			opt.ValidateOpts.HostData = coordPolicyHashBytes
+			name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
+			validatorLog := logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name})
+			var v atls.Validator
+			if len(opt.APEIP) == 4 {
+				seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
+				apEIP := binary.BigEndian.Uint32(opt.APEIP)
+				v = snp.NewIterativeValidator(opt.VerifyOpts, opt.ValidateOpts, seed, apEIP, opt.VCPUSig, opt.AllowedChipIDs, validatorLog, name)
+			} else {
+				v = snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, name)
+			}
+			validators = append(validators, v)
+		}
+
+		tdxOpts, err := m.TDXValidateOpts(kdsGetter)
+		if err != nil {
+			return nil, fmt.Errorf("generating TDX validation options: %w", err)
+		}
+		var mrConfigID [48]byte
+		copy(mrConfigID[:], coordPolicyHashBytes)
+		for i, opt := range tdxOpts {
+			name := fmt.Sprintf("tdx-%d", i)
+			opt.ValidateOpts.TdQuoteBodyOptions.MrConfigID = mrConfigID[:]
+			validators = append(validators, tdx.NewValidator(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), name))
+		}
 	}
 
 	return validators, nil


### PR DESCRIPTION
The intention here was to avoid incompatible coordinators. However, we now have the `VersionsMatch` check that should give stronger guarantees, and allowing a slightly different Coordinator (for example: different name) unblocks some use cases.

Fixes CON-174.