### PR TITLE
just: only acquire lease for gpu target

### DIFF
--- a/justfile
+++ b/justfile
@@ -108,7 +108,7 @@ e2e target=default_deploy_target platform=default_platform set=default_set:
 _e2e target=default_deploy_target platform=default_platform set=default_set: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy memdump debugshell k8s-log-collector strongswan (node-installer platform)
     #!/usr/bin/env bash
     set -euo pipefail
-    if [[ {{ platform }} == "Metal-QEMU-SNP-GPU" || {{ platform }} == "Metal-QEMU-TDX-GPU" ]] ; then
+    if [[ {{ target }} == "gpu" ]] ; then
         just request-fifo-ticket 90m
     fi
     if [[ -n "${contrast_ghcr_read:-}" ]]; then
@@ -329,7 +329,7 @@ apply target=default_deploy_target platform=default_platform:
             kubectl apply -f ./{{ workspace_dir }}/runtime/runtime.yml
         ;;
         *)
-            if [[ {{ platform }} == "Metal-QEMU-SNP-GPU" || {{ platform }} == "Metal-QEMU-TDX-GPU"  ]] ; then
+            if [[ {{ target }} == "gpu" || {{ target }} == "custom" && {{ platform }} == *-GPU ]] ; then
                 just request-fifo-ticket 90m
                 trap 'just release-fifo-ticket' ERR
                 kubectl label ns $(tail -1 ./{{ workspace_dir }}/just.namespace) contrast.edgeless.systems/sync-ticket=$(cat ./{{ workspace_dir }}/just.sync-ticket) --overwrite


### PR DESCRIPTION
We want to avoid collisions of workloads using the GPU, not workloads running at all. This changes `just default` and `just e2e` to only acquire the lease if we're using the `gpu` set.

Note that this allows `just default custom` to bypass leases although there might be GPUs used by the custom resources. Alternatively, we could opportunistically acquire the lease on `custom`, or do a `grep NVIDIA` on the resources.