### PR TITLE
initdata-processor: cast Rdev to uint64 to satisfy linter running on darwin

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -76,8 +76,13 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin]
     env:
       SET: base
+      GOOS: ${{ matrix.goos }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/initdata-processor/main.go
+++ b/initdata-processor/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/edgelesssys/contrast/initdata-processor/policy"
 	"github.com/edgelesssys/contrast/initdata-processor/validator"
 	"github.com/edgelesssys/contrast/internal/initdata"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -144,7 +143,7 @@ func checkDeviceAvailability(id string, magic []byte) (string, error) {
 
 		// Check whether the device major number indicates a disk type.
 		// https://www.kernel.org/doc/html/latest/admin-guide/devices.html
-		major := unix.Major(stat.Rdev)
+		major := devMajor(stat)
 		switch {
 		case major == 8:
 			// SCSI / SATA

--- a/initdata-processor/rdev_fallback.go
+++ b/initdata-processor/rdev_fallback.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !linux
+
+package main
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// devMajor returns the major device number from stat.Rdev.
+func devMajor(stat *syscall.Stat_t) uint32 {
+	// Off Linux, Stat_t.Rdev is not uint64 (e.g. int32 on darwin), so convert
+	// it. These non-Linux variants exist only so the package builds and lints
+	// on macOS; the initdata-processor itself only runs on Linux.
+	return unix.Major(uint64(stat.Rdev))
+}

--- a/initdata-processor/rdev_linux.go
+++ b/initdata-processor/rdev_linux.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// devMajor returns the major device number from stat.Rdev.
+func devMajor(stat *syscall.Stat_t) uint32 {
+	return unix.Major(stat.Rdev)
+}


### PR DESCRIPTION
The pre-commit hook (the linter specifically) was failing today locally for me because of https://github.com/edgelesssys/contrast/commit/346c35add6a8a1f0e62dc592a71441c80bc2f065 with

```
Running golangci-lint with tags contrast_unstable_api on /Users/sespiros/git-pulls/edgelesssys/contrast/.worktree/release-e2e-genpolicy-cache/initdata-processor
initdata-processor/main.go:1  typecheck  : # github.com/edgelesssys/contrast/initdata-processor
initdata-processor/main.go:147:23: cannot use stat.Rdev (variable of type int32) as uint64 value in argument to unix.Major
1 issues:
* typecheck: 1
```

I also added a test to run on new PRs to try and catch these in the future.