### PR TITLE
e2e: persist genpolicy layer cache across nightly release runs

### DIFF
--- a/.github/actions/release_build_linux/action.yml
+++ b/.github/actions/release_build_linux/action.yml
@@ -79,6 +79,30 @@ runs:
         path: |
           LICENSE
           ${{ steps.create-artifacts.outputs.paths }}
+    # Warm the genpolicy layer cache on this fast github-hosted runner so the
+    # self-hosted e2e jobs read it instead of pulling image layers over their
+    # slow ghcr link, which can exceed generate's timeout.
+    - name: Warm genpolicy layer cache for e2e
+      shell: bash
+      env:
+        PATHS: ${{ steps.create-artifacts.outputs.paths }}
+      run: |
+        set -u
+        mkdir -p genpolicy-warmup
+        cp $PATHS genpolicy-warmup/
+        touch genpolicy-warmup/layers-cache.json
+        nix build -L ".#base.contrast.cli-release"
+        ./result/bin/contrast generate \
+          --reference-values Metal-QEMU-SNP \
+          --genpolicy-cache-path genpolicy-warmup/layers-cache.json \
+          genpolicy-warmup/ \
+          || echo "genpolicy warm-up failed; e2e will pull cold"
+    - name: Upload genpolicy layer cache
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: genpolicy-layer-cache
+        path: genpolicy-warmup/layers-cache.json
+        if-no-files-found: warn
     # Dev/test-only image, but pushed here so it can share this job's
     # packages:write permission. The e2e release matrix consumes the digest
     # to substitute the :latest placeholder when get-logs generates the

--- a/.github/actions/release_e2e_test/action.yml
+++ b/.github/actions/release_e2e_test/action.yml
@@ -138,6 +138,11 @@ runs:
       run: |
         mkdir -p workspace
         echo "ghcr.io/edgelesssys/contrast/k8s-log-collector:latest=${LOG_COLLECTOR_IMAGE}" >> workspace/just.containerlookup
+    - name: Download warmed genpolicy layer cache
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: genpolicy-layer-cache
+        path: workspace
     - name: E2E Test
       shell: bash
       env:
@@ -146,6 +151,7 @@ runs:
         PLATFORM_NAME: ${{ inputs.platform_name }}
         NODE_INSTALLER_TARGET_CONF: ${{ inputs.node_installer_target_conf }}
         CLI_ARCH: ${{ inputs.cli_arch }}
+        GENPOLICY_CACHE_PATH: ${{ github.workspace }}/workspace/layers-cache.json
       run: |
         mkdir -p workspace
         nix build ".#base.scripts.get-logs"

--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	tokenEnvVar = "GH_TOKEN"
+	tokenEnvVar          = "GH_TOKEN"
+	genpolicyCacheEnvVar = "GENPOLICY_CACHE_PATH"
 )
 
 var (
@@ -195,7 +196,12 @@ func TestRelease(t *testing.T) {
 		}
 	}), "deployment processing needs to succeed for subsequent tests to run")
 
-	contrast.Run(ctx, t, 4*time.Minute, "generate", "--reference-values", *platformStr, "deployment/")
+	generateArgs := []string{"generate", "--reference-values", *platformStr}
+	if cachePath := os.Getenv(genpolicyCacheEnvVar); cachePath != "" {
+		generateArgs = append(generateArgs, "--genpolicy-cache-path", cachePath)
+	}
+	generateArgs = append(generateArgs, "deployment/")
+	contrast.Run(ctx, t, 4*time.Minute, generateArgs...)
 
 	require.True(t, t.Run("patch reference values", func(t *testing.T) {
 		require := require.New(t)


### PR DESCRIPTION
The release e2e test runs `contrast generate` against published images pulled straight from ghcr.io with no warm layer cache: the default cache lands in the throwaway release dir, so every nightly re-pulls and re-decompresses every layer from cold. When ghcr is slow this overruns the 4-minute generate deadline and the whole TestRelease fails (e.g. the 2026-06-23 nightly, where a single service-mesh-proxy layer took ~100s).

https://github.com/edgelesssys/contrast/actions/runs/27984552112

Warm the genpolicy layer cache once in the release build job, which runs on a github-hosted runner with fast ghcr access, and hand it to the e2e jobs as a workflow artifact. The build copies the workspace, runs generate over it to populate layers-cache.json, and uploads it; the bare-metal e2e jobs download it and point --genpolicy-cache-path at it, so their generate reads the cache instead of pulling layers over the slow lab link. The cache is rebuilt fresh from each run's own images, so there's no cross-run or per-runner state to manage, and warm-up is non-fatal: if it fails the e2e jobs just pull cold like today.

Only the generate pull path is covered here; the node-installer pull during apply-runtime is a separate slow path and unaffected.