### PR TITLE
`go-sev/tdx-guest`: bump to latest main of upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/edgelesssys/contrast
 go 1.25.6
 
 // Upstream is poorly maintained, use edgelesssys fork instead.
-replace github.com/google/go-tdx-guest => github.com/edgelesssys/go-tdx-guest v0.0.0-20260120144929-ac8c4b4a23eb
+replace github.com/google/go-tdx-guest => github.com/edgelesssys/go-tdx-guest v0.0.0-20260625101654-86bb3d849c88
+
+replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20260625075350-5c9638ef2416
 
 require (
 	filippo.io/keygen v0.0.0-20260114151900-8e2790ea4c5b

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgelesssys/go-tdx-guest v0.0.0-20260120144929-ac8c4b4a23eb h1:FRg7kvMZrhz0DM4z0XF7tRzTniNAqr2cH+Cw7EsFTN8=
-github.com/edgelesssys/go-tdx-guest v0.0.0-20260120144929-ac8c4b4a23eb/go.mod h1:uHy3VaNXNXhl0fiPxKqTxieeouqQmW6A0EfLcaeCYBk=
+github.com/edgelesssys/go-sev-guest v0.0.0-20260625075350-5c9638ef2416 h1:iCCw9rksqF4SrQWJrkKvfJzmZe88wqbssz9SgY+3cQE=
+github.com/edgelesssys/go-sev-guest v0.0.0-20260625075350-5c9638ef2416/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/edgelesssys/go-tdx-guest v0.0.0-20260625101654-86bb3d849c88 h1:L+kxXOzbtb8xTqIScjnd19HI3etugk60gvhn4/Qw55o=
+github.com/edgelesssys/go-tdx-guest v0.0.0-20260625101654-86bb3d849c88/go.mod h1:uHy3VaNXNXhl0fiPxKqTxieeouqQmW6A0EfLcaeCYBk=
 github.com/elazarl/goproxy v1.8.2 h1:keGt9KHFAnrXFEctQuOF9NRxKFCXtd5cQg5PrBdeVW4=
 github.com/elazarl/goproxy v1.8.2/go.mod h1:b5xm6W48AUHNpRTCvlnd0YVh+JafCCtsLsJZvvNTz+E=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -93,8 +95,6 @@ github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItU
 github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
-github.com/google/go-sev-guest v0.14.2-0.20251119154202-af1c107a648f h1:UVLafZ3h85JE5e0QU5dUixIJa2PO5G51THLMuXrtnTw=
-github.com/google/go-sev-guest v0.14.2-0.20251119154202-af1c107a648f/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/logger v1.1.2 h1:e+W0nsqc42cydCWvpuVHHg4L/ZBR+S9zwZoBHkuQ8QI=
 github.com/google/logger v1.1.2/go.mod h1:yhXfkxV3qOWUUWXbUfYTbGZZUN/SF43DkCjnc/FOzaU=

--- a/packages/by-name/contrast/contrast/package.nix
+++ b/packages/by-name/contrast/contrast/package.nix
@@ -53,7 +53,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-t97WJrMe2NN7XNpNlVv76/XMbdRYhmCa2vngUORwoY4=";
+  vendorHash = "sha256-0VyZRepbNJlGtAsrBvNgOi5mtUKCdeTz1anrH7hQlgc=";
 
   subPackages = packageOutputs;
 


### PR DESCRIPTION
Before this can be updated & merged, these two need to be merged first:
- [x] https://github.com/edgelesssys/go-tdx-guest/pull/7
- [x] https://github.com/edgelesssys/go-sev-guest/pull/3

I'm just using this PR as an opportunity to run more extensive tests using the updated versions.