### PR TITLE
collateral-proxy: use in set/verify/recover/SDK, use per-getter config instead of global

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -82,7 +82,7 @@ func cachedir(subdir string) (string, error) {
 	return filepath.Join(dir, subdir), nil
 }
 
-func cachedHTTPSGetter(log *slog.Logger) (*certcache.CachedHTTPSGetter, error) {
+func cachedHTTPSGetter(log *slog.Logger, collateralProxy string) (*certcache.CachedHTTPSGetter, error) {
 	kdsDir, err := cachedir("kds")
 	if err != nil {
 		return nil, fmt.Errorf("getting cache dir: %w", err)
@@ -90,7 +90,7 @@ func cachedHTTPSGetter(log *slog.Logger) (*certcache.CachedHTTPSGetter, error) {
 	log.Debug("Using KDS cache dir", "dir", kdsDir)
 
 	kdsCache := fsstore.New(afero.NewBasePathFs(afero.NewOsFs(), kdsDir), log.WithGroup("kds-cache"))
-	return certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter")), nil
+	return certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"), collateralProxy), nil
 }
 
 func addCollateralProxyFlag(cmd *cobra.Command) {

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -93,6 +93,10 @@ func cachedHTTPSGetter(log *slog.Logger) (*certcache.CachedHTTPSGetter, error) {
 	return certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter")), nil
 }
 
+func addCollateralProxyFlag(cmd *cobra.Command) {
+	cmd.Flags().String("collateral-proxy", "", "route attestation-collateral fetches through the caching proxy at this base URL")
+}
+
 func must(err error) {
 	if err != nil {
 		panic(err)

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -87,7 +87,7 @@ subcommands.`,
 	must(cmd.Flags().MarkHidden("image-replacements"))
 	cmd.Flags().Bool("skip-initializer", false, "skip injection of Contrast Initializer")
 	cmd.Flags().Bool("skip-service-mesh", false, "skip injection of Contrast service mesh sidecar")
-	cmd.Flags().String("collateral-proxy", "", "route attestation-collateral fetches through the caching proxy at this base URL")
+	addCollateralProxyFlag(cmd)
 	cmd.Flags().Bool("inject-image-store", false, "inject an ephemeral storage device to pull images onto instead of into memory")
 	cmd.Flags().Bool("insecure-enable-debug-shell-access", false, "enable the debug shell service in the pod CVM to get access from container to guest VM")
 	cmd.Flags().Bool("calculate-pod-memory", false, "calculate pod memory based on image layer sizes and container resource limits")

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 
 	"github.com/edgelesssys/contrast/internal/atls"
-	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
@@ -76,8 +75,7 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("decrypting seed: %w", err)
 	}
 
-	certcache.SetCollateralProxy(flags.collateralProxyURL)
-	kdsGetter, err := cachedHTTPSGetter(log)
+	kdsGetter, err := cachedHTTPSGetter(log, flags.collateralProxyURL)
 	if err != nil {
 		return fmt.Errorf("configuring KDS cache: %w", err)
 	}

--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
@@ -41,6 +42,7 @@ The recover command is used to provide the seed to the Coordinator.`,
 	cmd.Flags().String("seedshare-owner-key", seedshareOwnerPEM, "private key file to decrypt the seed share")
 	cmd.Flags().String("seed", seedSharesFilename, "file with the encrypted seed shares")
 	cmd.Flags().Bool("force", false, "skip sanity checks while recovering")
+	addCollateralProxyFlag(cmd)
 
 	return cmd
 }
@@ -74,6 +76,7 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("decrypting seed: %w", err)
 	}
 
+	certcache.SetCollateralProxy(flags.collateralProxyURL)
 	kdsGetter, err := cachedHTTPSGetter(log)
 	if err != nil {
 		return fmt.Errorf("configuring KDS cache: %w", err)
@@ -114,6 +117,7 @@ type recoverFlags struct {
 	workloadOwnerKeyPath  string
 	manifestPath          string
 	workspaceDir          string
+	collateralProxyURL    string
 	force                 bool
 }
 
@@ -181,6 +185,10 @@ func parseRecoverFlags(cmd *cobra.Command) (*recoverFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	collateralProxyURL, err := cmd.Flags().GetString("collateral-proxy")
+	if err != nil {
+		return nil, err
+	}
 
 	if workspaceDir != "" {
 		// Prepend default paths with workspaceDir
@@ -205,6 +213,7 @@ func parseRecoverFlags(cmd *cobra.Command) (*recoverFlags, error) {
 		workloadOwnerKeyPath:  workloadOwnerKeyPath,
 		manifestPath:          manifestPath,
 		workspaceDir:          workspaceDir,
+		collateralProxyURL:    collateralProxyURL,
 		force:                 force,
 	}, nil
 }

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/internal/atls"
-	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	grpcRetry "github.com/edgelesssys/contrast/internal/grpc/retry"
 	"github.com/edgelesssys/contrast/internal/history"
@@ -136,8 +135,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	certcache.SetCollateralProxy(flags.collateralProxyURL)
-	kdsGetter, err := cachedHTTPSGetter(log)
+	kdsGetter, err := cachedHTTPSGetter(log, flags.collateralProxyURL)
 	if err != nil {
 		return fmt.Errorf("configuring KDS cache: %w", err)
 	}

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	grpcRetry "github.com/edgelesssys/contrast/internal/grpc/retry"
 	"github.com/edgelesssys/contrast/internal/history"
@@ -59,6 +60,7 @@ issuer certificates.`,
 	cmd.Flags().String("latest-transition", "", "latest transition hash set at the coordinator (hex string)")
 	cmd.Flags().StringP("signature", "s", "", "path to a detached transition signature (DER) file")
 	must(cmd.MarkFlagFilename("signature"))
+	addCollateralProxyFlag(cmd)
 
 	return cmd
 }
@@ -134,6 +136,7 @@ func runSet(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	certcache.SetCollateralProxy(flags.collateralProxyURL)
 	kdsGetter, err := cachedHTTPSGetter(log)
 	if err != nil {
 		return fmt.Errorf("configuring KDS cache: %w", err)
@@ -217,6 +220,7 @@ type setFlags struct {
 	latestTransition     string
 	signaturePath        string
 	workspaceDir         string
+	collateralProxyURL   string
 }
 
 func parseSetFlags(cmd *cobra.Command) (*setFlags, error) {
@@ -253,6 +257,10 @@ func parseSetFlags(cmd *cobra.Command) (*setFlags, error) {
 	flags.workspaceDir, err = cmd.Flags().GetString("workspace-dir")
 	if err != nil {
 		return nil, fmt.Errorf("getting workspace-dir flag: %w", err)
+	}
+	flags.collateralProxyURL, err = cmd.Flags().GetString("collateral-proxy")
+	if err != nil {
+		return nil, fmt.Errorf("getting collateral-proxy flag: %w", err)
 	}
 
 	if flags.workspaceDir != "" {

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -48,6 +48,7 @@ all policies, and the certificates of the Coordinator certificate authority.`,
 	cmd.Flags().StringP("manifest", "m", manifestFilename, "path to manifest (.json) file")
 	cmd.Flags().StringP("coordinator", "c", "", "endpoint the coordinator can be reached at")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "coordinator"))
+	addCollateralProxyFlag(cmd)
 
 	return cmd
 }
@@ -68,6 +69,8 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read manifest file: %w", err)
 	}
+
+	certcache.SetCollateralProxy(flags.collateralProxyURL)
 
 	kdsDir, err := cachedir("kds")
 	if err != nil {
@@ -130,9 +133,10 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 }
 
 type verifyFlags struct {
-	manifestPath string
-	coordinator  string
-	workspaceDir string
+	manifestPath       string
+	coordinator        string
+	workspaceDir       string
+	collateralProxyURL string
 }
 
 func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
@@ -148,6 +152,10 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	collateralProxyURL, err := cmd.Flags().GetString("collateral-proxy")
+	if err != nil {
+		return nil, err
+	}
 
 	if workspaceDir != "" {
 		// Prepend default path with workspaceDir
@@ -157,9 +165,10 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	}
 
 	return &verifyFlags{
-		manifestPath: manifestPath,
-		coordinator:  coordinator,
-		workspaceDir: workspaceDir,
+		manifestPath:       manifestPath,
+		coordinator:        coordinator,
+		workspaceDir:       workspaceDir,
+		collateralProxyURL: collateralProxyURL,
 	}, nil
 }
 

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -70,15 +70,13 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to read manifest file: %w", err)
 	}
 
-	certcache.SetCollateralProxy(flags.collateralProxyURL)
-
 	kdsDir, err := cachedir("kds")
 	if err != nil {
 		return fmt.Errorf("getting cache dir: %w", err)
 	}
 	log.Debug("Using KDS cache dir", "dir", kdsDir)
 
-	resp, err := getCoordinatorState(cmd.Context(), kdsDir, manifestBytes, flags.coordinator, log)
+	resp, err := getCoordinatorState(cmd.Context(), kdsDir, manifestBytes, flags.coordinator, flags.collateralProxyURL, log)
 	if err != nil {
 		return fmt.Errorf("getting manifests: %w", err)
 	}
@@ -188,7 +186,7 @@ func writeFilelist(dir string, filelist map[string][]byte) error {
 }
 
 // getCoordinatorState calls GetManifests on the coordinator's userapi via aTLS.
-func getCoordinatorState(ctx context.Context, kdsDir string, manifestBytes []byte, endpoint string, log *slog.Logger) (sdk.CoordinatorState, error) {
+func getCoordinatorState(ctx context.Context, kdsDir string, manifestBytes []byte, endpoint, collateralProxy string, log *slog.Logger) (sdk.CoordinatorState, error) {
 	var m manifest.Manifest
 	if err := json.Unmarshal(manifestBytes, &m); err != nil {
 		return sdk.CoordinatorState{}, fmt.Errorf("unmarshalling manifest: %w", err)
@@ -198,7 +196,7 @@ func getCoordinatorState(ctx context.Context, kdsDir string, manifestBytes []byt
 	}
 
 	kdsCache := fsstore.New(afero.NewBasePathFs(afero.NewOsFs(), kdsDir), log.WithGroup("kds-cache"))
-	kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"))
+	kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"), collateralProxy)
 	validator, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {
 		return sdk.CoordinatorState{}, fmt.Errorf("getting validators: %w", err)

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -83,9 +83,9 @@ func run() (retErr error) {
 
 	logger.Info("Coordinator started")
 
-	if proxy := os.Getenv(constants.CollateralProxyEnvVar); proxy != "" {
-		logger.Info("routing attestation collateral through proxy", "proxy", proxy)
-		certcache.SetCollateralProxy(proxy)
+	collateralProxy := os.Getenv(constants.CollateralProxyEnvVar)
+	if collateralProxy != "" {
+		logger.Info("routing attestation collateral through proxy", "proxy", collateralProxy)
 	}
 
 	// The coordinator doesn't have an initcontainer to remove the default deny rule.
@@ -122,7 +122,7 @@ func run() (retErr error) {
 
 	meshAuth := stateguard.New(hist, promRegistry, logger)
 
-	issuer, err := issuer.New(logger)
+	issuer, err := issuer.New(logger, collateralProxy)
 	if err != nil {
 		return fmt.Errorf("creating issuer: %w", err)
 	}
@@ -135,7 +135,7 @@ func run() (retErr error) {
 	month := 30 * 24 * time.Hour
 	ticker := clock.RealClock{}.NewTicker(9 * month)
 	defer ticker.Stop()
-	kdsGetter := certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, loggerpkg.NewNamed(logger, "kds-getter-validator"))
+	kdsGetter := certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, loggerpkg.NewNamed(logger, "kds-getter-validator"), collateralProxy)
 
 	meshAPIcredentials := meshAuth.Credentials(promRegistry, issuer, kdsGetter)
 	meshAPIServer := newGRPCServer(meshAPIcredentials, serverMetrics)

--- a/e2e/atls/atls_test.go
+++ b/e2e/atls/atls_test.go
@@ -152,7 +152,7 @@ func TestATLS(t *testing.T) {
 
 				// TODO(burgerdev): should this test use Manifest.CoordinatorValidator()?
 				kdsCache := memstore.New[string, []byte]()
-				kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, logger.WithGroup("kds-getter"))
+				kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, logger.WithGroup("kds-getter"), "")
 				opts, err := manifestParsed.SNPValidateOpts(kdsGetter)
 				require.NoError(err, "getting SNP validate options")
 				var allValidators []validators.Validator

--- a/e2e/attestation/attestation_test.go
+++ b/e2e/attestation/attestation_test.go
@@ -184,7 +184,7 @@ func TestAttestation(t *testing.T) {
 
 				logger := slog.Default()
 				store := fsstore.New(afero.NewMemMapFs(), logger)
-				cache := certcache.NewCachedHTTPSGetter(store, certcache.NeverGCTicker, logger)
+				cache := certcache.NewCachedHTTPSGetter(store, certcache.NeverGCTicker, logger, "")
 				validator, err := m.CoordinatorValidator(logger, cache)
 				require.NoError(err)
 

--- a/e2e/internal/contrasttest/contrasttest.go
+++ b/e2e/internal/contrasttest/contrasttest.go
@@ -412,7 +412,12 @@ func (ct *ContrastTest) RunVerify(ctx context.Context) error {
 		return fmt.Errorf("calling HTTP API: %w", err)
 	}
 
-	state, err := client.ValidateAttestation(ctx, nonce, serializedAttestation)
+	var state *sdk.CoordinatorState
+	err = ct.withForwardedCollateralProxy(ctx, func(proxyBaseURL string) error {
+		var err error
+		state, err = client.WithCollateralProxy(proxyBaseURL).ValidateAttestation(ctx, nonce, serializedAttestation)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("validating attestation: %w", err)
 	}
@@ -557,6 +562,21 @@ func (ct *ContrastTest) getImagePullSecret(ctx context.Context, t *testing.T) []
 	return nil
 }
 
+const (
+	collateralProxyNamespace  = "default"
+	collateralProxyPodName    = "collateral-proxy-0"
+	collateralProxyRemotePort = "80"
+)
+
+func (ct *ContrastTest) withForwardedCollateralProxy(ctx context.Context, f func(proxyBaseURL string) error) error {
+	if ct.DoNotUseCollateralProxy {
+		return f("")
+	}
+	return ct.Kubeclient.WithForwardedPort(ctx, collateralProxyNamespace, collateralProxyPodName, collateralProxyRemotePort, func(proxyAddr string) error {
+		return f("http://" + proxyAddr)
+	})
+}
+
 // runAgainstCoordinator forwards the coordinator port and executes the command against it.
 func (ct *ContrastTest) runAgainstCoordinator(ctx context.Context, cmd *cobra.Command, args ...string) error {
 	if err := ct.Kubeclient.WaitForCoordinator(ctx, ct.Namespace); err != nil {
@@ -572,21 +592,26 @@ func (ct *ContrastTest) runAgainstCoordinator(ctx context.Context, cmd *cobra.Co
 	cmd.Flags().String("workspace-dir", "", "")
 	cmd.Flags().String("log-level", "debug", "")
 
-	return ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-coordinator", userapi.Port, func(addr string) error {
-		// Go never uses a proxy for connections to localhost. To enable proxy tests, we
-		// replace localhost with 0.0.0.0, which can be used as localhost on Linux and BSD.
-		addr = strings.Replace(addr, "localhost", "0.0.0.0", 1)
+	return ct.withForwardedCollateralProxy(ctx, func(proxyBaseURL string) error {
+		return ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-coordinator", userapi.Port, func(addr string) error {
+			// Go never uses a proxy for connections to localhost. To enable proxy tests, we
+			// replace localhost with 0.0.0.0, which can be used as localhost on Linux and BSD.
+			addr = strings.Replace(addr, "localhost", "0.0.0.0", 1)
 
-		commonArgs := append(ct.commonArgs(), "--coordinator", addr)
-		cmd.SetArgs(append(commonArgs, args...))
-		cmd.SetOut(io.Discard)
-		errBuf := &bytes.Buffer{}
-		cmd.SetErr(errBuf)
+			cmdArgs := append(ct.commonArgs(), "--coordinator", addr)
+			if proxyBaseURL != "" {
+				cmdArgs = append(cmdArgs, "--collateral-proxy", proxyBaseURL)
+			}
+			cmd.SetArgs(append(cmdArgs, args...))
+			cmd.SetOut(io.Discard)
+			errBuf := &bytes.Buffer{}
+			cmd.SetErr(errBuf)
 
-		if err := cmd.ExecuteContext(ctx); err != nil {
-			return fmt.Errorf("running %q: %s", cmd.Use, errBuf)
-		}
-		return nil
+			if err := cmd.ExecuteContext(ctx); err != nil {
+				return fmt.Errorf("running %q: %s", cmd.Use, errBuf)
+			}
+			return nil
+		})
 	})
 }
 

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
-	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/defaultdeny"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/logger"
@@ -78,9 +77,9 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 
 	log.Info("Initializer started")
 
-	if proxy := os.Getenv(constants.CollateralProxyEnvVar); proxy != "" {
-		log.Info("routing attestation collateral through proxy", "proxy", proxy)
-		certcache.SetCollateralProxy(proxy)
+	collateralProxy := os.Getenv(constants.CollateralProxyEnvVar)
+	if collateralProxy != "" {
+		log.Info("routing attestation collateral through proxy", "proxy", collateralProxy)
 	}
 
 	// If the service mesh is disabled, we don't have a service mesh sidecar
@@ -107,7 +106,7 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 		return fmt.Errorf("generating key: %w", err)
 	}
 
-	issuer, err := issuer.New(log)
+	issuer, err := issuer.New(log, collateralProxy)
 	if err != nil {
 		return fmt.Errorf("creating issuer: %w", err)
 	}

--- a/internal/atls/issuer/issuer_linux.go
+++ b/internal/atls/issuer/issuer_linux.go
@@ -17,12 +17,13 @@ import (
 )
 
 // New creates an attestation issuer for the current platform.
-func New(log *slog.Logger) (atls.Issuer, error) {
+func New(log *slog.Logger, collateralProxy string) (atls.Issuer, error) {
 	cpuid.Detect()
 	switch {
 	case cpuid.CPU.Supports(cpuid.SEV_SNP):
 		return snpissuer.New(
 			logger.NewWithAttrs(logger.NewNamed(log, "issuer"), map[string]string{"tee-type": "snp"}),
+			collateralProxy,
 		), nil
 	case cpuid.CPU.Supports(cpuid.TDX_GUEST):
 		return tdxissuer.New(

--- a/internal/atls/issuer/issuer_universal.go
+++ b/internal/atls/issuer/issuer_universal.go
@@ -12,6 +12,6 @@ import (
 )
 
 // New creates an attestation issuer for the current platform.
-func New(_ *slog.Logger) (atls.Issuer, error) {
+func New(_ *slog.Logger, _ string) (atls.Issuer, error) {
 	panic("issuing is only supported on Linux")
 }

--- a/internal/attestation/certcache/cached_client.go
+++ b/internal/attestation/certcache/cached_client.go
@@ -6,18 +6,25 @@ package certcache
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	neturl "net/url"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
-	"github.com/google/go-sev-guest/kds"
-	"github.com/google/go-tdx-guest/pcs"
 	"github.com/google/go-tdx-guest/verify/trust"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
+)
+
+const (
+	// retryInterval is the spacing between upstream fetch attempts.
+	retryInterval = 5 * time.Second
+	// retryAttemptsProxy is the number of times we attempt to use the proxy before falling back to upstream.
+	retryAttemptsProxy = 5
 )
 
 var (
@@ -36,18 +43,10 @@ func alwaysRevalidate(rawURL string) bool {
 
 var collateralProxyBase string
 
-const intelCertificatesHost = "certificates.trustedservices.intel.com"
-
-// SetCollateralProxy routes attestation-collateral fetches through the in-cluster collateral-proxy at proxyURL.
+// SetCollateralProxy routes attestation-collateral fetches through the collateral-proxy at proxyURL.
+// An empty proxyURL leaves fetches going directly upstream.
 func SetCollateralProxy(proxyURL string) {
-	proxyURL = strings.TrimRight(proxyURL, "/")
-	if proxyURL == "" {
-		return
-	}
-	kds.KDSBaseURL = proxyURL
-	pcs.SgxBaseURL = proxyURL + "/sgx/certification/v4"
-	pcs.TdxBaseURL = proxyURL + "/tdx/certification/v4"
-	collateralProxyBase = proxyURL
+	collateralProxyBase = strings.TrimRight(proxyURL, "/")
 }
 
 func redirectToProxy(rawURL string) string {
@@ -55,7 +54,7 @@ func redirectToProxy(rawURL string) string {
 		return rawURL
 	}
 	u, err := neturl.Parse(rawURL)
-	if err != nil || u.Host != intelCertificatesHost {
+	if err != nil {
 		return rawURL
 	}
 	redirected := collateralProxyBase + u.Path
@@ -72,17 +71,41 @@ type CachedHTTPSGetter struct {
 
 	gcTicker clock.Ticker
 	cache    store
+
+	proxyUnreachable atomic.Bool
 }
 
 // NewCachedHTTPSGetter returns a new CachedHTTPSGetter.
 func NewCachedHTTPSGetter(s store, ticker clock.Ticker, log *slog.Logger) *CachedHTTPSGetter {
 	c := &CachedHTTPSGetter{
-		ContextHTTPSGetter: NewRetryHTTPSGetter(http.DefaultClient, 5*time.Second),
+		ContextHTTPSGetter: NewRetryHTTPSGetter(http.DefaultClient, retryInterval),
 		logger:             log,
 		cache:              s,
 		gcTicker:           ticker,
 	}
 	return c
+}
+
+// fetch issues the GET request, routing it through the collateral-proxy if configured.
+func (c *CachedHTTPSGetter) fetch(ctx context.Context, url string) (map[string][]string, []byte, error) {
+	if collateralProxyBase == "" || c.proxyUnreachable.Load() {
+		return c.ContextHTTPSGetter.GetContext(ctx, url)
+	}
+
+	proxyCtx, cancel := context.WithTimeout(ctx, retryAttemptsProxy*retryInterval)
+	header, body, err := c.ContextHTTPSGetter.GetContext(proxyCtx, redirectToProxy(url))
+	cancel()
+	if err == nil {
+		return header, body, nil
+	}
+	var httpErr *httpError
+	if errors.As(err, &httpErr) {
+		return nil, nil, err
+	}
+	if c.proxyUnreachable.CompareAndSwap(false, true) {
+		c.logger.Warn("collateral proxy not reachable, falling back to direct upstream fetching", "url", url, "error", err)
+	}
+	return c.ContextHTTPSGetter.GetContext(ctx, url)
 }
 
 // Get makes a GET request to the given URL.
@@ -99,13 +122,12 @@ func (c *CachedHTTPSGetter) GetContext(ctx context.Context, url string) (map[str
 	default:
 	}
 
-	url = redirectToProxy(url)
 	log := c.logger.With("url", url)
 
 	if alwaysRevalidate(url) {
 		// For CRLs or TDX TCB/QeIdentity always query. When request failure, fallback to cache.
 		log.Debug("Requesting URL")
-		header, body, err := c.ContextHTTPSGetter.GetContext(ctx, url)
+		header, body, err := c.fetch(ctx, url)
 		if err == nil {
 			if data, err := json.Marshal(cacheEntry{header, body}); err == nil {
 				c.cache.Set(url, data)
@@ -134,7 +156,7 @@ func (c *CachedHTTPSGetter) GetContext(ctx context.Context, url string) (map[str
 		}
 	}
 	log.Debug("Cache miss, requesting")
-	header, body, err := c.ContextHTTPSGetter.GetContext(ctx, url)
+	header, body, err := c.fetch(ctx, url)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/attestation/certcache/cached_client.go
+++ b/internal/attestation/certcache/cached_client.go
@@ -41,29 +41,6 @@ func alwaysRevalidate(rawURL string) bool {
 	return snpCrlPath.MatchString(u.Path) || tdxRootCrlPath.MatchString(u.Path) || tdxBasePath.MatchString(u.Path)
 }
 
-var collateralProxyBase string
-
-// SetCollateralProxy routes attestation-collateral fetches through the collateral-proxy at proxyURL.
-// An empty proxyURL leaves fetches going directly upstream.
-func SetCollateralProxy(proxyURL string) {
-	collateralProxyBase = strings.TrimRight(proxyURL, "/")
-}
-
-func redirectToProxy(rawURL string) string {
-	if collateralProxyBase == "" {
-		return rawURL
-	}
-	u, err := neturl.Parse(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	redirected := collateralProxyBase + u.Path
-	if u.RawQuery != "" {
-		redirected += "?" + u.RawQuery
-	}
-	return redirected
-}
-
 // CachedHTTPSGetter is a HTTPS client that caches responses in memory.
 type CachedHTTPSGetter struct {
 	trust.ContextHTTPSGetter
@@ -72,28 +49,46 @@ type CachedHTTPSGetter struct {
 	gcTicker clock.Ticker
 	cache    store
 
+	collateralProxyBase string
+
 	proxyUnreachable atomic.Bool
 }
 
 // NewCachedHTTPSGetter returns a new CachedHTTPSGetter.
-func NewCachedHTTPSGetter(s store, ticker clock.Ticker, log *slog.Logger) *CachedHTTPSGetter {
+func NewCachedHTTPSGetter(s store, ticker clock.Ticker, log *slog.Logger, collateralProxy string) *CachedHTTPSGetter {
 	c := &CachedHTTPSGetter{
-		ContextHTTPSGetter: NewRetryHTTPSGetter(http.DefaultClient, retryInterval),
-		logger:             log,
-		cache:              s,
-		gcTicker:           ticker,
+		ContextHTTPSGetter:  NewRetryHTTPSGetter(http.DefaultClient, retryInterval),
+		logger:              log,
+		cache:               s,
+		gcTicker:            ticker,
+		collateralProxyBase: strings.TrimRight(collateralProxy, "/"),
 	}
 	return c
 }
 
+func (c *CachedHTTPSGetter) redirectToProxy(rawURL string) string {
+	if c.collateralProxyBase == "" {
+		return rawURL
+	}
+	u, err := neturl.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	redirected := c.collateralProxyBase + u.Path
+	if u.RawQuery != "" {
+		redirected += "?" + u.RawQuery
+	}
+	return redirected
+}
+
 // fetch issues the GET request, routing it through the collateral-proxy if configured.
 func (c *CachedHTTPSGetter) fetch(ctx context.Context, url string) (map[string][]string, []byte, error) {
-	if collateralProxyBase == "" || c.proxyUnreachable.Load() {
+	if c.collateralProxyBase == "" || c.proxyUnreachable.Load() {
 		return c.ContextHTTPSGetter.GetContext(ctx, url)
 	}
 
 	proxyCtx, cancel := context.WithTimeout(ctx, retryAttemptsProxy*retryInterval)
-	header, body, err := c.ContextHTTPSGetter.GetContext(proxyCtx, redirectToProxy(url))
+	header, body, err := c.ContextHTTPSGetter.GetContext(proxyCtx, c.redirectToProxy(url))
 	cancel()
 	if err == nil {
 		return header, body, nil

--- a/internal/attestation/certcache/cached_client.go
+++ b/internal/attestation/certcache/cached_client.go
@@ -25,6 +25,8 @@ const (
 	retryInterval = 5 * time.Second
 	// retryAttemptsProxy is the number of times we attempt to use the proxy before falling back to upstream.
 	retryAttemptsProxy = 5
+	// proxyRetryCooldown is how long we fall back to direct upstream fetching, before trying the proxy again.
+	proxyRetryCooldown = 2 * time.Minute
 )
 
 var (
@@ -47,11 +49,12 @@ type CachedHTTPSGetter struct {
 	logger *slog.Logger
 
 	gcTicker clock.Ticker
+	clock    clock.PassiveClock
 	cache    store
 
 	collateralProxyBase string
 
-	proxyUnreachable atomic.Bool
+	proxyRetryAfter atomic.Int64
 }
 
 // NewCachedHTTPSGetter returns a new CachedHTTPSGetter.
@@ -61,6 +64,7 @@ func NewCachedHTTPSGetter(s store, ticker clock.Ticker, log *slog.Logger, collat
 		logger:              log,
 		cache:               s,
 		gcTicker:            ticker,
+		clock:               clock.RealClock{},
 		collateralProxyBase: strings.TrimRight(collateralProxy, "/"),
 	}
 	return c
@@ -83,7 +87,7 @@ func (c *CachedHTTPSGetter) redirectToProxy(rawURL string) string {
 
 // fetch issues the GET request, routing it through the collateral-proxy if configured.
 func (c *CachedHTTPSGetter) fetch(ctx context.Context, url string) (map[string][]string, []byte, error) {
-	if c.collateralProxyBase == "" || c.proxyUnreachable.Load() {
+	if c.collateralProxyBase == "" || c.proxyInCooldown() {
 		return c.ContextHTTPSGetter.GetContext(ctx, url)
 	}
 
@@ -91,16 +95,22 @@ func (c *CachedHTTPSGetter) fetch(ctx context.Context, url string) (map[string][
 	header, body, err := c.ContextHTTPSGetter.GetContext(proxyCtx, c.redirectToProxy(url))
 	cancel()
 	if err == nil {
+		// The proxy recovered (or was reachable all along); clear any pending cooldown.
+		c.proxyRetryAfter.Store(0)
 		return header, body, nil
 	}
 	var httpErr *httpError
 	if errors.As(err, &httpErr) {
 		return nil, nil, err
 	}
-	if c.proxyUnreachable.CompareAndSwap(false, true) {
-		c.logger.Warn("collateral proxy not reachable, falling back to direct upstream fetching", "url", url, "error", err)
-	}
+	c.proxyRetryAfter.Store(c.clock.Now().Add(proxyRetryCooldown).UnixNano())
+	c.logger.Warn("collateral proxy not reachable, falling back to direct upstream fetching", "url", url, "error", err, "cooldown", proxyRetryCooldown)
 	return c.ContextHTTPSGetter.GetContext(ctx, url)
+}
+
+func (c *CachedHTTPSGetter) proxyInCooldown() bool {
+	retryAfter := c.proxyRetryAfter.Load()
+	return retryAfter != 0 && c.clock.Now().UnixNano() < retryAfter
 }
 
 // Get makes a GET request to the given URL.

--- a/internal/attestation/certcache/cached_client_test.go
+++ b/internal/attestation/certcache/cached_client_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	neturl "net/url"
 	"sync"
 	"testing"
 	"time"
@@ -58,9 +59,12 @@ func TestRedirectToProxy(t *testing.T) {
 	assert.Equal(t,
 		proxy+"/IntelSGXRootCA.der",
 		redirectToProxy("https://certificates.trustedservices.intel.com/IntelSGXRootCA.der"))
-
-	assert.Equal(t, proxy+"/vcek/v1/Milan/crl", redirectToProxy(proxy+"/vcek/v1/Milan/crl"))
-	assert.Equal(t, "https://kdsintf.amd.com/vcek/v1/Milan/abc", redirectToProxy("https://kdsintf.amd.com/vcek/v1/Milan/abc"))
+	assert.Equal(t,
+		proxy+"/vcek/v1/Milan/abc",
+		redirectToProxy("https://kdsintf.amd.com/vcek/v1/Milan/abc"))
+	assert.Equal(t,
+		proxy+"/sgx/certification/v4/pckcrl?ca=platform&encoding=der",
+		redirectToProxy("https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der"))
 
 	// With no proxy configured, nothing is rewritten.
 	collateralProxyBase = ""
@@ -243,6 +247,87 @@ func TestContextCancellation(t *testing.T) {
 
 	_, _, err := getter.GetContext(ctx, crlURLMatch)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestProxyFallback(t *testing.T) {
+	const (
+		proxyBase = "http://collateral-proxy.default.svc"
+		proxyHost = "collateral-proxy.default.svc"
+		kdsHost   = "kdsintf.amd.com"
+	)
+	t.Cleanup(func() { collateralProxyBase = "" })
+	collateralProxyBase = proxyBase
+
+	directCRL := "https://" + kdsHost + "/vcek/v1/Milan/crl"
+
+	t.Run("unreachable proxy falls back to upstream", func(t *testing.T) {
+		assert := assert.New(t)
+		getter := &fakeHostGetter{
+			hits:     map[string]int{},
+			errHosts: map[string]error{proxyHost: errors.New("dial tcp: connection refused")},
+			body:     []byte("crl-bytes"),
+		}
+		client := newHostGetterClient(getter)
+
+		_, body, err := client.Get(directCRL)
+		assert.NoError(err)
+		assert.Equal([]byte("crl-bytes"), body)
+		assert.Equal(1, getter.hits[proxyHost])
+		assert.Equal(1, getter.hits[kdsHost])
+		assert.True(client.proxyUnreachable.Load())
+
+		_, _, err = client.Get(directCRL)
+		assert.NoError(err)
+		assert.Equal(1, getter.hits[proxyHost])
+		assert.Equal(2, getter.hits[kdsHost])
+	})
+
+	t.Run("HTTP status from proxy is honored, no fallback", func(t *testing.T) {
+		assert := assert.New(t)
+		getter := &fakeHostGetter{
+			hits:     map[string]int{},
+			errHosts: map[string]error{proxyHost: &httpError{code: 404, status: "404 Not Found"}},
+		}
+		client := newHostGetterClient(getter)
+
+		_, _, err := client.Get(directCRL)
+		assert.Error(err)
+		assert.Equal(1, getter.hits[proxyHost])
+		assert.Equal(0, getter.hits[kdsHost]) // upstream not contacted
+		assert.False(client.proxyUnreachable.Load())
+	})
+}
+
+func newHostGetterClient(getter *fakeHostGetter) *CachedHTTPSGetter {
+	return &CachedHTTPSGetter{
+		ContextHTTPSGetter: getter,
+		gcTicker:           NeverGCTicker,
+		cache:              memstore.New[string, []byte](),
+		logger:             slog.Default(),
+	}
+}
+
+// fakeHostGetter records hits and returns a configured error per upstream host.
+type fakeHostGetter struct {
+	mux      sync.Mutex
+	hits     map[string]int
+	errHosts map[string]error
+	header   map[string][]string
+	body     []byte
+}
+
+func (g *fakeHostGetter) GetContext(_ context.Context, url string) (map[string][]string, []byte, error) {
+	u, err := neturl.Parse(url)
+	if err != nil {
+		return nil, nil, err
+	}
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	g.hits[u.Host]++
+	if e := g.errHosts[u.Host]; e != nil {
+		return nil, nil, e
+	}
+	return g.header, g.body, nil
 }
 
 // Ensure CachedHTTPSGetter implements the expected interfaces.

--- a/internal/attestation/certcache/cached_client_test.go
+++ b/internal/attestation/certcache/cached_client_test.go
@@ -263,19 +263,47 @@ func TestProxyFallback(t *testing.T) {
 			errHosts: map[string]error{proxyHost: errors.New("dial tcp: connection refused")},
 			body:     []byte("crl-bytes"),
 		}
-		client := newHostGetterClient(getter, proxyBase)
+		client, _ := newHostGetterClient(getter, proxyBase)
 
 		_, body, err := client.Get(directCRL)
 		assert.NoError(err)
 		assert.Equal([]byte("crl-bytes"), body)
 		assert.Equal(1, getter.hits[proxyHost])
 		assert.Equal(1, getter.hits[kdsHost])
-		assert.True(client.proxyUnreachable.Load())
+		assert.True(client.proxyInCooldown())
 
 		_, _, err = client.Get(directCRL)
 		assert.NoError(err)
 		assert.Equal(1, getter.hits[proxyHost])
 		assert.Equal(2, getter.hits[kdsHost])
+	})
+
+	t.Run("proxy is tried again after the cooldown", func(t *testing.T) {
+		assert := assert.New(t)
+		getter := &fakeHostGetter{
+			hits:     map[string]int{},
+			errHosts: map[string]error{proxyHost: errors.New("dial tcp: connection refused")},
+			body:     []byte("crl-bytes"),
+		}
+		client, testClock := newHostGetterClient(getter, proxyBase)
+
+		_, _, err := client.Get(directCRL)
+		assert.NoError(err)
+		assert.Equal(1, getter.hits[proxyHost])
+		assert.True(client.proxyInCooldown())
+
+		testClock.Step(proxyRetryCooldown - time.Second)
+		_, _, err = client.Get(directCRL)
+		assert.NoError(err)
+		assert.Equal(1, getter.hits[proxyHost])
+
+		delete(getter.errHosts, proxyHost)
+		testClock.Step(2 * time.Second)
+		_, body, err := client.Get(directCRL)
+		assert.NoError(err)
+		assert.Equal([]byte("crl-bytes"), body)
+		assert.Equal(2, getter.hits[proxyHost])
+		assert.False(client.proxyInCooldown())
 	})
 
 	t.Run("HTTP status from proxy is honored, no fallback", func(t *testing.T) {
@@ -284,24 +312,26 @@ func TestProxyFallback(t *testing.T) {
 			hits:     map[string]int{},
 			errHosts: map[string]error{proxyHost: &httpError{code: 404, status: "404 Not Found"}},
 		}
-		client := newHostGetterClient(getter, proxyBase)
+		client, _ := newHostGetterClient(getter, proxyBase)
 
 		_, _, err := client.Get(directCRL)
 		assert.Error(err)
 		assert.Equal(1, getter.hits[proxyHost])
 		assert.Equal(0, getter.hits[kdsHost]) // upstream not contacted
-		assert.False(client.proxyUnreachable.Load())
+		assert.False(client.proxyInCooldown())
 	})
 }
 
-func newHostGetterClient(getter *fakeHostGetter, collateralProxyBase string) *CachedHTTPSGetter {
+func newHostGetterClient(getter *fakeHostGetter, collateralProxyBase string) (*CachedHTTPSGetter, *testingclock.FakeClock) {
+	testClock := testingclock.NewFakeClock(time.Now())
 	return &CachedHTTPSGetter{
 		ContextHTTPSGetter:  getter,
 		gcTicker:            NeverGCTicker,
+		clock:               testClock,
 		cache:               memstore.New[string, []byte](),
 		logger:              slog.Default(),
 		collateralProxyBase: collateralProxyBase,
-	}
+	}, testClock
 }
 
 // fakeHostGetter records hits and returns a configured error per upstream host.

--- a/internal/attestation/certcache/cached_client_test.go
+++ b/internal/attestation/certcache/cached_client_test.go
@@ -53,23 +53,21 @@ func TestAlwaysRevalidate(t *testing.T) {
 
 func TestRedirectToProxy(t *testing.T) {
 	const proxy = "http://collateral-proxy.default.svc"
-	t.Cleanup(func() { collateralProxyBase = "" })
-
-	collateralProxyBase = proxy
+	c := &CachedHTTPSGetter{collateralProxyBase: proxy}
 	assert.Equal(t,
 		proxy+"/IntelSGXRootCA.der",
-		redirectToProxy("https://certificates.trustedservices.intel.com/IntelSGXRootCA.der"))
+		c.redirectToProxy("https://certificates.trustedservices.intel.com/IntelSGXRootCA.der"))
 	assert.Equal(t,
 		proxy+"/vcek/v1/Milan/abc",
-		redirectToProxy("https://kdsintf.amd.com/vcek/v1/Milan/abc"))
+		c.redirectToProxy("https://kdsintf.amd.com/vcek/v1/Milan/abc"))
 	assert.Equal(t,
 		proxy+"/sgx/certification/v4/pckcrl?ca=platform&encoding=der",
-		redirectToProxy("https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der"))
+		c.redirectToProxy("https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der"))
 
 	// With no proxy configured, nothing is rewritten.
-	collateralProxyBase = ""
+	noProxy := &CachedHTTPSGetter{}
 	const rootCRL = "https://certificates.trustedservices.intel.com/IntelSGXRootCA.der"
-	assert.Equal(t, rootCRL, redirectToProxy(rootCRL))
+	assert.Equal(t, rootCRL, noProxy.redirectToProxy(rootCRL))
 }
 
 const crlURLMatch string = "https://kdsintf.amd.com/vcek/v1/test/crl"
@@ -255,8 +253,6 @@ func TestProxyFallback(t *testing.T) {
 		proxyHost = "collateral-proxy.default.svc"
 		kdsHost   = "kdsintf.amd.com"
 	)
-	t.Cleanup(func() { collateralProxyBase = "" })
-	collateralProxyBase = proxyBase
 
 	directCRL := "https://" + kdsHost + "/vcek/v1/Milan/crl"
 
@@ -267,7 +263,7 @@ func TestProxyFallback(t *testing.T) {
 			errHosts: map[string]error{proxyHost: errors.New("dial tcp: connection refused")},
 			body:     []byte("crl-bytes"),
 		}
-		client := newHostGetterClient(getter)
+		client := newHostGetterClient(getter, proxyBase)
 
 		_, body, err := client.Get(directCRL)
 		assert.NoError(err)
@@ -288,7 +284,7 @@ func TestProxyFallback(t *testing.T) {
 			hits:     map[string]int{},
 			errHosts: map[string]error{proxyHost: &httpError{code: 404, status: "404 Not Found"}},
 		}
-		client := newHostGetterClient(getter)
+		client := newHostGetterClient(getter, proxyBase)
 
 		_, _, err := client.Get(directCRL)
 		assert.Error(err)
@@ -298,12 +294,13 @@ func TestProxyFallback(t *testing.T) {
 	})
 }
 
-func newHostGetterClient(getter *fakeHostGetter) *CachedHTTPSGetter {
+func newHostGetterClient(getter *fakeHostGetter, collateralProxyBase string) *CachedHTTPSGetter {
 	return &CachedHTTPSGetter{
-		ContextHTTPSGetter: getter,
-		gcTicker:           NeverGCTicker,
-		cache:              memstore.New[string, []byte](),
-		logger:             slog.Default(),
+		ContextHTTPSGetter:  getter,
+		gcTicker:            NeverGCTicker,
+		cache:               memstore.New[string, []byte](),
+		logger:              slog.Default(),
+		collateralProxyBase: collateralProxyBase,
 	}
 }
 

--- a/internal/attestation/snp/issuer/issuer.go
+++ b/internal/attestation/snp/issuer/issuer.go
@@ -38,12 +38,12 @@ type Issuer struct {
 }
 
 // New returns a new Issuer.
-func New(log *slog.Logger) *Issuer {
+func New(log *slog.Logger, collateralProxy string) *Issuer {
 	month := 30 * 24 * time.Hour
 	ticker := clock.RealClock{}.NewTicker(9 * month)
 	return &Issuer{
 		logger:    log,
-		kdsGetter: certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(log, "kds-getter-issuer")).SNPGetter(),
+		kdsGetter: certcache.NewCachedHTTPSGetter(memstore.New[string, []byte](), ticker, logger.NewNamed(log, "kds-getter-issuer"), collateralProxy).SNPGetter(),
 	}
 }
 

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -34,6 +34,9 @@ type Client struct {
 	// Client.
 	fsstore *fsstore.Store
 
+	// collateralProxy, when non-empty, is the base URL of a proxy that attestation-collateral fetches are routed through.
+	collateralProxy string
+
 	log *slog.Logger
 
 	// validatorsFromManifestOverride is used by tests to replace the validators.
@@ -76,6 +79,14 @@ func (c *Client) WithSlog(log *slog.Logger) *Client {
 // WithHTTPClient replaces the Client's default [http.Client].
 func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 	c.httpClient = httpClient
+	return c
+}
+
+// WithCollateralProxy routes the Client's attestation-collateral fetches (AMD KDS, Intel PCS, NVIDIA RIM)
+// through a caching proxy at the given base URL, falling back to direct upstream fetching when the proxy is unreachable.
+// An empty URL (the default) fetches directly upstream.
+func (c *Client) WithCollateralProxy(proxyURL string) *Client {
+	c.collateralProxy = proxyURL
 	return c
 }
 
@@ -158,7 +169,7 @@ func (c Client) ValidateAttestation(ctx context.Context, nonce []byte, attestati
 		return nil, fmt.Errorf("validating latest manifest: %w", err)
 	}
 
-	kdsGetter := certcache.NewCachedHTTPSGetter(c.fsstore, certcache.NeverGCTicker, c.log.WithGroup("kds-getter"))
+	kdsGetter := certcache.NewCachedHTTPSGetter(c.fsstore, certcache.NeverGCTicker, c.log.WithGroup("kds-getter"), c.collateralProxy)
 	validatorsFromManifest := func(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) (validators.Validator, error) {
 		return m.CoordinatorValidator(log, kdsGetter)
 	}


### PR DESCRIPTION
This is a couple of related things thrown together in this PR. The commits themselves are rather stand-alone.

- the remaining ticket was to make the proxy be used in set/verify/recover, that is done here
- noticed it should also be usable through the SDK, leading to a small refactor
- noticed when using the proxy in set/verify/recover in e2es I had to clean up the proxy setting since it was global, so refactored to use per-getter config. TBH should probably have been like that from the start.
- and finally, use in set/verify/recover in e2es