### PR TITLE
atls: move validators into dedicated package 

### DIFF
--- a/coordinator/internal/peerrecovery/recovery.go
+++ b/coordinator/internal/peerrecovery/recovery.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/manifest"
@@ -183,12 +184,12 @@ func periodically(ctx context.Context, clock clock.WithTicker, interval time.Dur
 }
 
 type meshAPIDialer interface {
-	Dial(context.Context, atls.Issuer, []atls.Validator, *slog.Logger, string) (meshapi.MeshAPIClient, func() error, error)
+	Dial(context.Context, atls.Issuer, []validators.Validator, *slog.Logger, string) (meshapi.MeshAPIClient, func() error, error)
 }
 
 type defaultMeshAPIDialer struct{}
 
-func (defaultMeshAPIDialer) Dial(ctx context.Context, issuer atls.Issuer, validators []atls.Validator, logger *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
+func (defaultMeshAPIDialer) Dial(ctx context.Context, issuer atls.Issuer, validators []validators.Validator, logger *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
 	dial := dialer.New(issuer, validators, atls.NoMetrics, nil, logger)
 	conn, err := dial.Dial(ctx, addr)
 	if err != nil {

--- a/coordinator/internal/peerrecovery/recovery_test.go
+++ b/coordinator/internal/peerrecovery/recovery_test.go
@@ -104,7 +104,7 @@ func TestRecoverOnce(t *testing.T) {
 			r := &Recoverer{
 				guard:      tc.guard,
 				peerGetter: tc.peerGetter,
-				issuer:     &atls.FakeIssuer{},
+				issuer:     &fakeIssuer{},
 				dialer:     &stubDialer{responses: tc.dialResponse},
 				logger:     logger,
 			}
@@ -128,7 +128,7 @@ func TestRecoverFromPeer(t *testing.T) {
 	}
 	r := &Recoverer{
 		guard:  newFakeStaleGuard(t),
-		issuer: &atls.FakeIssuer{},
+		issuer: &fakeIssuer{},
 		dialer: dialer,
 		logger: logger,
 	}
@@ -141,6 +141,10 @@ func TestRecoverFromPeer(t *testing.T) {
 	// One SNP reference value with APEIP set yields one IterativeValidator.
 	require.Len(dialer.recordedValidators, 1)
 	assert.IsType(&snp.IterativeValidator{}, dialer.recordedValidators[0])
+}
+
+type fakeIssuer struct {
+	atls.Issuer
 }
 
 type fakeStaleGuard struct {

--- a/coordinator/internal/peerrecovery/recovery_test.go
+++ b/coordinator/internal/peerrecovery/recovery_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/ca"
 	"github.com/edgelesssys/contrast/internal/manifest"
@@ -230,12 +231,12 @@ type stubDialer struct {
 	responses map[string]meshapi.MeshAPIClient
 
 	recordedIssuer     atls.Issuer
-	recordedValidators []atls.Validator
+	recordedValidators []validators.Validator
 	recordedAddress    string
 	closeCalled        bool
 }
 
-func (d *stubDialer) Dial(_ context.Context, issuer atls.Issuer, validators []atls.Validator, _ *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
+func (d *stubDialer) Dial(_ context.Context, issuer atls.Issuer, validators []validators.Validator, _ *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
 	d.recordedAddress = addr
 	d.recordedIssuer = issuer
 	d.recordedValidators = validators

--- a/coordinator/internal/stateguard/credentials.go
+++ b/coordinator/internal/stateguard/credentials.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
@@ -71,7 +72,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		State: state,
 	}
 
-	var validators []atls.Validator
+	var allValidators []validators.Validator
 
 	snpOpts, err := state.Manifest().SNPValidateOpts(c.kdsGetter)
 	if err != nil {
@@ -82,7 +83,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 	for i, opt := range snpOpts {
 		name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
 		validatorLog := logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"reference-values": name})
-		var validator atls.Validator
+		var validator validators.Validator
 		if len(opt.APEIP) == 4 {
 			seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
 			apEIP := binary.BigEndian.Uint32(opt.APEIP)
@@ -90,7 +91,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		} else {
 			validator = snp.NewValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, &authInfo, name)
 		}
-		validators = append(validators, validator)
+		allValidators = append(allValidators, validator)
 	}
 
 	tdxOpts, err := state.Manifest().TDXValidateOpts(c.kdsGetter)
@@ -100,11 +101,11 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 	}
 	for i, opt := range tdxOpts {
 		name := fmt.Sprintf("tdx-%d", i)
-		validators = append(validators, tdx.NewValidatorWithReportSetter(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs,
+		allValidators = append(allValidators, tdx.NewValidatorWithReportSetter(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs,
 			logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"reference-values": name}), &authInfo, name))
 	}
 
-	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, validators, c.attestationFailuresCounter)
+	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, allValidators, c.attestationFailuresCounter)
 	if err != nil {
 		log.Error("Could not create TLS config", "error", err)
 		return nil, nil, err

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -27,6 +27,7 @@ import (
 	userapiserver "github.com/edgelesssys/contrast/coordinator/internal/userapi"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/defaultdeny"
@@ -127,7 +128,7 @@ func run() (retErr error) {
 		return fmt.Errorf("creating issuer: %w", err)
 	}
 
-	userAPICredentials := atlscredentials.New(issuer, atls.NoValidators, atls.NoMetrics, loggerpkg.NewNamed(logger, "atlscredentials"))
+	userAPICredentials := atlscredentials.New(issuer, validators.NoValidation(), atls.NoMetrics, loggerpkg.NewNamed(logger, "atlscredentials"))
 	userAPIServer := newGRPCServer(userAPICredentials, serverMetrics)
 	userapi.RegisterUserAPIServer(userAPIServer, userapiserver.New(logger, meshAuth, discovery))
 	serverMetrics.InitializeMetrics(userAPIServer)

--- a/e2e/atls/atls_test.go
+++ b/e2e/atls/atls_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
@@ -152,12 +153,12 @@ func TestATLS(t *testing.T) {
 				kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, logger.WithGroup("kds-getter"))
 				opts, err := manifestParsed.SNPValidateOpts(kdsGetter)
 				require.NoError(err, "getting SNP validate options")
-				var validators []atls.Validator
+				var allValidators []validators.Validator
 				for i, opt := range opts {
 					opt.ValidateOpts.HostData = coordPolicyHashBytes
 					assert.NoError(tc.manifestModifyFunc(&opt))
 					name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
-					var v atls.Validator
+					var v validators.Validator
 					if len(opt.APEIP) == 4 {
 						seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
 						apEIP := binary.BigEndian.Uint32(opt.APEIP)
@@ -165,10 +166,10 @@ func TestATLS(t *testing.T) {
 					} else {
 						v = snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, logger.WithGroup("validator"), name)
 					}
-					validators = append(validators, v)
+					allValidators = append(allValidators, v)
 				}
 
-				dialer := dialer.New(atls.NoIssuer, validators, atls.NoMetrics, nil, logger)
+				dialer := dialer.New(atls.NoIssuer, allValidators, atls.NoMetrics, nil, logger)
 				conn, err := dialer.Dial(ctx, addr)
 				require.NoError(err, "dialing coordinator")
 				defer conn.Close()

--- a/e2e/attestation/attestation_test.go
+++ b/e2e/attestation/attestation_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
@@ -244,7 +245,7 @@ func TestAttestation(t *testing.T) {
 
 		validator := tdx.NewValidatorWithReportSetter(verifyOpts, validateOptsGen, nil, logger, &reportRecorder, "tdx-collateral-test")
 
-		cfg, err := atls.CreateAttestationClientTLSConfig(ctx, nil, []atls.Validator{validator}, nil)
+		cfg, err := atls.CreateAttestationClientTLSConfig(ctx, nil, []validators.Validator{validator}, nil)
 		require.NoError(err)
 
 		require.NoError(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-coordinator", userapi.Port, func(addr string) error {

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/defaultdeny"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
@@ -115,7 +116,7 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 	requestCert := func() (*meshapi.NewMeshCertResponse, error) {
 		// Supply an empty list of validators, as the coordinator does not need to be
 		// validated by the initializer.
-		dial := dialer.NewWithKey(issuer, atls.NoValidators, atls.NoMetrics, nil, privKey, log)
+		dial := dialer.NewWithKey(issuer, validators.NoValidation(), atls.NoMetrics, nil, privKey, log)
 		conn, err := dial.Dial(ctx, net.JoinHostPort(coordinatorHostname, meshapi.Port))
 		if err != nil {
 			return nil, fmt.Errorf("dialing: %w", err)

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -23,14 +23,13 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/internal/atls/reportdata"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	// NoValidators skips validation of the server's attestation document.
-	NoValidators = []Validator{}
 	// NoIssuer skips embedding the client's attestation document.
 	NoIssuer Issuer
 	// NoMetrics skips collecting metrics for attestation failures.
@@ -45,7 +44,7 @@ var (
 // CreateAttestationServerTLSConfig creates a tls.Config object with a self-signed certificate and an embedded attestation document.
 // Pass a list of validators to enable mutual aTLS.
 // If issuer is nil, no attestation will be embedded.
-func CreateAttestationServerTLSConfig(issuer Issuer, validators []Validator, attestationFailures prometheus.Counter) (*tls.Config, error) {
+func CreateAttestationServerTLSConfig(issuer Issuer, validators []validators.Validator, attestationFailures prometheus.Counter) (*tls.Config, error) {
 	getConfigForClient, err := getATLSConfigForClientFunc(issuer, validators, attestationFailures)
 	if err != nil {
 		return nil, fmt.Errorf("get aTLS config for client: %w", err)
@@ -63,7 +62,7 @@ func CreateAttestationServerTLSConfig(issuer Issuer, validators []Validator, att
 //
 // If no validators are set, the server's attestation document will not be verified.
 // If issuer is nil, the client will be unable to perform mutual aTLS.
-func CreateAttestationClientTLSConfig(ctx context.Context, issuer Issuer, validators []Validator, privKey crypto.PrivateKey) (*tls.Config, error) {
+func CreateAttestationClientTLSConfig(ctx context.Context, issuer Issuer, validators []validators.Validator, privKey crypto.PrivateKey) (*tls.Config, error) {
 	clientNonce, err := cryptohelpers.GenerateRandomBytes(cryptohelpers.RNGLengthDefault)
 	if err != nil {
 		return nil, err
@@ -95,17 +94,10 @@ type Issuer interface {
 	Issue(ctx context.Context, reportData [64]byte) (quote []byte, err error)
 }
 
-// Validator is able to validate an attestation document.
-type Validator interface {
-	Getter
-	Validate(ctx context.Context, attDoc []byte, reportData []byte) error
-	fmt.Stringer
-}
-
 // getATLSConfigForClientFunc returns a config setup function that is called once for every client connecting to the server.
 // This allows for different server configuration for every client.
 // In aTLS this is used to generate unique nonces for every client.
-func getATLSConfigForClientFunc(issuer Issuer, validators []Validator, attestationFailures prometheus.Counter) (func(*tls.ClientHelloInfo) (*tls.Config, error), error) {
+func getATLSConfigForClientFunc(issuer Issuer, validators []validators.Validator, attestationFailures prometheus.Counter) (func(*tls.ClientHelloInfo) (*tls.Config, error), error) {
 	// generate key for the server
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -227,7 +219,7 @@ func processCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) (*x509.Certi
 // verifyEmbeddedReport verifies an aTLS certificate by validating the attestation document embedded in the TLS certificate.
 //
 // It will check against all applicable validator for the type of attestation document, and return success on the first match.
-func verifyEmbeddedReport(ctx context.Context, validators []Validator, cert *x509.Certificate, peerPublicKey, nonce []byte) (retErr error) {
+func verifyEmbeddedReport(ctx context.Context, validators []validators.Validator, cert *x509.Certificate, peerPublicKey, nonce []byte) (retErr error) {
 	// For better error reporting, let's keep track of whether we've found a valid extension at all..
 	var foundExtension bool
 	// .. and whether we've found a matching validator.
@@ -382,7 +374,7 @@ func extractNonce(proto string) (string, error) {
 // clientConnection holds state for client to server connections.
 type clientConnection struct {
 	issuer      Issuer
-	validators  []Validator
+	validators  []validators.Validator
 	clientNonce []byte
 	privKey     crypto.PrivateKey
 }
@@ -441,7 +433,7 @@ func publicKey(key crypto.PrivateKey) crypto.PublicKey {
 // serverConnection holds state for server to client connections.
 type serverConnection struct {
 	issuer              Issuer
-	validators          []Validator
+	validators          []validators.Validator
 	attestationFailures prometheus.Counter
 	privKey             crypto.PrivateKey
 	serverNonce         []byte

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -496,21 +496,6 @@ func getNonce(chi *tls.ClientHelloInfo) ([]byte, error) {
 	return clientNonce, nil
 }
 
-// FakeIssuer fakes an issuer and can be used for tests.
-type FakeIssuer struct {
-	Getter
-}
-
-// NewFakeIssuer creates a new FakeIssuer with the given OID.
-func NewFakeIssuer(oid Getter) *FakeIssuer {
-	return &FakeIssuer{oid}
-}
-
-// Issue marshals the user data and returns it.
-func (FakeIssuer) Issue(_ context.Context, reportData [64]byte) ([]byte, error) {
-	return json.Marshal(FakeAttestationDoc{ReportData: reportData[:]})
-}
-
 // FakeValidator fakes a validator and can be used for tests.
 type FakeValidator struct {
 	Getter

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -5,7 +5,6 @@
 package atls
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -17,7 +16,6 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -494,46 +492,6 @@ func getNonce(chi *tls.ClientHelloInfo) ([]byte, error) {
 		return nil, fmt.Errorf("decoding nonce from SNI: %w", err)
 	}
 	return clientNonce, nil
-}
-
-// FakeValidator fakes a validator and can be used for tests.
-type FakeValidator struct {
-	Getter
-	err error // used for package internal testing only
-}
-
-// NewFakeValidator creates a new FakeValidator with the given OID.
-func NewFakeValidator(oid Getter) *FakeValidator {
-	return &FakeValidator{oid, nil}
-}
-
-// NewFakeValidators returns a slice with a single FakeValidator.
-func NewFakeValidators(oid Getter) []Validator {
-	return []Validator{NewFakeValidator(oid)}
-}
-
-// Validate unmarshals the attestation document and verifies the nonce.
-func (v FakeValidator) Validate(_ context.Context, attDoc []byte, reportData []byte) error {
-	var doc FakeAttestationDoc
-	if err := json.Unmarshal(attDoc, &doc); err != nil {
-		return err
-	}
-
-	if !bytes.Equal(doc.ReportData, reportData) {
-		return fmt.Errorf("invalid reportData: expected %x, got %x", doc.ReportData, reportData)
-	}
-
-	return v.err
-}
-
-// String returns the name as identifier of the validator.
-func (v *FakeValidator) String() string {
-	return ""
-}
-
-// FakeAttestationDoc is a fake attestation document used for testing.
-type FakeAttestationDoc struct {
-	ReportData []byte
 }
 
 // Getter returns an ASN.1 Object Identifier.

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -4,6 +4,7 @@
 package atls
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/tls"
@@ -12,6 +13,7 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/edgelesssys/contrast/internal/atls/reportdata"
@@ -24,7 +26,7 @@ import (
 
 func TestVerifyEmbeddedReport(t *testing.T) {
 	expectedReportData := reportdata.Construct(nil, nil)
-	fakeAttDoc := &FakeAttestationDoc{
+	fakeAttDoc := &fakeAttestationDoc{
 		ReportData: expectedReportData[:],
 	}
 	attDocBytes, err := json.Marshal(fakeAttDoc)
@@ -48,7 +50,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: NewFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(stubSNPValidator{}),
 		},
 		"multiple matches": {
 			cert: &x509.Certificate{
@@ -63,7 +65,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: NewFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(stubSNPValidator{}),
 		},
 		"skip non-matching validator": {
 			cert: &x509.Certificate{
@@ -77,7 +79,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: append(NewFakeValidators(stubSNPValidator{}), NewFakeValidator(stubFooValidator{})),
+			validators: append(newFakeValidators(stubSNPValidator{}), newFakeValidators(stubFooValidator{})...),
 		},
 		"match, error": {
 			cert: &x509.Certificate{
@@ -88,7 +90,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: NewFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(stubSNPValidator{}),
 			wantErr:    true,
 		},
 		"no extensions": {
@@ -126,6 +128,39 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeValidator fakes a validator and can be used for tests.
+type fakeValidator struct {
+	Getter
+	err error
+}
+
+// newFakeValidators returns a slice with a single FakeValidator.
+func newFakeValidators(oid Getter) []Validator {
+	return []Validator{&fakeValidator{oid, nil}}
+}
+
+func (v fakeValidator) Validate(_ context.Context, attDoc []byte, reportData []byte) error {
+	var doc fakeAttestationDoc
+	if err := json.Unmarshal(attDoc, &doc); err != nil {
+		return err
+	}
+
+	if !bytes.Equal(doc.ReportData, reportData) {
+		return fmt.Errorf("invalid reportData: expected %x, got %x", doc.ReportData, reportData)
+	}
+
+	return v.err
+}
+
+func (v *fakeValidator) String() string {
+	return ""
+}
+
+// fakeAttestationDoc is a fake attestation document used for testing.
+type fakeAttestationDoc struct {
+	ReportData []byte
 }
 
 type stubSNPValidator struct{}

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/contrast/internal/atls/reportdata"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
 	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/edgelesssys/contrast/internal/testkeys"
@@ -34,7 +35,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 
 	testCases := map[string]struct {
 		cert       *x509.Certificate
-		validators []Validator
+		validators []validators.Validator
 		wantErr    bool
 		targetErr  error
 	}{
@@ -137,8 +138,8 @@ type fakeValidator struct {
 }
 
 // newFakeValidators returns a slice with a single FakeValidator.
-func newFakeValidators(oid Getter) []Validator {
-	return []Validator{&fakeValidator{oid, nil}}
+func newFakeValidators(oid Getter) []validators.Validator {
+	return []validators.Validator{&fakeValidator{oid, nil}}
 }
 
 func (v fakeValidator) Validate(_ context.Context, attDoc []byte, reportData []byte) error {
@@ -223,7 +224,7 @@ func TestContextPassdown(t *testing.T) {
 			},
 		},
 	}
-	validators := []Validator{validator}
+	validators := []validators.Validator{validator}
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	// If the context is not passed down, the select statement in ValidateContext will not return at all.

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// package validators defines the Validator interface and helpers for working with validators.
+package validators
+
+import (
+	"context"
+	"encoding/asn1"
+	"fmt"
+)
+
+// Validator is able to validate an attestation document.
+type Validator interface {
+	// OID returns the identifier for documents that this validator supports.
+	OID() asn1.ObjectIdentifier
+
+	// Validate validates an attestation doc and returns an error if validation failed.
+	//
+	// If validation passes, the validator guarantees that the given reportData was present in the
+	// attestation document.
+	Validate(ctx context.Context, attDoc []byte, reportData []byte) error
+
+	// Stringer allows better logging of validation results.
+	fmt.Stringer
+}
+
+// NoValidation skips validation of the server's attestation document.
+func NoValidation() []Validator {
+	return []Validator{}
+}

--- a/internal/grpc/atlscredentials/atlscredentials.go
+++ b/internal/grpc/atlscredentials/atlscredentials.go
@@ -14,6 +14,7 @@ import (
 	"net"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/credentials"
@@ -22,14 +23,14 @@ import (
 // Credentials for attested TLS (ATLS).
 type Credentials struct {
 	issuer              atls.Issuer
-	validators          []atls.Validator
+	validators          []validators.Validator
 	attestationFailures prometheus.Counter
 	privKey             crypto.PrivateKey
 	logger              *slog.Logger
 }
 
 // New creates new ATLS credentials.
-func New(issuer atls.Issuer, validators []atls.Validator, attestationFailures prometheus.Counter, log *slog.Logger) *Credentials {
+func New(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, log *slog.Logger) *Credentials {
 	return &Credentials{
 		issuer:              issuer,
 		attestationFailures: attestationFailures,
@@ -39,7 +40,7 @@ func New(issuer atls.Issuer, validators []atls.Validator, attestationFailures pr
 }
 
 // NewWithKey creates new ATLS credentials for the given key.
-func NewWithKey(issuer atls.Issuer, validators []atls.Validator, attestationFailures prometheus.Counter, key crypto.PrivateKey, log *slog.Logger) *Credentials {
+func NewWithKey(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, key crypto.PrivateKey, log *slog.Logger) *Credentials {
 	return &Credentials{
 		privKey:             key,
 		issuer:              issuer,

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -11,6 +11,7 @@ import (
 	"net"
 
 	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/grpc/atlscredentials"
 	"github.com/edgelesssys/contrast/internal/logger"
@@ -23,7 +24,7 @@ import (
 // Dialer can open grpc client connections with different levels of ATLS encryption / verification.
 type Dialer struct {
 	issuer              atls.Issuer
-	validators          []atls.Validator
+	validators          []validators.Validator
 	attestationFailures prometheus.Counter
 	netDialer           NetDialer
 	privKey             crypto.PrivateKey
@@ -31,7 +32,7 @@ type Dialer struct {
 }
 
 // New creates a new Dialer.
-func New(issuer atls.Issuer, validators []atls.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, log *slog.Logger) *Dialer {
+func New(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, log *slog.Logger) *Dialer {
 	return &Dialer{
 		issuer:              issuer,
 		validators:          validators,
@@ -42,7 +43,7 @@ func New(issuer atls.Issuer, validators []atls.Validator, attestationFailures pr
 }
 
 // NewWithKey creates a new Dialer with the given private key.
-func NewWithKey(issuer atls.Issuer, validators []atls.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, privKey crypto.PrivateKey, log *slog.Logger) *Dialer {
+func NewWithKey(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, privKey crypto.PrivateKey, log *slog.Logger) *Dialer {
 	return &Dialer{
 		issuer:              issuer,
 		validators:          validators,
@@ -82,7 +83,7 @@ func (d *Dialer) DialInsecure(_ context.Context, target string) (*grpc.ClientCon
 
 // DialNoVerify creates a new grpc client connection to the given target without verifying the server's attestation.
 func (d *Dialer) DialNoVerify(_ context.Context, target string) (*grpc.ClientConn, error) {
-	credentials := atlscredentials.New(atls.NoIssuer, atls.NoValidators, atls.NoMetrics, logger.NewNamed(d.logger, "atlscredentials"))
+	credentials := atlscredentials.New(atls.NoIssuer, validators.NoValidation(), atls.NoMetrics, logger.NewNamed(d.logger, "atlscredentials"))
 
 	return grpc.NewClient(
 		target,

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -11,7 +11,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
@@ -24,8 +24,8 @@ import (
 // Originally an unexported function in the contrast CLI.
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
 // Validators MUST NOT be used concurrently.
-func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) ([]atls.Validator, error) {
-	var validators []atls.Validator
+func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) ([]validators.Validator, error) {
+	var allValidators []validators.Validator
 
 	coordPolicyHash, err := m.CoordinatorPolicyHash()
 	if err != nil {
@@ -43,7 +43,7 @@ func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.
 		opt.ValidateOpts.HostData = coordPolicyHashBytes
 		name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
 		validatorLog := logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name})
-		var v atls.Validator
+		var v validators.Validator
 		if len(opt.APEIP) == 4 {
 			seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
 			apEIP := binary.BigEndian.Uint32(opt.APEIP)
@@ -51,7 +51,7 @@ func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.
 		} else {
 			v = snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, name)
 		}
-		validators = append(validators, v)
+		allValidators = append(allValidators, v)
 	}
 
 	tdxOpts, err := m.TDXValidateOpts(kdsGetter)
@@ -63,8 +63,8 @@ func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.
 	for i, opt := range tdxOpts {
 		name := fmt.Sprintf("tdx-%d", i)
 		opt.ValidateOpts.TdQuoteBodyOptions.MrConfigID = mrConfigID[:]
-		validators = append(validators, tdx.NewValidator(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), name))
+		allValidators = append(allValidators, tdx.NewValidator(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), name))
 	}
 
-	return validators, nil
+	return allValidators, nil
 }

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -15,7 +15,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
 	"github.com/edgelesssys/contrast/internal/fsstore"
@@ -38,7 +38,7 @@ type Client struct {
 	log *slog.Logger
 
 	// validatorsFromManifestOverride is used by tests to replace the validators.
-	validatorsFromManifestOverride func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) ([]atls.Validator, error)
+	validatorsFromManifestOverride func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) ([]validators.Validator, error)
 }
 
 // New returns a new [Client].

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -13,7 +13,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/edgelesssys/contrast/internal/atls"
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/httpapi"
@@ -153,8 +153,8 @@ func TestValidateAttestation(t *testing.T) {
 
 			c := New()
 
-			c.validatorsFromManifestOverride = func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) ([]atls.Validator, error) {
-				return []atls.Validator{&stubValidator{err: tc.validateErr}}, nil
+			c.validatorsFromManifestOverride = func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) ([]validators.Validator, error) {
+				return []validators.Validator{&stubValidator{err: tc.validateErr}}, nil
 			}
 			state, err := c.ValidateAttestation(t.Context(), tc.nonce, attestation)
 			if tc.wantErr != "" {
@@ -226,7 +226,7 @@ var testManifest = []byte(`
 `)
 
 type stubValidator struct {
-	atls.Validator
+	validators.Validator
 
 	err error
 }


### PR DESCRIPTION
My overall plan is to consolidate the attestation validation logic into one package. We currently construct validators (at least) here:

https://github.com/edgelesssys/contrast/blob/41ae00c1bfa42b4073f317b5f14658d027222703/sdk/common.go#L27-L29

https://github.com/edgelesssys/contrast/blob/41ae00c1bfa42b4073f317b5f14658d027222703/coordinator/internal/stateguard/credentials.go#L74

https://github.com/edgelesssys/contrast/blob/41ae00c1bfa42b4073f317b5f14658d027222703/e2e/atls/atls_test.go#L153-L156

Since the manifest is the authoritative source for admission policy, I would like to move all of this into the manifest package.

Such a refactoring is currently hard to do, because what were supposed to be validation internals leak throughout the code base.

- The `reportSetter` is a special purpose implementation for aTLS only, but leaves its traces in validator constructors and duplicated implementations. If validators returned a report struct it would not be necessary, as the Coordinator could just wrap the validator.
- The OID `Getter` design only makes sense in this particular loop over validators: https://github.com/edgelesssys/contrast/blob/41ae00c1bfa42b4073f317b5f14658d027222703/internal/atls/atls.go#L249-L254 Now we're forced to present an exact list of validators that can each only validate one type of document. But the Coordinator can't wrap a list.
- Something that's been bothering me for quite some time: an empty list of validators means "skip validation", while a populated list means "at least one validator must pass". The logic should not surprise people assuming [vacuous truth ](https://en.wikipedia.org/wiki/Vacuous_truth). I want my sums of empty lists to be 0. https://github.com/edgelesssys/contrast/blob/41ae00c1bfa42b4073f317b5f14658d027222703/internal/atls/atls.go#L399-L404 If we did not deal in lists, this would be trivial to fix in a `validators` package.

---

That being said, this PR takes an initial step into this direction.

* Clean up around the existing validator definition (first two commits).
* Move the `Validator` into its own package.

No functional change, but this paves the way for above plan.
