### PR TITLE
atls: invert the validator OID lookup logic 

### DIFF
--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -90,7 +90,7 @@ func CreateAttestationClientTLSConfig(ctx context.Context, issuer Issuer, valida
 
 // Issuer issues an attestation document.
 type Issuer interface {
-	Getter
+	OID() asn1.ObjectIdentifier
 	Issue(ctx context.Context, reportData [64]byte) (quote []byte, err error)
 }
 
@@ -239,7 +239,7 @@ func verifyEmbeddedReport(ctx context.Context, validators []validators.Validator
 		foundExtension = true
 		for _, validator := range validators {
 			// Optimization: Skip the validator if it doesn't match the attestation type of the document.
-			if !ex.Id.Equal(validator.OID()) {
+			if !validator.Supports(ex.Id) {
 				continue
 			}
 
@@ -484,9 +484,4 @@ func getNonce(chi *tls.ClientHelloInfo) ([]byte, error) {
 		return nil, fmt.Errorf("decoding nonce from SNI: %w", err)
 	}
 	return clientNonce, nil
-}
-
-// Getter returns an ASN.1 Object Identifier.
-type Getter interface {
-	OID() asn1.ObjectIdentifier
 }

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -51,7 +51,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(oid.RawSNPReport),
 		},
 		"multiple matches": {
 			cert: &x509.Certificate{
@@ -66,7 +66,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(oid.RawSNPReport),
 		},
 		"skip non-matching validator": {
 			cert: &x509.Certificate{
@@ -80,7 +80,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: append(newFakeValidators(stubSNPValidator{}), newFakeValidators(stubFooValidator{})...),
+			validators: append(newFakeValidators(oid.RawSNPReport), newFakeValidators([]int{1, 2, 3})...),
 		},
 		"match, error": {
 			cert: &x509.Certificate{
@@ -91,7 +91,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(oid.RawSNPReport),
 			wantErr:    true,
 		},
 		"no extensions": {
@@ -133,13 +133,17 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 
 // fakeValidator fakes a validator and can be used for tests.
 type fakeValidator struct {
-	Getter
+	oid asn1.ObjectIdentifier
 	err error
 }
 
 // newFakeValidators returns a slice with a single FakeValidator.
-func newFakeValidators(oid Getter) []validators.Validator {
+func newFakeValidators(oid asn1.ObjectIdentifier) []validators.Validator {
 	return []validators.Validator{&fakeValidator{oid, nil}}
+}
+
+func (v *fakeValidator) Supports(other asn1.ObjectIdentifier) bool {
+	return v.oid.Equal(other)
 }
 
 func (v fakeValidator) Validate(_ context.Context, attDoc []byte, reportData []byte) error {
@@ -164,18 +168,6 @@ type fakeAttestationDoc struct {
 	ReportData []byte
 }
 
-type stubSNPValidator struct{}
-
-func (v stubSNPValidator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
-}
-
-type stubFooValidator struct{}
-
-func (v stubFooValidator) OID() asn1.ObjectIdentifier {
-	return []int{1, 2, 3}
-}
-
 // TestPublicKey ensures that all key types used by Contrast can be passed to publicKey.
 func TestPublicKey(t *testing.T) {
 	for typ, key := range map[string]crypto.PrivateKey{
@@ -197,8 +189,8 @@ type contextValidator struct {
 	inputC <-chan error
 }
 
-func (contextValidator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
+func (contextValidator) Supports(other asn1.ObjectIdentifier) bool {
+	return oid.RawSNPReport.Equal(other)
 }
 
 func (contextValidator) String() string {
@@ -220,7 +212,7 @@ func TestContextPassdown(t *testing.T) {
 	cert := &x509.Certificate{
 		Extensions: []pkix.Extension{
 			{
-				Id: validator.OID(),
+				Id: oid.RawSNPReport,
 			},
 		},
 	}

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -12,8 +12,8 @@ import (
 
 // Validator is able to validate an attestation document.
 type Validator interface {
-	// OID returns the identifier for documents that this validator supports.
-	OID() asn1.ObjectIdentifier
+	// Supports returns true if this validator understands attestation docs with the given OID.
+	Supports(oid asn1.ObjectIdentifier) bool
 
 	// Validate validates an attestation doc and returns an error if validation failed.
 	//

--- a/internal/attestation/insecure/insecure_test.go
+++ b/internal/attestation/insecure/insecure_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,3 +59,6 @@ type stubReportSetter struct {
 func (s *stubReportSetter) SetReport(report attestation.Report) {
 	s.report = report
 }
+
+// Ensure that Validator implements the intended interface.
+var _ = validators.Validator(&Validator{})

--- a/internal/attestation/insecure/validator.go
+++ b/internal/attestation/insecure/validator.go
@@ -33,9 +33,9 @@ func NewValidatorWithReportSetter(log *slog.Logger, reportSetter attestation.Rep
 	return &Validator{reportSetter: reportSetter, logger: log, name: name}
 }
 
-// OID returns the OID for the insecure attestation.
-func (v *Validator) OID() asn1.ObjectIdentifier {
-	return oid.RawInsecureReport
+// Supports returns true if the given OID is the OID for insecure reports.
+func (v *Validator) Supports(other asn1.ObjectIdentifier) bool {
+	return oid.RawInsecureReport.Equal(other)
 }
 
 // Validate verifies the fake attestation document and extracts the host data.

--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -68,9 +68,9 @@ func NewValidatorWithReportSetter(
 	}
 }
 
-// OID returns the OID for the raw SNP report extension used by the validator.
-func (v *Validator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
+// Supports returns true if the given OID is the OID for raw SNP reports.
+func (v *Validator) Supports(other asn1.ObjectIdentifier) bool {
+	return oid.RawSNPReport.Equal(other)
 }
 
 // Validate a SNP based attestation.
@@ -204,9 +204,9 @@ func NewIterativeValidatorWithReportSetter(
 	return v
 }
 
-// OID returns the OID for the raw SNP report extension.
-func (v *IterativeValidator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
+// Supports returns true if the given OID is the OID for raw SNP reports.
+func (v *IterativeValidator) Supports(other asn1.ObjectIdentifier) bool {
+	return oid.RawSNPReport.Equal(other)
 }
 
 // Validate tries vCPU counts 1–220, verifying the attestation once and

--- a/internal/attestation/snp/validator_test.go
+++ b/internal/attestation/snp/validator_test.go
@@ -1,0 +1,11 @@
+// Copyright 2024 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package snp
+
+import "github.com/edgelesssys/contrast/internal/atls/validators"
+
+// TODO(burgerdev): there should be tests for the SNP validator!
+
+// Ensure that Validator implements the intended interface.
+var _ = validators.Validator(&Validator{})

--- a/internal/attestation/tdx/validator.go
+++ b/internal/attestation/tdx/validator.go
@@ -68,9 +68,9 @@ func NewValidatorWithReportSetter(verifyOpts *verify.Options, optsGen validateOp
 	return v
 }
 
-// OID returns the OID for the raw TDX report extension used by the validator.
-func (v *Validator) OID() asn1.ObjectIdentifier {
-	return oid.RawTDXReport
+// Supports returns true if the given OID is the OID for raw TDX reports.
+func (v *Validator) Supports(other asn1.ObjectIdentifier) bool {
+	return oid.RawTDXReport.Equal(other)
 }
 
 // Validate a TDX attestation.

--- a/internal/attestation/tdx/validator_test.go
+++ b/internal/attestation/tdx/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/google/go-tdx-guest/proto/tdx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -133,3 +134,6 @@ var quoteJSON = `
   "extraBytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
 }
 `
+
+// Ensure that Validator implements the intended interface.
+var _ = validators.Validator(&Validator{})


### PR DESCRIPTION
This is step 2  teasered in #2483. I'd like to change the APIs in the`atls` package to only work with a single validator and leave the logic of walking over the individual validators in the `validators` package. For this to work, I need the interface to allow for the implementation to decide whether a given report can be processed, not the `atls` package. This PR changes the interface accordingly.