### PR TITLE
coordinator: include report OID in HTTP response

### DIFF
--- a/coordinator/internal/httpapi/attest.go
+++ b/coordinator/internal/httpapi/attest.go
@@ -77,6 +77,7 @@ func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*ht
 
 	resp := &httpapi.AttestationResponse{
 		Version:           constants.Version,
+		AttestationType:   h.Issuer.OID(),
 		RawAttestationDoc: attestation,
 		CoordinatorState:  *coordinatorState,
 	}

--- a/coordinator/internal/httpapi/attest_test.go
+++ b/coordinator/internal/httpapi/attest_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
+	"encoding/asn1"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -125,8 +126,9 @@ func TestAttestationHandler(t *testing.T) {
 			require.NoError(err)
 			tc.guard.ca = ca
 
+			expectedOID := asn1.ObjectIdentifier{1, 2, 3}
 			if tc.issuer == nil {
-				tc.issuer = &stubIssuer{}
+				tc.issuer = &stubIssuer{oid: expectedOID}
 			}
 
 			handler := &AttestationHandler{
@@ -171,6 +173,7 @@ func TestAttestationHandler(t *testing.T) {
 				var resp httpapi.AttestationResponse
 				require.NoError(json.NewDecoder(res.Body).Decode(&resp))
 				require.Equal(constants.Version, resp.Version)
+				require.Equal(expectedOID, resp.AttestationType)
 				require.NotEmpty(resp.RawAttestationDoc)
 			}
 		})
@@ -178,8 +181,13 @@ func TestAttestationHandler(t *testing.T) {
 }
 
 type stubIssuer struct {
+	oid      asn1.ObjectIdentifier
 	issueErr error
 	atls.Issuer
+}
+
+func (s *stubIssuer) OID() asn1.ObjectIdentifier {
+	return s.oid
 }
 
 func (s *stubIssuer) Issue(_ context.Context, _ [64]byte) (quote []byte, err error) {

--- a/e2e/coordinator/coordinator_test.go
+++ b/e2e/coordinator/coordinator_test.go
@@ -6,10 +6,12 @@
 package coordinator
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -212,6 +214,17 @@ func TestCoordinator(t *testing.T) {
 		}))
 
 		state, err := client.ValidateAttestation(ctx, nonce[:], report)
+		require.NoError(err)
+		require.Equal(manifestBytesExpected, state.Manifests[0])
+
+		// Test backwards compatibility of AttestationType.
+		var resp httpapi.AttestationResponse
+		require.NoError(json.NewDecoder(bytes.NewReader(report)).Decode(&resp))
+		resp.AttestationType = nil
+		reportWithoutType, err := json.Marshal(resp)
+		require.NoError(err)
+
+		state, err = client.ValidateAttestation(ctx, nonce[:], reportWithoutType)
 		require.NoError(err)
 		require.Equal(manifestBytesExpected, state.Manifests[0])
 

--- a/e2e/coordinator/coordinator_test.go
+++ b/e2e/coordinator/coordinator_test.go
@@ -11,6 +11,8 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"flag"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,9 +20,11 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/internal/httpapi"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
+	"github.com/edgelesssys/contrast/sdk"
 	"github.com/stretchr/testify/require"
 )
 
@@ -171,6 +175,50 @@ func TestCoordinator(t *testing.T) {
 		t.Logf("Using OpenSSL from: %s", string(out))
 
 		require.NoError(ct.RunSet(ctx, "--signature", filepath.Join(ct.WorkDir, "transition.sig")))
+	})
+
+	t.Run("http api", func(t *testing.T) {
+		require := require.New(t)
+		ct := contrasttest.New(t)
+
+		resources := kuberesource.CoordinatorBundle()
+		resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
+		resources = kuberesource.AddPortForwarders(resources)
+		ct.Init(t, resources)
+
+		require.True(t.Run("generate", ct.Generate), "contrast generate needs to succeed for subsequent tests")
+		require.True(t.Run("apply", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
+		require.True(t.Run("set", ct.Set), "contrast set needs to succeed for subsequent tests")
+
+		// Read manifest for later comparison.
+		manifestBytesExpected, err := os.ReadFile(ct.ManifestPath())
+		require.NoError(err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
+		t.Cleanup(cancel)
+
+		client := sdk.New()
+		client.WithSlog(slog.Default())
+
+		nonce := [32]byte{}
+		var report []byte
+		require.NoError(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-coordinator-ready", httpapi.Port, func(addr string) error {
+			r, err := client.GetAttestation(ctx, fmt.Sprintf("http://%s/attest", addr), nonce[:])
+			if err != nil {
+				return err
+			}
+			report = r
+			return nil
+		}))
+
+		state, err := client.ValidateAttestation(ctx, nonce[:], report)
+		require.NoError(err)
+		require.Equal(manifestBytesExpected, state.Manifests[0])
+
+		nonce[0] = 0xFF
+		state, err = client.ValidateAttestation(ctx, nonce[:], report)
+		require.Error(err)
+		require.Nil(state)
 	})
 }
 

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -219,7 +219,7 @@ func processCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) (*x509.Certi
 // verifyEmbeddedReport verifies an aTLS certificate by validating the attestation document embedded in the TLS certificate.
 //
 // It will check against all applicable validator for the type of attestation document, and return success on the first match.
-func verifyEmbeddedReport(ctx context.Context, validators []validators.Validator, cert *x509.Certificate, peerPublicKey, nonce []byte) (retErr error) {
+func verifyEmbeddedReport(ctx context.Context, allValidators []validators.Validator, cert *x509.Certificate, peerPublicKey, nonce []byte) (retErr error) {
 	// For better error reporting, let's keep track of whether we've found a valid extension at all..
 	var foundExtension bool
 	// .. and whether we've found a matching validator.
@@ -237,22 +237,18 @@ func verifyEmbeddedReport(ctx context.Context, validators []validators.Validator
 
 		// We have a valid attestation document. Let's check it against all applicable validators.
 		foundExtension = true
-		for _, validator := range validators {
-			// Optimization: Skip the validator if it doesn't match the attestation type of the document.
-			if !ex.Id.Equal(validator.OID()) {
-				continue
-			}
-
-			// We've found a matching validator. Let's validate the document.
-			foundMatchingValidator = true
-
-			validationErr := validator.Validate(ctx, ex.Value, expectedReportData[:])
+		for _, validator := range allValidators {
+			validationErr := validator.Validate(ctx, ex.Id, ex.Value, expectedReportData[:])
 			if validationErr == nil {
 				// The validator has successfully verified the document. We can exit.
 				return nil
+			} else if errors.Is(validationErr, validators.ErrOIDNotSupported) {
+				// This is the wrong validator, don't include the generic error in the response.
+				continue
 			}
 			// Otherwise, we'll keep track of the error and continue with the next validator.
-			retErr = errors.Join(retErr, fmt.Errorf(" validator %s failed: %w", validator.String(), validationErr))
+			foundMatchingValidator = true
+			retErr = errors.Join(retErr, fmt.Errorf(" validator %s failed: %w", validatorName(validator), validationErr))
 		}
 	}
 
@@ -489,4 +485,11 @@ func getNonce(chi *tls.ClientHelloInfo) ([]byte, error) {
 // Getter returns an ASN.1 Object Identifier.
 type Getter interface {
 	OID() asn1.ObjectIdentifier
+}
+
+func validatorName(v any) string {
+	if s, ok := v.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%T", v)
 }

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -51,7 +51,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(oid.RawSNPReport),
 		},
 		"multiple matches": {
 			cert: &x509.Certificate{
@@ -66,7 +66,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(oid.RawSNPReport),
 		},
 		"skip non-matching validator": {
 			cert: &x509.Certificate{
@@ -80,7 +80,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: append(newFakeValidators(stubSNPValidator{}), newFakeValidators(stubFooValidator{})...),
+			validators: append(newFakeValidators(oid.RawSNPReport), newFakeValidators(asn1.ObjectIdentifier{1, 2, 3})...),
 		},
 		"match, error": {
 			cert: &x509.Certificate{
@@ -91,7 +91,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(stubSNPValidator{}),
+			validators: newFakeValidators(oid.RawSNPReport),
 			wantErr:    true,
 		},
 		"no extensions": {
@@ -133,16 +133,19 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 
 // fakeValidator fakes a validator and can be used for tests.
 type fakeValidator struct {
-	Getter
+	oid asn1.ObjectIdentifier
 	err error
 }
 
 // newFakeValidators returns a slice with a single FakeValidator.
-func newFakeValidators(oid Getter) []validators.Validator {
+func newFakeValidators(oid asn1.ObjectIdentifier) []validators.Validator {
 	return []validators.Validator{&fakeValidator{oid, nil}}
 }
 
-func (v fakeValidator) Validate(_ context.Context, attDoc []byte, reportData []byte) error {
+func (v fakeValidator) Validate(_ context.Context, id asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+	if !v.oid.Equal(id) {
+		return validators.ErrOIDNotSupported
+	}
 	var doc fakeAttestationDoc
 	if err := json.Unmarshal(attDoc, &doc); err != nil {
 		return err
@@ -162,18 +165,6 @@ func (v *fakeValidator) String() string {
 // fakeAttestationDoc is a fake attestation document used for testing.
 type fakeAttestationDoc struct {
 	ReportData []byte
-}
-
-type stubSNPValidator struct{}
-
-func (v stubSNPValidator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
-}
-
-type stubFooValidator struct{}
-
-func (v stubFooValidator) OID() asn1.ObjectIdentifier {
-	return []int{1, 2, 3}
 }
 
 // TestPublicKey ensures that all key types used by Contrast can be passed to publicKey.
@@ -197,15 +188,7 @@ type contextValidator struct {
 	inputC <-chan error
 }
 
-func (contextValidator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
-}
-
-func (contextValidator) String() string {
-	return "contextValidator"
-}
-
-func (c *contextValidator) Validate(ctx context.Context, _, _ []byte) error {
+func (c *contextValidator) Validate(ctx context.Context, _ asn1.ObjectIdentifier, _, _ []byte) error {
 	select {
 	case err := <-c.inputC:
 		return err
@@ -220,7 +203,7 @@ func TestContextPassdown(t *testing.T) {
 	cert := &x509.Certificate{
 		Extensions: []pkix.Extension{
 			{
-				Id: validator.OID(),
+				Id: oid.RawSNPReport,
 			},
 		},
 	}

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -7,22 +7,32 @@ package validators
 import (
 	"context"
 	"encoding/asn1"
-	"fmt"
+	"errors"
 )
 
-// Validator is able to validate an attestation document.
-type Validator interface {
-	// OID returns the identifier for documents that this validator supports.
-	OID() asn1.ObjectIdentifier
+// ErrOIDNotSupported is returned by a validator when it doesn't understand the OID provided as input.
+var ErrOIDNotSupported = errors.New("OID not supported")
 
+// Validator is able to validate an attestation document.
+//
+// Validators are encouraged to implement the fmt.Stringer interface to improve logging.
+type Validator interface {
 	// Validate validates an attestation doc and returns an error if validation failed.
+	//
+	// Implementations should first check whether they understand the given OID. If they don't,
+	// they should return ErrOIDNotSupported.
 	//
 	// If validation passes, the validator guarantees that the given reportData was present in the
 	// attestation document.
-	Validate(ctx context.Context, attDoc []byte, reportData []byte) error
+	Validate(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error
+}
 
-	// Stringer allows better logging of validation results.
-	fmt.Stringer
+// ValidatorFunc creates a validator from a func.
+type ValidatorFunc func(context.Context, asn1.ObjectIdentifier, []byte, []byte) error
+
+// Validate calls the adapted func to implement Validator.Validate.
+func (f ValidatorFunc) Validate(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+	return f(ctx, oid, attDoc, reportData)
 }
 
 // NoValidation skips validation of the server's attestation document.

--- a/internal/attestation/insecure/insecure_test.go
+++ b/internal/attestation/insecure/insecure_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,3 +59,6 @@ type stubReportSetter struct {
 func (s *stubReportSetter) SetReport(report attestation.Report) {
 	s.report = report
 }
+
+// Ensure that Validator implements the intended interface.
+var _ validators.Validator = (*Validator)(nil)

--- a/internal/attestation/insecure/insecure_test.go
+++ b/internal/attestation/insecure/insecure_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
+	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +35,7 @@ func TestIssueAndValidate(t *testing.T) {
 
 	setter := &stubReportSetter{}
 	validator := NewValidatorWithReportSetter(slog.Default(), setter, "insecure")
-	require.NoError(t, validator.Validate(context.Background(), attDoc, reportData[:]))
+	require.NoError(t, validator.Validate(context.Background(), oid.RawInsecureReport, attDoc, reportData[:]))
 	require.NotNil(t, setter.report)
 	assert.Equal(t, hostData, setter.report.HostData())
 }
@@ -43,7 +44,7 @@ func TestValidateMismatchingReportData(t *testing.T) {
 	validator := NewValidator(slog.Default(), "insecure")
 	attDoc := []byte(`{"reportData":"AQ==","hostData":"Ag=="}`)
 
-	err := validator.Validate(context.Background(), attDoc, []byte{0x02})
+	err := validator.Validate(context.Background(), oid.RawInsecureReport, attDoc, []byte{0x02})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reportData mismatch")
 }

--- a/internal/attestation/insecure/validator.go
+++ b/internal/attestation/insecure/validator.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/oid"
 )
@@ -33,13 +34,11 @@ func NewValidatorWithReportSetter(log *slog.Logger, reportSetter attestation.Rep
 	return &Validator{reportSetter: reportSetter, logger: log, name: name}
 }
 
-// OID returns the OID for the insecure attestation.
-func (v *Validator) OID() asn1.ObjectIdentifier {
-	return oid.RawInsecureReport
-}
-
 // Validate verifies the fake attestation document and extracts the host data.
-func (v *Validator) Validate(_ context.Context, attDocRaw []byte, reportData []byte) error {
+func (v *Validator) Validate(_ context.Context, id asn1.ObjectIdentifier, attDocRaw []byte, reportData []byte) error {
+	if !oid.RawInsecureReport.Equal(id) {
+		return validators.ErrOIDNotSupported
+	}
 	var doc attestationDoc
 	if err := json.Unmarshal(attDocRaw, &doc); err != nil {
 		return fmt.Errorf("unmarshaling insecure attestation: %w", err)

--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/idblock"
@@ -68,13 +69,11 @@ func NewValidatorWithReportSetter(
 	}
 }
 
-// OID returns the OID for the raw SNP report extension used by the validator.
-func (v *Validator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
-}
-
 // Validate a SNP based attestation.
-func (v *Validator) Validate(ctx context.Context, attDocRaw []byte, reportData []byte) (err error) {
+func (v *Validator) Validate(ctx context.Context, id asn1.ObjectIdentifier, attDocRaw []byte, reportData []byte) (err error) {
+	if !oid.RawSNPReport.Equal(id) {
+		return validators.ErrOIDNotSupported
+	}
 	v.logger.Info("Validate called", "name", v.name, "report-data", hex.EncodeToString(reportData))
 	defer func() {
 		if err != nil {
@@ -204,14 +203,12 @@ func NewIterativeValidatorWithReportSetter(
 	return v
 }
 
-// OID returns the OID for the raw SNP report extension.
-func (v *IterativeValidator) OID() asn1.ObjectIdentifier {
-	return oid.RawSNPReport
-}
-
 // Validate tries vCPU counts 1–220, verifying the attestation once and
 // then validating claims against the first matching per-vCPU measurement.
-func (v *IterativeValidator) Validate(ctx context.Context, attDocRaw []byte, reportData []byte) (err error) {
+func (v *IterativeValidator) Validate(ctx context.Context, id asn1.ObjectIdentifier, attDocRaw []byte, reportData []byte) (err error) {
+	if !oid.RawSNPReport.Equal(id) {
+		return validators.ErrOIDNotSupported
+	}
 	v.logger.Info("Validate called", "name", v.name, "report-data", hex.EncodeToString(reportData))
 	defer func() {
 		if err != nil {

--- a/internal/attestation/snp/validator_test.go
+++ b/internal/attestation/snp/validator_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package snp
+
+import "github.com/edgelesssys/contrast/internal/atls/validators"
+
+// TODO(burgerdev): there should be tests for the SNP validator!
+
+// Ensure that Validator implements the intended interface.
+var (
+	_ validators.Validator = (*Validator)(nil)
+	_ validators.Validator = (*IterativeValidator)(nil)
+)

--- a/internal/attestation/tdx/validator.go
+++ b/internal/attestation/tdx/validator.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx/quote"
 	"github.com/edgelesssys/contrast/internal/oid"
@@ -68,13 +69,11 @@ func NewValidatorWithReportSetter(verifyOpts *verify.Options, optsGen validateOp
 	return v
 }
 
-// OID returns the OID for the raw TDX report extension used by the validator.
-func (v *Validator) OID() asn1.ObjectIdentifier {
-	return oid.RawTDXReport
-}
-
 // Validate a TDX attestation.
-func (v *Validator) Validate(ctx context.Context, attDocRaw []byte, reportData []byte) (err error) {
+func (v *Validator) Validate(ctx context.Context, id asn1.ObjectIdentifier, attDocRaw []byte, reportData []byte) (err error) {
+	if !oid.RawTDXReport.Equal(id) {
+		return validators.ErrOIDNotSupported
+	}
 	v.logger.Info("Validate called", "name", v.name, "report-data", hex.EncodeToString(reportData))
 	defer func() {
 		if err != nil {

--- a/internal/attestation/tdx/validator_test.go
+++ b/internal/attestation/tdx/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/google/go-tdx-guest/proto/tdx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -133,3 +134,6 @@ var quoteJSON = `
   "extraBytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
 }
 `
+
+// Ensure that Validator implements the intended interface.
+var _ validators.Validator = (*Validator)(nil)

--- a/internal/httpapi/attest.go
+++ b/internal/httpapi/attest.go
@@ -5,6 +5,7 @@ package httpapi
 
 import (
 	"bytes"
+	"encoding/asn1"
 	"encoding/json"
 	"fmt"
 
@@ -33,6 +34,10 @@ type AttestationResponse struct {
 	Version string `json:"version"`
 	// RawAttestationDoc is a raw attestation report.
 	RawAttestationDoc []byte `json:"raw_attestation_doc"`
+	// AttestationType is the OID used to identify the type of attestation document.
+	//
+	// Outside of unit tests, this will always be an OID from the internal/oid package.
+	AttestationType asn1.ObjectIdentifier `json:"attestation_type"`
 
 	CoordinatorState
 }

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -8,6 +8,7 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"encoding/asn1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,11 +18,15 @@ import (
 
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
+	"github.com/edgelesssys/contrast/internal/attestation/insecure"
+	"github.com/edgelesssys/contrast/internal/attestation/snp"
+	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
 	"github.com/edgelesssys/contrast/internal/fsstore"
 	"github.com/edgelesssys/contrast/internal/history"
 	"github.com/edgelesssys/contrast/internal/httpapi"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/spf13/afero"
 )
 
@@ -176,7 +181,15 @@ func (c Client) ValidateAttestation(ctx context.Context, nonce []byte, attestati
 	validated := false
 	var errs []error
 	for _, v := range validators {
-		if err := v.Validate(ctx, resp.RawAttestationDoc, reportData[:]); err != nil {
+		if resp.AttestationType == nil {
+			wrapped, err := validatorForLegacyResponse(v)
+			if err != nil {
+				c.log.Warn("using this validator requires a server update", "error", err)
+				continue
+			}
+			v = wrapped
+		}
+		if err := v.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
 			c.log.Debug("validator failed", "error", err)
 			errs = append(errs, err)
 			continue
@@ -210,4 +223,27 @@ type CoordinatorState struct {
 	LatestTransitionHash []byte
 	// Signature of the latest transition hash by the Coordinator.
 	LatestTransitionSignature []byte
+}
+
+// validatorForLegacyResponse determines the right OID for the given validator and overrides the input OID with it.
+//
+// This is needed because the OID was not part of the HTTP API response in prior versions.
+//
+// TODO(burgerdev): remove once all clients receive the OID from the HTTP API.
+func validatorForLegacyResponse(v validators.Validator) (validators.Validator, error) {
+	var id asn1.ObjectIdentifier
+	switch v.(type) {
+	case *snp.Validator, *snp.IterativeValidator:
+		id = oid.RawSNPReport
+	case *tdx.Validator:
+		id = oid.RawTDXReport
+	case *insecure.Validator:
+		id = oid.RawInsecureReport
+	default:
+		return nil, fmt.Errorf("unexpected validator type: %T", v)
+	}
+
+	return validators.ValidatorFunc(func(ctx context.Context, _ asn1.ObjectIdentifier, attDoc, reportData []byte) error {
+		return v.Validate(ctx, id, attDoc, reportData)
+	}), nil
 }

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -7,6 +7,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/asn1"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -106,6 +107,7 @@ func TestGetAttestation(t *testing.T) {
 
 func TestValidateAttestation(t *testing.T) {
 	testNonce := make([]byte, 32)
+	testOID := asn1.ObjectIdentifier{1, 2, 3}
 	for name, tc := range map[string]struct {
 		nonce       []byte
 		resp        *httpapi.AttestationResponse
@@ -115,6 +117,7 @@ func TestValidateAttestation(t *testing.T) {
 		"success": {
 			nonce: testNonce,
 			resp: &httpapi.AttestationResponse{
+				AttestationType:   testOID,
 				RawAttestationDoc: testNonce,
 				CoordinatorState: httpapi.CoordinatorState{
 					Manifests: [][]byte{testManifest},
@@ -124,6 +127,7 @@ func TestValidateAttestation(t *testing.T) {
 		"no manifests": {
 			nonce: testNonce,
 			resp: &httpapi.AttestationResponse{
+				AttestationType:   testOID,
 				RawAttestationDoc: testNonce,
 				CoordinatorState:  httpapi.CoordinatorState{},
 			},
@@ -135,6 +139,7 @@ func TestValidateAttestation(t *testing.T) {
 		"failed validation": {
 			nonce: testNonce,
 			resp: &httpapi.AttestationResponse{
+				AttestationType:   testOID,
 				RawAttestationDoc: testNonce,
 				CoordinatorState: httpapi.CoordinatorState{
 					Manifests: [][]byte{testManifest},
@@ -226,11 +231,9 @@ var testManifest = []byte(`
 `)
 
 type stubValidator struct {
-	validators.Validator
-
 	err error
 }
 
-func (v *stubValidator) Validate(context.Context, []byte, []byte) error {
+func (v *stubValidator) Validate(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
 	return v.err
 }


### PR DESCRIPTION
The Coordinator's HTTP API has a new field in the attestation response: The `attestation_type` field now contains the OID Contrast uses internally to identify different attestation flavours, telling the validator how to interpret `raw_attestation_doc`. This change is backwards-compatible for now: old validators just ignore the field populated by new Coordinators, while new validators fall back to the old code if the field was left unset by an old Coordinator. 

*In a future Contrast version, the fallback path will be removed.*

---

Original PR description:

This PR changes the `validators.Validator` interface to only consist of a single function, `Validate`. The idea is that the validator itself should decide whether it supports a given OID, allowing for future validators to accept more than one OID (such as for a single combined validator for all reference values).  More background in the description of #2483.

This change surfaced a bug in the SDK, where we are not checking for OID support before invoking `Validate`. This is not problematic because reports are signed anyway, but I needed to add a bit of helper logic to make the old HTTP response work with the new API. A test is added to ensure we stay backwards compatible. 