### PR TITLE
cli: adjust container memory limit when using pod memory limits

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -576,18 +576,19 @@ func patchTargets(fileMap map[string][]*unstructured.Unstructured, imageReplacem
 		if flags.collateralProxyURL != "" && isCoordinator(res) {
 			res = kuberesource.SetCollateralProxyEnv([]any{res}, flags.collateralProxyURL)[0]
 		}
+		memoryProfile := kuberesource.MemoryProfile(flags.calculatePodMemory)
 		if flags.insecureEnableDebugShell {
-			if _, err := kuberesource.AddDebugShell(res, kuberesource.DebugShell()); err != nil {
+			if _, err := kuberesource.AddDebugShell(res, kuberesource.DebugShell(memoryProfile)); err != nil {
 				return nil, fmt.Errorf("injecting debug shell container: %w", err)
 			}
 		}
 		if !flags.skipInitializer {
-			if err := injectInitializer(res, coordinatorNamespace, flags.collateralProxyURL); err != nil {
+			if err := injectInitializer(res, coordinatorNamespace, flags.collateralProxyURL, memoryProfile); err != nil {
 				return nil, fmt.Errorf("injecting Initializer: %w", err)
 			}
 		}
 		if !flags.skipServiceMesh {
-			if err := injectServiceMesh(res); err != nil {
+			if err := injectServiceMesh(res, memoryProfile); err != nil {
 				return nil, fmt.Errorf("injecting Service Mesh: %w", err)
 			}
 		}
@@ -611,7 +612,7 @@ func patchTargets(fileMap map[string][]*unstructured.Unstructured, imageReplacem
 	})
 }
 
-func injectInitializer(resource any, coordinatorNamespace, collateralProxyURL string) error {
+func injectInitializer(resource any, coordinatorNamespace, collateralProxyURL string, memoryProfile kuberesource.MemoryProfile) error {
 	if isCoordinator(resource) {
 		return nil
 	}
@@ -619,7 +620,7 @@ func injectInitializer(resource any, coordinatorNamespace, collateralProxyURL st
 		coordinatorNamespace = "default"
 	}
 	coordinatorHost := fmt.Sprintf("coordinator-ready.%s", coordinatorNamespace)
-	initializer := kuberesource.Initializer(coordinatorHost)
+	initializer := kuberesource.Initializer(coordinatorHost, memoryProfile)
 	if collateralProxyURL != "" {
 		initializer.WithEnv(kuberesource.NewEnvVar(constants.CollateralProxyEnvVar, collateralProxyURL))
 	}
@@ -629,11 +630,11 @@ func injectInitializer(resource any, coordinatorNamespace, collateralProxyURL st
 	return nil
 }
 
-func injectServiceMesh(resource any) error {
+func injectServiceMesh(resource any, memoryProfile kuberesource.MemoryProfile) error {
 	if isCoordinator(resource) {
 		return nil
 	}
-	if _, err := kuberesource.AddServiceMesh(resource, kuberesource.ServiceMeshProxy()); err != nil {
+	if _, err := kuberesource.AddServiceMesh(resource, kuberesource.ServiceMeshProxy(memoryProfile)); err != nil {
 		return err
 	}
 	return nil

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -23,11 +23,11 @@ func TestStatefulSetInjections(t *testing.T) {
 	resources := []any{statefulSet()}
 
 	t.Run("injectInitializer", func(t *testing.T) {
-		require.NoError(t, injectInitializer(resources, "coordinator-namespace", ""))
+		require.NoError(t, injectInitializer(resources, "coordinator-namespace", "", kuberesource.MemoryProfileFull))
 	})
 
 	t.Run("injectServiceMesh", func(t *testing.T) {
-		require.NoError(t, injectServiceMesh(resources))
+		require.NoError(t, injectServiceMesh(resources, kuberesource.MemoryProfileFull))
 	})
 }
 

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -130,7 +130,7 @@ func TestPatchNamespaces(t *testing.T) {
 }
 
 func TestAddInitializer(t *testing.T) {
-	initializer := Initializer("coordinator-ready.default")
+	initializer := Initializer("coordinator-ready.default", MemoryProfileFull)
 	expectedInitializerContainerName := *initializer.Name
 	expectedInitializerVolumeMountName := *initializer.VolumeMounts[0].Name
 	for _, tc := range []struct {
@@ -439,7 +439,7 @@ func TestAddServiceMesh(t *testing.T) {
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
-								WithInitContainers(ServiceMeshProxy()).
+								WithInitContainers(ServiceMeshProxy(MemoryProfileFull)).
 								WithRuntimeClassName("contrast-cc"),
 						))),
 			wantError: false,
@@ -456,7 +456,7 @@ func TestAddServiceMesh(t *testing.T) {
 								WithRuntimeClassName("contrast-cc").
 								WithVolumes(
 									Volume().
-										WithName(*ServiceMeshProxy().VolumeMounts[0].Name).
+										WithName(*ServiceMeshProxy(MemoryProfileFull).VolumeMounts[0].Name).
 										WithEmptyDir(EmptyDirVolumeSource().Inner()),
 								),
 						))),
@@ -474,7 +474,7 @@ func TestAddServiceMesh(t *testing.T) {
 								WithRuntimeClassName("contrast-cc").
 								WithVolumes(
 									Volume().
-										WithName(*ServiceMeshProxy().VolumeMounts[0].Name).
+										WithName(*ServiceMeshProxy(MemoryProfileFull).VolumeMounts[0].Name).
 										WithConfigMap(Volume().ConfigMap),
 								),
 						))),
@@ -484,7 +484,7 @@ func TestAddServiceMesh(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			_, err := AddServiceMesh(tc.d, ServiceMeshProxy())
+			_, err := AddServiceMesh(tc.d, ServiceMeshProxy(MemoryProfileFull))
 			if tc.wantError {
 				require.Error(err)
 				return
@@ -496,13 +496,13 @@ func TestAddServiceMesh(t *testing.T) {
 				return
 			}
 			require.NotEmpty(tc.d.Spec.Template.Spec.InitContainers)
-			require.Equal(*tc.d.Spec.Template.Spec.InitContainers[0].Name, *ServiceMeshProxy().Name)
+			require.Equal(*tc.d.Spec.Template.Spec.InitContainers[0].Name, *ServiceMeshProxy(MemoryProfileFull).Name)
 			require.NotEmpty(tc.d.Spec.Template.Spec.InitContainers[0].VolumeMounts)
-			require.Equal(*tc.d.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].Name, *ServiceMeshProxy().VolumeMounts[0].Name)
+			require.Equal(*tc.d.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].Name, *ServiceMeshProxy(MemoryProfileFull).VolumeMounts[0].Name)
 
 			serviceMeshCount := 0
 			for _, c := range tc.d.Spec.Template.Spec.InitContainers {
-				if *c.Name == *ServiceMeshProxy().Name {
+				if *c.Name == *ServiceMeshProxy(MemoryProfileFull).Name {
 					serviceMeshCount++
 				}
 			}
@@ -511,7 +511,7 @@ func TestAddServiceMesh(t *testing.T) {
 			require.NotEmpty(tc.d.Spec.Template.Spec.Volumes)
 			serviceMeshVolumeCount := 0
 			for _, v := range tc.d.Spec.Template.Spec.Volumes {
-				if *v.Name == *ServiceMeshProxy().VolumeMounts[0].Name {
+				if *v.Name == *ServiceMeshProxy(MemoryProfileFull).VolumeMounts[0].Name {
 					serviceMeshVolumeCount++
 				}
 			}
@@ -785,7 +785,7 @@ spec:
 			res, err := UnmarshalApplyConfigurations(tc.resource)
 			require.Len(res, 1)
 			require.NoError(err)
-			withShell, err := AddDebugShell(res[0], DebugShell())
+			withShell, err := AddDebugShell(res[0], DebugShell(false))
 			require.NoError(err)
 
 			pod, ok := withShell.(*applycorev1.PodApplyConfiguration)

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -19,6 +19,36 @@ import (
 	applyrbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 )
 
+// MemoryProfile represents the memory profile of a container.
+type MemoryProfile bool
+
+const (
+	// MemoryProfileFull includes the image requirements in the container memory limits.
+	MemoryProfileFull MemoryProfile = false
+	// MemoryProfileRuntimeOnly only includes the runtime requirements in the container memory limits.
+	MemoryProfileRuntimeOnly MemoryProfile = true
+)
+
+var containerMemoryLimits = map[string]map[MemoryProfile]int64{
+	"contrast-initializer": {
+		// In v1.18.0, the initializer image was 50MiB compressed, 160MiB uncompressed.
+		// Double that because only 50% of the VM memory are available for /run.
+		MemoryProfileFull: 420,
+		// The container's cgroup memory.peak is at about 5MiB.
+		MemoryProfileRuntimeOnly: 20,
+	},
+	"contrast-service-mesh": {
+		MemoryProfileFull: 400,
+		// When running the emojivoto deployment, the container's cgroup memory.peak is at about 20MiB.
+		MemoryProfileRuntimeOnly: 100,
+	},
+	"contrast-debug-shell": {
+		MemoryProfileFull: 1000,
+		// Leave enough memory for debugging tasks.
+		MemoryProfileRuntimeOnly: 200,
+	},
+}
+
 // ContrastRuntimeClass creates a new RuntimeClassConfig.
 func ContrastRuntimeClass(platform platforms.Platform) (*RuntimeClassConfig, error) {
 	runtimeHandler, err := manifest.RuntimeHandler(platform)
@@ -490,15 +520,14 @@ func PortForwarderForService(svc *applycorev1.ServiceApplyConfiguration) (*apply
 }
 
 // Initializer creates a new InitializerConfig.
-func Initializer(coordinatorHost string) *applycorev1.ContainerApplyConfiguration {
+func Initializer(coordinatorHost string, memoryProfile MemoryProfile) *applycorev1.ContainerApplyConfiguration {
+	memoryLimit := containerMemoryLimits["contrast-initializer"][memoryProfile]
 	return applycorev1.Container().
 		WithName("contrast-initializer").
 		WithImage("ghcr.io/edgelesssys/contrast/initializer:latest").
 		WithResources(
 			ResourceRequirements().
-				// In v1.18.0, the initializer image was 50MiB compressed, 160MiB uncompressed.
-				// Double that because only 50% of the VM memory are available for /run.
-				WithMemoryLimitAndRequest(420),
+				WithMemoryLimitAndRequest(memoryLimit),
 		).
 		WithEnv(NewEnvVar("COORDINATOR_HOST", coordinatorHost)).
 		WithVolumeMounts(
@@ -518,7 +547,8 @@ func Initializer(coordinatorHost string) *applycorev1.ContainerApplyConfiguratio
 }
 
 // ServiceMeshProxy creates a new service mesh proxy sidecar container.
-func ServiceMeshProxy() *applycorev1.ContainerApplyConfiguration {
+func ServiceMeshProxy(memoryProfile MemoryProfile) *applycorev1.ContainerApplyConfiguration {
+	memoryLimit := containerMemoryLimits["contrast-service-mesh"][memoryProfile]
 	return applycorev1.Container().
 		WithName("contrast-service-mesh").
 		WithImage("ghcr.io/edgelesssys/contrast/service-mesh-proxy:latest").
@@ -547,19 +577,20 @@ func ServiceMeshProxy() *applycorev1.ContainerApplyConfiguration {
 		).
 		WithResources(
 			ResourceRequirements().
-				WithMemoryLimitAndRequest(400),
+				WithMemoryLimitAndRequest(memoryLimit),
 		)
 }
 
 // DebugShell creates a new debug shell container.
-func DebugShell() *applycorev1.ContainerApplyConfiguration {
+func DebugShell(memoryProfile MemoryProfile) *applycorev1.ContainerApplyConfiguration {
+	memoryLimit := containerMemoryLimits["contrast-debug-shell"][memoryProfile]
 	return applycorev1.Container().
 		WithName("contrast-debug-shell").
 		WithImage("ghcr.io/edgelesssys/contrast/debugshell:latest").
 		WithRestartPolicy(corev1.ContainerRestartPolicyAlways).
 		WithResources(
 			ResourceRequirements().
-				WithMemoryLimitAndRequest(1000),
+				WithMemoryLimitAndRequest(memoryLimit),
 		)
 }
 


### PR DESCRIPTION
When using the `--calculate-pod-memory` flag during `generate`, the pods get additional memory assigned through pod level resource limits, based on the image sizes. The Initializer, Debugshell and Service Mesh containers have a predefined container memory limit that takes the image sizes already into account. When automatically adding the necessary memory with the `--calculate-pod-memory` flag, we can thus lower the container limits for our injected containers.

I looked at the `memory.peak` cgroup entry to approximately gauge how much memory is actually needed for the containers. Especially for the service mesh container, we should be generous with the necessary memory,  as this is dependent on the deployed workload.