### PR TITLE
manifest: authoritative source for validators

### DIFF
--- a/coordinator/internal/peerrecovery/recovery_test.go
+++ b/coordinator/internal/peerrecovery/recovery_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/validators"
-	"github.com/edgelesssys/contrast/internal/attestation/snp"
 	"github.com/edgelesssys/contrast/internal/ca"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/meshapi"
@@ -139,9 +138,7 @@ func TestRecoverFromPeer(t *testing.T) {
 	assert.Equal(expectedAddr, dialer.recordedAddress)
 	assert.NotNil(dialer.recordedIssuer)
 	assert.True(dialer.closeCalled)
-	// One SNP reference value with APEIP set yields one IterativeValidator.
 	require.Len(dialer.recordedValidators, 1)
-	assert.IsType(&snp.IterativeValidator{}, dialer.recordedValidators[0])
 }
 
 type fakeIssuer struct {

--- a/coordinator/internal/stateguard/credentials.go
+++ b/coordinator/internal/stateguard/credentials.go
@@ -6,22 +6,16 @@ package stateguard
 import (
 	"context"
 	"crypto/tls"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
-	"strings"
 
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
-	"github.com/edgelesssys/contrast/internal/attestation/snp"
-	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/constants"
-	"github.com/edgelesssys/contrast/internal/logger"
-	snpmeasure "github.com/edgelesssys/contrast/internal/snp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc/credentials"
@@ -72,40 +66,12 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		State: state,
 	}
 
-	var allValidators []validators.Validator
-
-	snpOpts, err := state.Manifest().SNPValidateOpts(c.kdsGetter)
+	validator, err := state.Manifest().Validator(log, c.kdsGetter, &authInfo)
 	if err != nil {
-		log.Error("Could not generate SNP validation options", "error", err)
-		return nil, nil, fmt.Errorf("generating SNP validation options: %w", err)
+		return nil, nil, fmt.Errorf("creating validator from manifest: %w", err)
 	}
 
-	for i, opt := range snpOpts {
-		name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
-		validatorLog := logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"reference-values": name})
-		var validator validators.Validator
-		if len(opt.APEIP) == 4 {
-			seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
-			apEIP := binary.BigEndian.Uint32(opt.APEIP)
-			validator = snp.NewIterativeValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts, seed, apEIP, opt.VCPUSig, opt.AllowedChipIDs, validatorLog, &authInfo, name)
-		} else {
-			validator = snp.NewValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, &authInfo, name)
-		}
-		allValidators = append(allValidators, validator)
-	}
-
-	tdxOpts, err := state.Manifest().TDXValidateOpts(c.kdsGetter)
-	if err != nil {
-		log.Error("Could not generate TDX validation options", "error", err)
-		return nil, nil, fmt.Errorf("generating TDX validation options: %w", err)
-	}
-	for i, opt := range tdxOpts {
-		name := fmt.Sprintf("tdx-%d", i)
-		allValidators = append(allValidators, tdx.NewValidatorWithReportSetter(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs,
-			logger.NewWithAttrs(logger.NewNamed(c.logger, "validator"), map[string]string{"reference-values": name}), &authInfo, name))
-	}
-
-	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, allValidators, c.attestationFailuresCounter)
+	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, []validators.Validator{validator}, c.attestationFailuresCounter)
 	if err != nil {
 		log.Error("Could not create TLS config", "error", err)
 		return nil, nil, err

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/asn1"
 	"errors"
+	"fmt"
 )
 
 // ErrOIDNotSupported is returned by a validator when it doesn't understand the OID provided as input.
@@ -38,4 +39,32 @@ func (f ValidatorFunc) Validate(ctx context.Context, oid asn1.ObjectIdentifier, 
 // NoValidation skips validation of the server's attestation document.
 func NoValidation() []Validator {
 	return []Validator{}
+}
+
+// Any creates a Validator that passes if one of the input Validators passes.
+//
+// The Validators are tried in order, until one succeeds or no more are left.
+// The combined Validator supports all OIDs that are supported by at least one sub-Validator.
+func Any(vs ...Validator) Validator {
+	return ValidatorFunc(func(ctx context.Context, oid asn1.ObjectIdentifier, attDoc, reportData []byte) error {
+		interestingErrors := make([]error, 0, len(vs))
+		for i, v := range vs {
+			err := v.Validate(ctx, oid, attDoc, reportData)
+			if err == nil {
+				return nil
+			}
+			// A bunch of "unsupported" errors would clutter the output, only add the interesting ones.
+			if !errors.Is(err, ErrOIDNotSupported) {
+				interestingErrors = append(interestingErrors, fmt.Errorf("sub-validator %d: %w", i, err))
+			}
+		}
+		// No validator passed, let's decide what to report back.
+		if len(interestingErrors) == 0 {
+			// If no error was added to the list, all errors were "not supported". Return that to
+			// the caller.
+			return ErrOIDNotSupported
+		}
+		// Bundle all interesting errors into one.
+		return errors.Join(interestingErrors...)
+	})
 }

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -68,3 +68,13 @@ func Any(vs ...Validator) Validator {
 		return errors.Join(interestingErrors...)
 	})
 }
+
+// WithFixedOID wraps the given Validator, passing a fixed OID instead of the original one.
+//
+// This is only useful for backwards compatibility in the HTTP API client.
+// TODO(burgerdev): remove once all clients receive the OID from the HTTP API.
+func WithFixedOID(oid asn1.ObjectIdentifier, v Validator) Validator {
+	return ValidatorFunc(func(ctx context.Context, _ asn1.ObjectIdentifier, attDoc, reportData []byte) error {
+		return v.Validate(ctx, oid, attDoc, reportData)
+	})
+}

--- a/internal/atls/validators/validators_test.go
+++ b/internal/atls/validators/validators_test.go
@@ -8,7 +8,9 @@ import (
 	"encoding/asn1"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAny(t *testing.T) {
@@ -86,6 +88,17 @@ func TestAny(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWithFixedOID(t *testing.T) {
+	require := require.New(t)
+	inputOID := oid.RawSNPReport
+	expectedOID := oid.RawTDXReport
+	s := &stubValidator{}
+	v := WithFixedOID(expectedOID, s)
+
+	require.NoError(v.Validate(t.Context(), inputOID, nil, nil))
+	require.True(expectedOID.Equal(s.oid))
 }
 
 type stubValidator struct {

--- a/internal/atls/validators/validators_test.go
+++ b/internal/atls/validators/validators_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package validators
+
+import (
+	"context"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAny(t *testing.T) {
+	oid := asn1.ObjectIdentifier{1, 2, 3}
+	for name, tc := range map[string]struct {
+		validators []*stubValidator
+		numTried   int
+		err        error
+	}{
+		"vacuous truth": {err: ErrOIDNotSupported},
+		"OID not supported": {
+			validators: []*stubValidator{{err: ErrOIDNotSupported}, {err: ErrOIDNotSupported}},
+			numTried:   2,
+			err:        ErrOIDNotSupported,
+		},
+		"matching validator first": {
+			validators: []*stubValidator{
+				{},
+				{err: ErrOIDNotSupported},
+			},
+			numTried: 1,
+		},
+		"matching validator second": {
+			validators: []*stubValidator{
+				{err: ErrOIDNotSupported},
+				{},
+			},
+			numTried: 2,
+		},
+		"no validator passes": {
+			validators: []*stubValidator{
+				{err: assert.AnError},
+				{err: assert.AnError},
+			},
+			numTried: 2,
+			err:      assert.AnError,
+		},
+		"second validator passes": {
+			validators: []*stubValidator{
+				{err: assert.AnError},
+				{},
+			},
+			numTried: 2,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			var validators []Validator
+			for _, v := range tc.validators {
+				validators = append(validators, v)
+			}
+
+			doc := []byte{1, 2, 3}
+			rd := []byte{4, 5, 6}
+			v := Any(validators...)
+			err := v.Validate(t.Context(), oid, doc, rd)
+			if tc.err != nil {
+				assert.ErrorIs(err, tc.err)
+			} else {
+				assert.NoError(err)
+			}
+
+			for i := range len(tc.validators) {
+				v := tc.validators[i]
+				if i < tc.numTried {
+					assert.True(oid.Equal(v.oid))
+					assert.Equal(doc, v.doc)
+					assert.Equal(rd, v.reportData)
+				} else {
+					assert.Nil(v.oid)
+					assert.Nil(v.doc)
+					assert.Nil(v.reportData)
+				}
+			}
+		})
+	}
+}
+
+type stubValidator struct {
+	err error
+
+	// saved arguments to Validate
+	oid        asn1.ObjectIdentifier
+	doc        []byte
+	reportData []byte
+}
+
+// Validate validates an attestation doc and returns an error if validation failed.
+//
+// If validation passes, the validator guarantees that the given reportData was present in the
+// attestation document.
+func (s *stubValidator) Validate(_ context.Context, oid asn1.ObjectIdentifier, doc []byte, rd []byte) error {
+	s.oid = oid
+	s.doc = doc
+	s.reportData = rd
+	return s.err
+}

--- a/internal/attestation/callback.go
+++ b/internal/attestation/callback.go
@@ -17,3 +17,11 @@ type Report interface {
 type ReportSetter interface {
 	SetReport(report Report)
 }
+
+// ReportSetterFunc creates a ReportSetter from a func.
+type ReportSetterFunc func(report Report)
+
+// SetReport calls the adapted func to implement ReportSetter.SetReport.
+func (f ReportSetterFunc) SetReport(report Report) {
+	f(report)
+}

--- a/internal/attestation/snp/validator.go
+++ b/internal/attestation/snp/validator.go
@@ -100,6 +100,7 @@ func (v *Validator) Validate(ctx context.Context, id asn1.ObjectIdentifier, attD
 	//
 
 	// CRL validity and expiration is checked as part of verify.SnpAttestation.
+	// TODO(CON-202): don't reuse the v.verifyOpts!
 	if err := addCRLtoVerifyOptions(attestationData, v.verifyOpts); err != nil {
 		// Log error but continue, the client can still request the CRL/VCEK from the KDS.
 		v.logger.Info("could not use cached CRL from Coordinator aTLS handshake", slog.String("error", err.Error()))

--- a/internal/manifest/validators.go
+++ b/internal/manifest/validators.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package manifest
+
+import (
+	"context"
+	"encoding/asn1"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/edgelesssys/contrast/internal/atls/validators"
+	"github.com/edgelesssys/contrast/internal/attestation"
+	"github.com/edgelesssys/contrast/internal/attestation/certcache"
+	"github.com/edgelesssys/contrast/internal/attestation/snp"
+	"github.com/edgelesssys/contrast/internal/attestation/tdx"
+	"github.com/edgelesssys/contrast/internal/logger"
+	"github.com/edgelesssys/contrast/internal/oid"
+	snpmeasure "github.com/edgelesssys/contrast/internal/snp"
+)
+
+// Validator creates a validator that only succeeds for workloads whose policy is in the manifest.
+//
+// The validator MUST NOT be used concurrently, which is a limitation of the wrapped SNP validator.
+func (m *Manifest) Validator(log *slog.Logger, kdsGetter *certcache.CachedHTTPSGetter, reportSetter attestation.ReportSetter) (validators.Validator, error) {
+	var allValidators []validators.Validator
+
+	snpOpts, err := m.SNPValidateOpts(kdsGetter)
+	if err != nil {
+		log.Error("Could not generate SNP validation options", "error", err)
+		return nil, fmt.Errorf("generating SNP validation options: %w", err)
+	}
+
+	for i, opt := range snpOpts {
+		name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
+		validatorLog := logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name})
+		var validator validators.Validator
+		if len(opt.APEIP) == 4 {
+			seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
+			apEIP := binary.BigEndian.Uint32(opt.APEIP)
+			validator = snp.NewIterativeValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts, seed, apEIP, opt.VCPUSig, opt.AllowedChipIDs, validatorLog, reportSetter, name)
+		} else {
+			validator = snp.NewValidatorWithReportSetter(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, reportSetter, name)
+		}
+		allValidators = append(allValidators, validators.WithFixedOID(oid.RawSNPReport, validator))
+	}
+
+	tdxOpts, err := m.TDXValidateOpts(kdsGetter)
+	if err != nil {
+		log.Error("Could not generate TDX validation options", "error", err)
+		return nil, fmt.Errorf("generating TDX validation options: %w", err)
+	}
+	for i, opt := range tdxOpts {
+		name := fmt.Sprintf("tdx-%d", i)
+		validator := tdx.NewValidatorWithReportSetter(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs,
+			logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), reportSetter, name)
+		allValidators = append(allValidators, validators.WithFixedOID(oid.RawTDXReport, validator))
+	}
+
+	return validators.Any(allValidators...), nil
+}
+
+// CoordinatorValidator returns a validator that succeeds only for workloads with the Coordinator role.
+//
+// This is a more restrictive version of Validator, see the warning there.
+func (m *Manifest) CoordinatorValidator(log *slog.Logger, kdsGetter *certcache.CachedHTTPSGetter) (validators.Validator, error) {
+	coordPolicyHash, err := m.CoordinatorPolicyHash()
+	if err != nil {
+		return nil, fmt.Errorf("getting coordinator policy hash: %w", err)
+	}
+	coordPolicyHashBytes, err := coordPolicyHash.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("converting coordinator policy hash to bytes: %w", err)
+	}
+
+	return validators.ValidatorFunc(func(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+		// We're creating the validator here to make execution reentrant and thread-safe. This way,
+		// the validators and the captured report variable are not shared. Constructing the
+		// validators is anyway orders of magnitude faster than doing the validation.
+		var report attestation.Report
+		validator, err := m.Validator(log, kdsGetter, attestation.ReportSetterFunc(func(r attestation.Report) {
+			report = r
+		}))
+		if err != nil {
+			return fmt.Errorf("creating validator from manifest: %w", err)
+		}
+		if err := validator.Validate(ctx, oid, attDoc, reportData); err != nil {
+			return err
+		}
+		if !slices.Equal(coordPolicyHashBytes, report.HostData()) {
+			return fmt.Errorf("wrong policy hash for Coordinator: got %x, want %x", report.HostData(), coordPolicyHashBytes)
+		}
+		return nil
+	}), nil
+}

--- a/packages/by-name/contrast/resourcegen/package.nix
+++ b/packages/by-name/contrast/resourcegen/package.nix
@@ -36,11 +36,14 @@ buildGoModule (_finalAttrs: {
         (path.append root "internal/manifest/Intel_SGX_Provisioning_Certification_RootCA.pem")
         (fileset.intersection (fileset.fileFilter (file: hasSuffix ".go" file.name) root) (
           fileset.unions [
+            (path.append root "internal/atls")
             (path.append root "internal/attestation")
             (path.append root "internal/constants")
             (path.append root "internal/idblock")
             (path.append root "internal/kuberesource")
+            (path.append root "internal/logger")
             (path.append root "internal/manifest")
+            (path.append root "internal/oid")
             (path.append root "internal/platforms")
             (path.append root "internal/retry")
             (path.append root "internal/userapi")

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -6,18 +6,12 @@
 package sdk
 
 import (
-	"encoding/binary"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
-	"github.com/edgelesssys/contrast/internal/attestation/snp"
-	"github.com/edgelesssys/contrast/internal/attestation/tdx"
-	"github.com/edgelesssys/contrast/internal/logger"
 	"github.com/edgelesssys/contrast/internal/manifest"
-	snpmeasure "github.com/edgelesssys/contrast/internal/snp"
 )
 
 // ValidatorsFromManifest returns a list of validators corresponding to the reference values in the given manifest.
@@ -25,46 +19,9 @@ import (
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
 // Validators MUST NOT be used concurrently.
 func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) ([]validators.Validator, error) {
-	var allValidators []validators.Validator
-
-	coordPolicyHash, err := m.CoordinatorPolicyHash()
+	v, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {
-		return nil, fmt.Errorf("getting coordinator policy hash: %w", err)
+		return nil, fmt.Errorf("creating coordinator validator: %w", err)
 	}
-	coordPolicyHashBytes, err := coordPolicyHash.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("converting coordinator policy hash to bytes: %w", err)
-	}
-	opts, err := m.SNPValidateOpts(kdsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("getting SNP validate options: %w", err)
-	}
-	for i, opt := range opts {
-		opt.ValidateOpts.HostData = coordPolicyHashBytes
-		name := fmt.Sprintf("snp-%d-%s", i, strings.TrimPrefix(opt.VerifyOpts.Product.Name.String(), "SEV_PRODUCT_"))
-		validatorLog := logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name})
-		var v validators.Validator
-		if len(opt.APEIP) == 4 {
-			seed := [snpmeasure.LaunchDigestSize]byte(opt.ValidateOpts.Measurement)
-			apEIP := binary.BigEndian.Uint32(opt.APEIP)
-			v = snp.NewIterativeValidator(opt.VerifyOpts, opt.ValidateOpts, seed, apEIP, opt.VCPUSig, opt.AllowedChipIDs, validatorLog, name)
-		} else {
-			v = snp.NewValidator(opt.VerifyOpts, opt.ValidateOpts, opt.AllowedChipIDs, validatorLog, name)
-		}
-		allValidators = append(allValidators, v)
-	}
-
-	tdxOpts, err := m.TDXValidateOpts(kdsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("generating TDX validation options: %w", err)
-	}
-	var mrConfigID [48]byte
-	copy(mrConfigID[:], coordPolicyHashBytes)
-	for i, opt := range tdxOpts {
-		name := fmt.Sprintf("tdx-%d", i)
-		opt.ValidateOpts.TdQuoteBodyOptions.MrConfigID = mrConfigID[:]
-		allValidators = append(allValidators, tdx.NewValidator(opt.VerifyOpts, &tdx.StaticValidateOptsGenerator{Opts: opt.ValidateOpts}, opt.AllowedPIIDs, logger.NewWithAttrs(logger.NewNamed(log, "validator"), map[string]string{"reference-values": name}), name))
-	}
-
-	return allValidators, nil
+	return []validators.Validator{v}, nil
 }

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -8,7 +8,6 @@ package sdk
 import (
 	"bytes"
 	"context"
-	"encoding/asn1"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,15 +17,11 @@ import (
 
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
-	"github.com/edgelesssys/contrast/internal/attestation/insecure"
-	"github.com/edgelesssys/contrast/internal/attestation/snp"
-	"github.com/edgelesssys/contrast/internal/attestation/tdx"
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
 	"github.com/edgelesssys/contrast/internal/fsstore"
 	"github.com/edgelesssys/contrast/internal/history"
 	"github.com/edgelesssys/contrast/internal/httpapi"
 	"github.com/edgelesssys/contrast/internal/manifest"
-	"github.com/edgelesssys/contrast/internal/oid"
 	"github.com/spf13/afero"
 )
 
@@ -181,14 +176,6 @@ func (c Client) ValidateAttestation(ctx context.Context, nonce []byte, attestati
 	validated := false
 	var errs []error
 	for _, v := range validators {
-		if resp.AttestationType == nil {
-			wrapped, err := validatorForLegacyResponse(v)
-			if err != nil {
-				c.log.Warn("using this validator requires a server update", "error", err)
-				continue
-			}
-			v = wrapped
-		}
 		if err := v.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
 			c.log.Debug("validator failed", "error", err)
 			errs = append(errs, err)
@@ -223,27 +210,4 @@ type CoordinatorState struct {
 	LatestTransitionHash []byte
 	// Signature of the latest transition hash by the Coordinator.
 	LatestTransitionSignature []byte
-}
-
-// validatorForLegacyResponse determines the right OID for the given validator and overrides the input OID with it.
-//
-// This is needed because the OID was not part of the HTTP API response in prior versions.
-//
-// TODO(burgerdev): remove once all clients receive the OID from the HTTP API.
-func validatorForLegacyResponse(v validators.Validator) (validators.Validator, error) {
-	var id asn1.ObjectIdentifier
-	switch v.(type) {
-	case *snp.Validator, *snp.IterativeValidator:
-		id = oid.RawSNPReport
-	case *tdx.Validator:
-		id = oid.RawTDXReport
-	case *insecure.Validator:
-		id = oid.RawInsecureReport
-	default:
-		return nil, fmt.Errorf("unexpected validator type: %T", v)
-	}
-
-	return validators.ValidatorFunc(func(ctx context.Context, _ asn1.ObjectIdentifier, attDoc, reportData []byte) error {
-		return v.Validate(ctx, id, attDoc, reportData)
-	}), nil
 }


### PR DESCRIPTION
This PR continues the plan described in #2483, moving all validation logic from the various places we implemented it in to the `manifest` package, which is now the authoritative source for how to construct validators for a given manifest. Two helpers are added:

* This move needs to retain the backwards compat logic from the SDK, so we're adding a wrapper for that to the `validators` package, too.
* The `Any` combinator separates the for loop over eligible validators from their construction and individual invocation, simplifying the respective functions.