### PR TITLE
justfile: add just unit target and pre-push hook

### DIFF
--- a/dev-shells/git-hooks.nix
+++ b/dev-shells/git-hooks.nix
@@ -28,7 +28,7 @@
   };
   go-test = {
     enable = true;
-    entry = "go test -tags contrast_unstable_api -v ./...";
+    entry = "just unit";
     pass_filenames = false;
     stages = [ "pre-push" ];
   };

--- a/justfile
+++ b/justfile
@@ -546,6 +546,10 @@ fmt:
 lint:
     nix run -L .#base.scripts.golangci-lint -- run
 
+# Run Go unit tests.
+unit:
+    CGO_ENABLED=1 go test -tags=contrast_unstable_api -v -race ./...
+
 # Check links.
 check-links config="external":
     nix run .#base.nixpkgs.lychee -- --config tools/lychee/config-{{ config }}.toml .


### PR DESCRIPTION
During review of https://github.com/edgelesssys/contrast/pull/2487/ I noticed that a unit test failure was not being surfaced in the CI during PR review. Adding a new just target and a pre-push hook.