### PR TITLE
just/e2e: add flag to disable usage of very large images in tests

### DIFF
--- a/e2e/imagestore/imagestore_test.go
+++ b/e2e/imagestore/imagestore_test.go
@@ -59,7 +59,9 @@ func TestImageStore(t *testing.T) {
 		resources = append(resources, testPod(tc.name, tc.annotation))
 	}
 
-	resources = append(resources, tensorflowPod())
+	if !*skipLargeImage {
+		resources = append(resources, tensorflowPod())
+	}
 
 	resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
 	resources = kuberesource.AddPortForwarders(resources)
@@ -160,6 +162,10 @@ func TestImageStore(t *testing.T) {
 		})
 	}
 
+	if *skipLargeImage {
+		return
+	}
+
 	t.Run("large image with pod resource limits", func(t *testing.T) {
 		// Increase timeout, as pulling the image may take a while.
 		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(5*time.Minute))
@@ -197,6 +203,8 @@ func checkDiskSize(expected, size int, name string) error {
 	}
 	return nil
 }
+
+var skipLargeImage = flag.Bool("imagestore-skip-large-image", false, "skip the large (tensorflow) image pod and its subtest")
 
 func TestMain(m *testing.M) {
 	contrasttest.RegisterFlags()

--- a/justfile
+++ b/justfile
@@ -125,6 +125,10 @@ _e2e target=default_deploy_target platform=default_platform set=default_set: sof
     if [[ {{ target }} == "containerd-11644-reproducer" ]]; then
         just containerd-reproducer
     fi
+    test_args=()
+    if [[ {{ target }} == "imagestore" && "${imagestore_skip_large_image:-false}" == "true" ]]; then
+        test_args+=(--imagestore-skip-large-image)
+    fi
     get_logs=$(nix build .#{{ set }}.scripts.get-logs --no-link --print-out-paths)
     # get-logs start waits until the namespace file is created, then spawns self-cleaning background tasks and exits.
     "$get_logs/bin/get-logs" start ./{{ workspace_dir }}/just.namespace &
@@ -136,7 +140,8 @@ _e2e target=default_deploy_target platform=default_platform set=default_set: sof
             --node-installer-target-conf-type "${node_installer_target_conf_type}" \
             --namespace-suffix=${namespace_suffix-} \
             --sync-ticket-file ./{{ workspace_dir }}/just.sync-ticket \
-            --insecure-enable-debug-shell-access=${debug:-false}
+            --insecure-enable-debug-shell-access=${debug:-false} \
+            "${test_args[@]}"
 
 # Run additional tests for a PR. Set `post` to `true` to auto-post the comment.
 e2e-ci target platforms="all" post="false" set="testcase-default" debug_shell="false" skip_undeploy="false":


### PR DESCRIPTION
#2459 added the tensorflow image to the imagestore test. Unofrtunately, 7GB is way too large for `generate` to now finish in the 5min timeout window on my dev machine / with my internet connection. I assume I'm not alone. 

This PR adds a flag to just skip that container in the imagestore test. For CI, nothing changes; for devs, you can set `imagestore_skip_large_image="true"` in your `justfile.env` and have the tensorflow image be skipped.