### PR TITLE
manifest: allow more than one Coordinator policy

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -250,13 +250,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	mnf.Policies = policyMap
 	// Existing manifests are already validated above, but newly generated manifests may be missing reference values or a coordinator.
-	var ce *manifest.CoordinatorCountError
 	var ve *manifest.ValidationError
-	if err := mnf.Validate(); errors.As(err, &ce) {
-		if ce.Count == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "  No Coordinator resource found, did you forget to add it to your resources?")
-		}
-		return ce
+	if err := mnf.Validate(); errors.Is(err, manifest.ErrMissingCoordinator) {
+		fmt.Fprintln(cmd.OutOrStdout(), "  No Coordinator resource found, did you forget to add it to your resources?")
+		return err
 	} else if errors.As(err, &ve) && ve.OnlyExpectedMissingReferenceValues() {
 		for _, e := range ve.Unwrap() {
 			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", e)

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -42,7 +42,6 @@ import (
 const (
 	annotationPrefix              = "contrast.edgeless.systems/"
 	kataAnnotationPrefix          = "io.katacontainers.config.hypervisor."
-	contrastRoleAnnotationKey     = annotationPrefix + "pod-role"
 	workloadSecretIDAnnotationKey = annotationPrefix + "workload-secret-id"
 	idBlockAnnotation             = kataAnnotationPrefix + "snp_id_block_"
 	idAuthAnnotationKey           = kataAnnotationPrefix + "snp_id_auth_"
@@ -350,7 +349,7 @@ func isCoordinator(resource any) bool {
 		r.Spec.Template != nil &&
 		r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 		r.Spec.Template.Annotations != nil &&
-		r.Spec.Template.Annotations[contrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
+		r.Spec.Template.Annotations[kuberesource.ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
 		return true
 	}
 	return false

--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -73,7 +73,7 @@ func policiesFromKubeResources(fileMap map[string][]*unstructured.Unstructured) 
 				return meta, spec
 			}
 			annotation = meta.Annotations[initdata.InitdataAnnotationKey]
-			role = manifest.Role(meta.Annotations[contrastRoleAnnotationKey])
+			role = manifest.Role(meta.Annotations[kuberesource.ContrastRoleAnnotationKey])
 			workloadSecretID = meta.Annotations[workloadSecretIDAnnotationKey]
 			return meta, spec
 		})

--- a/cli/cmd/policies_test.go
+++ b/cli/cmd/policies_test.go
@@ -35,8 +35,8 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
 							WithAnnotations(map[string]string{
-								initdata.InitdataAnnotationKey: anno,
-								contrastRoleAnnotationKey:      "coordinator",
+								initdata.InitdataAnnotationKey:         anno,
+								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
 							}).
 							WithSpec(
 								kuberesource.PodSpec().
@@ -86,8 +86,8 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
 							WithAnnotations(map[string]string{
-								initdata.InitdataAnnotationKey: anno,
-								contrastRoleAnnotationKey:      "coordinator",
+								initdata.InitdataAnnotationKey:         anno,
+								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
 							}).
 							WithSpec(
 								kuberesource.PodSpec().

--- a/cli/verifier/versions_match.go
+++ b/cli/verifier/versions_match.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/regclient/regclient/types/ref"
 
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -40,7 +41,7 @@ func (v *VersionsMatch) Verify(toVerify any) error {
 
 		var podRole string
 		if meta != nil && meta.Annotations != nil {
-			podRole = meta.Annotations["contrast.edgeless.systems/pod-role"]
+			podRole = meta.Annotations[kuberesource.ContrastRoleAnnotationKey]
 		}
 		for _, container := range spec.Containers {
 			if !needsImageVersionCheck(*container.Name, podRole) {
@@ -74,7 +75,7 @@ func needsImageVersionCheck(containerName string, podRole string) bool {
 	if slices.Contains([]string{"contrast-initializer", "contrast-service-mesh"}, containerName) {
 		return true
 	}
-	if containerName == "coordinator" && podRole == "coordinator" {
+	if containerName == "coordinator" && podRole == string(manifest.RoleCoordinator) {
 		return true
 	}
 	return false

--- a/cli/verifier/versions_match_test.go
+++ b/cli/verifier/versions_match_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/edgelesssys/contrast/cli/verifier"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ kind: Pod
 metadata:
   name: test
   annotations:
-    contrast.edgeless.systems/pod-role: %s
+    %s: %s
 spec:
   runtimeClassName: contrast-cc
   containers:
@@ -65,7 +66,7 @@ func TestVerifyVersionsMatch(t *testing.T) {
 			version:       "v1.13.0",
 		},
 		"versions match with pod-role": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "coordinator", "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleCoordinator, "v1.13.0"),
 			version:       "v1.13.0",
 		},
 		"cli version newer": {
@@ -79,12 +80,12 @@ func TestVerifyVersionsMatch(t *testing.T) {
 			wantErr:       true,
 		},
 		"cli version mismatch with pod-role": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "coordinator", "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleCoordinator, "v1.13.0"),
 			version:       "v1.12.0",
 			wantErr:       true,
 		},
 		"cli version mismatch with differing pod-role unaffected": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, "not-coordinator", "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleNone, "v1.13.0"),
 			version:       "v1.12.0",
 		},
 		"resource missing version skipped": {

--- a/coordinator/internal/peerdiscovery/peerdiscovery.go
+++ b/coordinator/internal/peerdiscovery/peerdiscovery.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,7 +41,7 @@ func (d *Discovery) GetPeers(ctx context.Context) ([]string, error) {
 	}
 	var peers []string
 	for _, pod := range pods.Items {
-		if pod.Annotations["contrast.edgeless.systems/pod-role"] != "coordinator" ||
+		if pod.Annotations[kuberesource.ContrastRoleAnnotationKey] != string(manifest.RoleCoordinator) ||
 			pod.Name == os.Getenv("HOSTNAME") {
 			continue
 		}

--- a/coordinator/internal/peerdiscovery/peerdiscovery_test.go
+++ b/coordinator/internal/peerdiscovery/peerdiscovery_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/kuberesource"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,13 +80,13 @@ func TestGetPeers(t *testing.T) {
 	}
 }
 
-func newPod(name, namespace, labelName, role, ip string, isReady bool) runtime.Object {
+func newPod(name, namespace, labelName string, role manifest.Role, ip string, isReady bool) runtime.Object {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Labels:      map[string]string{"app.kubernetes.io/name": labelName},
-			Annotations: map[string]string{"contrast.edgeless.systems/pod-role": role},
+			Annotations: map[string]string{kuberesource.ContrastRoleAnnotationKey: string(role)},
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},

--- a/e2e/atls/atls_test.go
+++ b/e2e/atls/atls_test.go
@@ -80,9 +80,10 @@ func TestATLS(t *testing.T) {
 		require.NoError(json.Unmarshal(manifestBytes, &manifestParsed))
 		require.NoError(manifestParsed.Validate())
 
-		coordPolicyHash, err := manifestParsed.CoordinatorPolicyHash()
+		coordPolicyHashes, err := manifestParsed.CoordinatorPolicyHashes()
 		require.NoError(err, "getting coordinator policy hash")
-		coordPolicyHashBytes, err = coordPolicyHash.Bytes()
+		require.Len(coordPolicyHashes, 1)
+		coordPolicyHashBytes, err = coordPolicyHashes[0].Bytes()
 		require.NoError(err, "converting coordinator policy hash to bytes")
 	}))
 

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -183,8 +183,10 @@ func TestPolicy(t *testing.T) {
 		require.NoError(json.Unmarshal(manifestBytes, &m))
 
 		// Change expected coordinator policy hash.
-		policyHash, err := m.CoordinatorPolicyHash()
+		policyHashes, err := m.CoordinatorPolicyHashes()
 		require.NoError(err)
+		require.Len(policyHashes, 1)
+		policyHash := policyHashes[0]
 		policy := m.Policies[policyHash]
 		delete(m.Policies, policyHash)
 		policyHashBytes, err := policyHash.Bytes()

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	exposeServiceAnnotation       = "contrast.edgeless.systems/expose-service"
-	contrastRoleAnnotationKey     = "contrast.edgeless.systems/pod-role"
 	skipInitializerAnnotationKey  = "contrast.edgeless.systems/skip-initializer"
 	smIngressConfigAnnotationKey  = "contrast.edgeless.systems/servicemesh-ingress"
 	smEgressConfigAnnotationKey   = "contrast.edgeless.systems/servicemesh-egress"
@@ -40,6 +39,11 @@ const (
 
 	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
 	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"
+
+	// ContrastRoleAnnotationKey assigns a role to the annotated pod.
+	//
+	// This is used to determine whether a given pod may act as Coordinator.
+	ContrastRoleAnnotationKey = "contrast.edgeless.systems/pod-role"
 )
 
 // CollateralProxyDefaultService is the default in-cluster URL of the collateral-proxy.
@@ -320,7 +324,7 @@ func SetCollateralProxyEnv(resources []any, proxyURL string) []any {
 	out := make([]any, 0, len(resources))
 	for _, resource := range resources {
 		out = append(out, MapPodSpecWithMeta(resource, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
-			if meta == nil || meta.Annotations[contrastRoleAnnotationKey] != "coordinator" {
+			if meta == nil || meta.Annotations[ContrastRoleAnnotationKey] != string(manifest.RoleCoordinator) {
 				return meta, spec
 			}
 			for i := range spec.Containers {
@@ -515,7 +519,7 @@ func AddLogging(resources []any, level, subsystem string) []any {
 		switch r := resource.(type) {
 		case *applyappsv1.StatefulSetApplyConfiguration:
 			if r.Spec != nil && r.Spec.Template != nil &&
-				r.Spec.Template.Annotations["contrast.edgeless.systems/pod-role"] == "coordinator" {
+				r.Spec.Template.Annotations[ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
 				r.Spec.Template.Spec.Containers[0].WithEnv(
 					NewEnvVar("CONTRAST_LOG_LEVEL", level),
 					NewEnvVar("CONTRAST_LOG_SUBSYSTEMS", subsystem),
@@ -744,7 +748,7 @@ func PatchCoordinatorMetrics(resources []any) []any {
 		case *applyappsv1.StatefulSetApplyConfiguration:
 			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.Spec != nil &&
 				len(r.Spec.Template.Spec.Containers) > 0 &&
-				r.Spec.Template.Annotations[contrastRoleAnnotationKey] == "coordinator" {
+				r.Spec.Template.Annotations[ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
 				r.Spec.Template.Spec.Containers[0].WithEnv(NewEnvVar("CONTRAST_METRICS", "1"))
 				r.Spec.Template.Spec.Containers[0].WithPorts(
 					ContainerPort().

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -809,7 +809,7 @@ func TestSetCollateralProxyEnv(t *testing.T) {
 	assert := assert.New(t)
 
 	coordinatorPod := applycorev1.Pod("coordinator", "default").
-		WithAnnotations(map[string]string{contrastRoleAnnotationKey: "coordinator"}).
+		WithAnnotations(map[string]string{ContrastRoleAnnotationKey: "coordinator"}).
 		WithSpec(applycorev1.PodSpec().
 			WithRuntimeClassName("contrast-cc-foo").
 			WithContainers(applycorev1.Container().WithName("coordinator").WithImage("coordinator")))

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -82,14 +82,9 @@ func (m *Manifest) Validate() error {
 		}
 	}
 
-	var coordinatorCount uint
-	for _, policy := range m.Policies {
-		if policy.Role == RoleCoordinator {
-			coordinatorCount++
-		}
-	}
-	if coordinatorCount != 1 {
-		return &CoordinatorCountError{Count: coordinatorCount}
+	// Implicitly checks Coordinator count.
+	if _, err := m.CoordinatorPolicyHashes(); err != nil {
+		return err
 	}
 
 	if err := m.ReferenceValues.Validate(); err != nil {
@@ -110,14 +105,18 @@ func (m *Manifest) Validate() error {
 	return errors.Join(errs...)
 }
 
-// CoordinatorPolicyHash returns the hash of the coordinator policy.
-func (m *Manifest) CoordinatorPolicyHash() (HexString, error) {
+// CoordinatorPolicyHashes returns policy hashes for all workloads with role Coordinator.
+func (m *Manifest) CoordinatorPolicyHashes() ([]HexString, error) {
+	var all []HexString
 	for policyHash, policy := range m.Policies {
 		if policy.Role == RoleCoordinator {
-			return policyHash, nil
+			all = append(all, policyHash)
 		}
 	}
-	return "", errors.New("no coordinator found in manifest")
+	if len(all) == 0 {
+		return nil, ErrMissingCoordinator
+	}
+	return all, nil
 }
 
 // SNPValidateOpts returns validate options generators populated with the manifest's
@@ -536,12 +535,8 @@ func (e *ValidationError) OnlyExpectedMissingReferenceValues() bool {
 	return true
 }
 
-// CoordinatorCountError occurs during manifest validation when either zero, or more than one coordinators have been defined.
-type CoordinatorCountError struct{ Count uint }
-
-func (e *CoordinatorCountError) Error() string {
-	return fmt.Sprintf("expected exactly 1 policy with role 'coordinator', got %d", e.Count)
-}
+// ErrMissingCoordinator is returned when the manifest does not contain at least one policy for a Coordinator.
+var ErrMissingCoordinator = errors.New("expected at least 1 policy with role 'coordinator'")
 
 func toPtr[T any](v T) *T {
 	return &v

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -392,6 +392,8 @@ const (
 	RoleNone Role = ""
 	// RoleCoordinator is the coordinator role.
 	RoleCoordinator Role = "coordinator"
+	// RoleNodeInstaller is the node installer DaemonSet.
+	RoleNodeInstaller Role = "contrast-node-installer"
 )
 
 // Validate checks the validity of the role.

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -224,7 +224,6 @@ func TestValidate(t *testing.T) {
 					Role: "coordinator",
 				}
 			},
-			wantErr: true,
 		},
 		"no chip IDs": {
 			m: newTestManifestSNP(),

--- a/internal/manifest/validators.go
+++ b/internal/manifest/validators.go
@@ -71,13 +71,25 @@ var ErrWrongCoordinatorPolicyHash = errors.New("wrong policy hash for Coordinato
 //
 // This is a more restrictive version of Validator, see the warning there.
 func (m *Manifest) CoordinatorValidator(log *slog.Logger, kdsGetter *certcache.CachedHTTPSGetter) (validators.Validator, error) {
-	coordPolicyHash, err := m.CoordinatorPolicyHash()
+	coordPolicyHashes, err := m.CoordinatorPolicyHashes()
 	if err != nil {
 		return nil, fmt.Errorf("getting coordinator policy hash: %w", err)
 	}
-	coordPolicyHashBytes, err := coordPolicyHash.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("converting coordinator policy hash to bytes: %w", err)
+	return coordinatorValidator(m.Validator, coordPolicyHashes, log, kdsGetter)
+}
+
+type validatorFactory func(log *slog.Logger, kdsGetter *certcache.CachedHTTPSGetter, reportSetter attestation.ReportSetter) (validators.Validator, error)
+
+// coordinatorValidator is the implementation of the post-validation step for CoordinatorValidator.
+// It can be parametrized for testing.
+func coordinatorValidator(validatorFactory validatorFactory, coordPolicyHashes []HexString, log *slog.Logger, kdsGetter *certcache.CachedHTTPSGetter) (validators.Validator, error) {
+	var allHashes [][]byte
+	for _, hash := range coordPolicyHashes {
+		b, err := hash.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("converting coordinator policy hash %q to bytes: %w", hash.String(), err)
+		}
+		allHashes = append(allHashes, b)
 	}
 
 	return validators.ValidatorFunc(func(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
@@ -85,7 +97,7 @@ func (m *Manifest) CoordinatorValidator(log *slog.Logger, kdsGetter *certcache.C
 		// the validators and the captured report variable are not shared. Constructing the
 		// validators is anyway orders of magnitude faster than doing the validation.
 		var report attestation.Report
-		validator, err := m.Validator(log, kdsGetter, attestation.ReportSetterFunc(func(r attestation.Report) {
+		validator, err := validatorFactory(log, kdsGetter, attestation.ReportSetterFunc(func(r attestation.Report) {
 			report = r
 		}))
 		if err != nil {
@@ -94,8 +106,10 @@ func (m *Manifest) CoordinatorValidator(log *slog.Logger, kdsGetter *certcache.C
 		if err := validator.Validate(ctx, oid, attDoc, reportData); err != nil {
 			return err
 		}
-		if !slices.Equal(coordPolicyHashBytes, report.HostData()) {
-			return fmt.Errorf("%w: got %x, want %x", ErrWrongCoordinatorPolicyHash, report.HostData(), coordPolicyHashBytes)
+		if !slices.ContainsFunc(allHashes, func(b []byte) bool {
+			return slices.Equal(report.HostData(), b)
+		}) {
+			return fmt.Errorf("%w: got %x, want %v", ErrWrongCoordinatorPolicyHash, report.HostData(), coordPolicyHashes)
 		}
 		return nil
 	}), nil

--- a/internal/manifest/validators.go
+++ b/internal/manifest/validators.go
@@ -67,6 +67,9 @@ func (m *Manifest) Validator(log *slog.Logger, kdsGetter *certcache.CachedHTTPSG
 // ErrWrongCoordinatorPolicyHash is returned when the Coordinator policy hash does not match the manifest policy hash.
 var ErrWrongCoordinatorPolicyHash = errors.New("wrong policy hash for Coordinator")
 
+// ErrBadValidator is returned when the validator did not call the ReportSetter callback.
+var ErrBadValidator = errors.New("validator did not produce a report")
+
 // CoordinatorValidator returns a validator that succeeds only for workloads with the Coordinator role.
 //
 // This is a more restrictive version of Validator, see the warning there.
@@ -105,6 +108,9 @@ func coordinatorValidator(validatorFactory validatorFactory, coordPolicyHashes [
 		}
 		if err := validator.Validate(ctx, oid, attDoc, reportData); err != nil {
 			return err
+		}
+		if report == nil {
+			return ErrBadValidator
 		}
 		if !slices.ContainsFunc(allHashes, func(b []byte) bool {
 			return slices.Equal(report.HostData(), b)

--- a/internal/manifest/validators_test.go
+++ b/internal/manifest/validators_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package manifest
+
+import (
+	"context"
+	"encoding/asn1"
+	"log/slog"
+	"testing"
+
+	"github.com/edgelesssys/contrast/internal/atls/validators"
+	"github.com/edgelesssys/contrast/internal/attestation"
+	"github.com/edgelesssys/contrast/internal/attestation/certcache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoordinatorValidator(t *testing.T) {
+	for name, tc := range map[string]struct {
+		// Configuration for the fake factory
+		validatorOutputHash []byte
+		validatorErr        error
+
+		// Hashes allowed by manifest
+		allowedHashes []HexString
+
+		// Final validation outcome
+		expectValidationErr error
+	}{
+		"validator fails": {
+			validatorErr:        assert.AnError,
+			expectValidationErr: assert.AnError,
+		},
+		"happy path single coordinator": {
+			validatorOutputHash: []byte{1, 2, 3},
+			allowedHashes:       []HexString{"010203"},
+		},
+		"matching coordinator first": {
+			validatorOutputHash: []byte{1, 2, 3},
+			allowedHashes:       []HexString{"010203", "040506"},
+		},
+		"matching coordinator second": {
+			validatorOutputHash: []byte{4, 5, 6},
+			allowedHashes:       []HexString{"010203", "040506"},
+		},
+		"no coordinator": {
+			validatorOutputHash: []byte{4, 5, 6},
+			expectValidationErr: ErrWrongCoordinatorPolicyHash,
+		},
+		"no match": {
+			validatorOutputHash: []byte{7, 8, 9},
+			allowedHashes:       []HexString{"010203", "040506"},
+			expectValidationErr: ErrWrongCoordinatorPolicyHash,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			dummyValidatorFactory := func(_ *slog.Logger, _ *certcache.CachedHTTPSGetter, reportSetter attestation.ReportSetter) (validators.Validator, error) {
+				return validators.ValidatorFunc(func(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
+					if tc.validatorErr != nil {
+						return tc.validatorErr
+					}
+					reportSetter.SetReport(&stubReport{hostData: tc.validatorOutputHash})
+					return nil
+				}), nil
+			}
+
+			v, err := coordinatorValidator(dummyValidatorFactory, tc.allowedHashes, nil, nil)
+			require.NoError(err)
+			require.NotNil(v)
+
+			validationErr := v.Validate(t.Context(), nil, nil, nil)
+			if tc.expectValidationErr != nil {
+				require.ErrorIs(validationErr, tc.expectValidationErr)
+			} else {
+				require.NoError(validationErr)
+			}
+		})
+	}
+
+	t.Run("bad factory", func(t *testing.T) {
+		require := require.New(t)
+
+		badFactory := func(*slog.Logger, *certcache.CachedHTTPSGetter, attestation.ReportSetter) (validators.Validator, error) {
+			return nil, assert.AnError
+		}
+
+		v, err := coordinatorValidator(badFactory, nil, nil, nil)
+		require.NoError(err)
+		require.NotNil(v)
+
+		require.ErrorIs(v.Validate(t.Context(), nil, nil, nil), assert.AnError)
+	})
+}
+
+type stubReport struct {
+	attestation.Report
+
+	hostData []byte
+}
+
+func (r *stubReport) HostData() []byte {
+	return r.hostData
+}

--- a/internal/manifest/validators_test.go
+++ b/internal/manifest/validators_test.go
@@ -92,6 +92,22 @@ func TestCoordinatorValidator(t *testing.T) {
 
 		require.ErrorIs(v.Validate(t.Context(), nil, nil, nil), assert.AnError)
 	})
+
+	t.Run("bad validator", func(t *testing.T) {
+		require := require.New(t)
+
+		badValidatorFactory := func(*slog.Logger, *certcache.CachedHTTPSGetter, attestation.ReportSetter) (validators.Validator, error) {
+			return validators.ValidatorFunc(func(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
+				return nil
+			}), nil
+		}
+
+		v, err := coordinatorValidator(badValidatorFactory, nil, nil, nil)
+		require.NoError(err)
+		require.NotNil(v)
+
+		require.ErrorIs(v.Validate(t.Context(), nil, nil, nil), ErrBadValidator)
+	})
 }
 
 type stubReport struct {


### PR DESCRIPTION
Contrast now allows more than one Coordinator in the resources passed to `contrast generate`. This is useful in a couple of scenarios:

- Coordinator instances running with different names or in different namespaces.
- Coordinator instances with different configuration (e.g. logging).
- Blue-green deployments.
- Different runtime class (SNP and TDX produce different policies).

---

Fixes CON-174