### PR TITLE
treewide: pass a single validator to aTLS

### DIFF
--- a/cli/cmd/recover.go
+++ b/cli/cmd/recover.go
@@ -14,7 +14,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/userapi"
-	"github.com/edgelesssys/contrast/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -79,12 +78,12 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("configuring KDS cache: %w", err)
 	}
-	validators, err := sdk.ValidatorsFromManifest(kdsGetter, &m, log)
+	validator, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {
 		return fmt.Errorf("getting validators: %w", err)
 	}
 
-	dialer := dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, nil, seedShareOwnerKey, log)
+	dialer := dialer.NewWithKey(atls.NoIssuer, validator, atls.NoMetrics, nil, seedShareOwnerKey, log)
 
 	log.Debug("Dialing coordinator", "endpoint", flags.coordinator)
 	conn, err := dialer.Dial(cmd.Context(), flags.coordinator)

--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -27,7 +27,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/retry"
 	"github.com/edgelesssys/contrast/internal/spinner"
 	"github.com/edgelesssys/contrast/internal/userapi"
-	"github.com/edgelesssys/contrast/sdk"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -139,16 +138,16 @@ func runSet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("configuring KDS cache: %w", err)
 	}
-	validators, err := sdk.ValidatorsFromManifest(kdsGetter, &m, log)
+	validator, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {
 		return fmt.Errorf("getting validators: %w", err)
 	}
 
 	var dialr *dialer.Dialer
 	if workloadOwnerKey == nil {
-		dialr = dialer.New(atls.NoIssuer, validators, atls.NoMetrics, nil, log)
+		dialr = dialer.New(atls.NoIssuer, validator, atls.NoMetrics, nil, log)
 	} else {
-		dialr = dialer.NewWithKey(atls.NoIssuer, validators, atls.NoMetrics, nil, workloadOwnerKey, log)
+		dialr = dialer.NewWithKey(atls.NoIssuer, validator, atls.NoMetrics, nil, workloadOwnerKey, log)
 	}
 
 	conn, err := dialr.Dial(cmd.Context(), flags.coordinator)

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -190,11 +190,11 @@ func getCoordinatorState(ctx context.Context, kdsDir string, manifestBytes []byt
 
 	kdsCache := fsstore.New(afero.NewBasePathFs(afero.NewOsFs(), kdsDir), log.WithGroup("kds-cache"))
 	kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, log.WithGroup("kds-getter"))
-	validators, err := sdk.ValidatorsFromManifest(kdsGetter, &m, log)
+	validator, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {
 		return sdk.CoordinatorState{}, fmt.Errorf("getting validators: %w", err)
 	}
-	dialer := dialer.New(atls.NoIssuer, validators, atls.NoMetrics, nil, log)
+	dialer := dialer.New(atls.NoIssuer, validator, atls.NoMetrics, nil, log)
 
 	log.Debug("Dialing coordinator", "endpoint", endpoint)
 

--- a/coordinator/internal/peerrecovery/recovery.go
+++ b/coordinator/internal/peerrecovery/recovery.go
@@ -184,12 +184,12 @@ func periodically(ctx context.Context, clock clock.WithTicker, interval time.Dur
 }
 
 type meshAPIDialer interface {
-	Dial(context.Context, atls.Issuer, []validators.Validator, *slog.Logger, string) (meshapi.MeshAPIClient, func() error, error)
+	Dial(context.Context, atls.Issuer, validators.Validator, *slog.Logger, string) (meshapi.MeshAPIClient, func() error, error)
 }
 
 type defaultMeshAPIDialer struct{}
 
-func (defaultMeshAPIDialer) Dial(ctx context.Context, issuer atls.Issuer, validators []validators.Validator, logger *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
+func (defaultMeshAPIDialer) Dial(ctx context.Context, issuer atls.Issuer, validators validators.Validator, logger *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
 	dial := dialer.New(issuer, validators, atls.NoMetrics, nil, logger)
 	conn, err := dial.Dial(ctx, addr)
 	if err != nil {

--- a/coordinator/internal/peerrecovery/recovery.go
+++ b/coordinator/internal/peerrecovery/recovery.go
@@ -22,7 +22,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/meshapi"
 	"github.com/edgelesssys/contrast/internal/seedengine"
-	"github.com/edgelesssys/contrast/sdk"
 	"k8s.io/utils/clock"
 )
 
@@ -136,12 +135,12 @@ type authorizer struct {
 // AuthorizeByManifest calls meshapi.Recover on a peer coordinator given as context value and
 // verifies that the peer is an authorized Coordinator according to the manifest.
 func (a *authorizer) AuthorizeByManifest(ctx context.Context, mnfst *manifest.Manifest) (*seedengine.SeedEngine, *ecdsa.PrivateKey, error) {
-	validators, err := sdk.ValidatorsFromManifest(a.httpsGetter, mnfst, a.logger)
+	validator, err := mnfst.CoordinatorValidator(a.logger, a.httpsGetter)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generating validators: %w", err)
 	}
 
-	client, closeConn, err := a.dialer.Dial(ctx, a.issuer, validators, a.logger, a.peer)
+	client, closeConn, err := a.dialer.Dial(ctx, a.issuer, validator, a.logger, a.peer)
 	if err != nil {
 		return nil, nil, fmt.Errorf("dialing coordinator: %w", err)
 	}

--- a/coordinator/internal/peerrecovery/recovery_test.go
+++ b/coordinator/internal/peerrecovery/recovery_test.go
@@ -138,7 +138,7 @@ func TestRecoverFromPeer(t *testing.T) {
 	assert.Equal(expectedAddr, dialer.recordedAddress)
 	assert.NotNil(dialer.recordedIssuer)
 	assert.True(dialer.closeCalled)
-	require.Len(dialer.recordedValidators, 1)
+	require.NotNil(dialer.recordedValidator)
 }
 
 type fakeIssuer struct {
@@ -227,16 +227,16 @@ func (pg *stubPeerGetter) GetPeers(context.Context) ([]string, error) {
 type stubDialer struct {
 	responses map[string]meshapi.MeshAPIClient
 
-	recordedIssuer     atls.Issuer
-	recordedValidators []validators.Validator
-	recordedAddress    string
-	closeCalled        bool
+	recordedIssuer    atls.Issuer
+	recordedValidator validators.Validator
+	recordedAddress   string
+	closeCalled       bool
 }
 
-func (d *stubDialer) Dial(_ context.Context, issuer atls.Issuer, validators []validators.Validator, _ *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
+func (d *stubDialer) Dial(_ context.Context, issuer atls.Issuer, validator validators.Validator, _ *slog.Logger, addr string) (meshapi.MeshAPIClient, func() error, error) {
 	d.recordedAddress = addr
 	d.recordedIssuer = issuer
-	d.recordedValidators = validators
+	d.recordedValidator = validator
 	cancel := func() error {
 		d.closeCalled = true
 		return nil

--- a/coordinator/internal/stateguard/credentials.go
+++ b/coordinator/internal/stateguard/credentials.go
@@ -12,7 +12,6 @@ import (
 	"net"
 
 	"github.com/edgelesssys/contrast/internal/atls"
-	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
@@ -71,7 +70,7 @@ func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.A
 		return nil, nil, fmt.Errorf("creating validator from manifest: %w", err)
 	}
 
-	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, []validators.Validator{validator}, c.attestationFailuresCounter)
+	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, validator, c.attestationFailuresCounter)
 	if err != nil {
 		log.Error("Could not create TLS config", "error", err)
 		return nil, nil, err

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -27,7 +27,6 @@ import (
 	userapiserver "github.com/edgelesssys/contrast/coordinator/internal/userapi"
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
-	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/defaultdeny"
@@ -128,7 +127,7 @@ func run() (retErr error) {
 		return fmt.Errorf("creating issuer: %w", err)
 	}
 
-	userAPICredentials := atlscredentials.New(issuer, validators.NoValidation(), atls.NoMetrics, loggerpkg.NewNamed(logger, "atlscredentials"))
+	userAPICredentials := atlscredentials.New(issuer, nil, atls.NoMetrics, loggerpkg.NewNamed(logger, "atlscredentials"))
 	userAPIServer := newGRPCServer(userAPICredentials, serverMetrics)
 	userapi.RegisterUserAPIServer(userAPIServer, userapiserver.New(logger, meshAuth, discovery))
 	serverMetrics.InitializeMetrics(userAPIServer)

--- a/e2e/atls/atls_test.go
+++ b/e2e/atls/atls_test.go
@@ -149,6 +149,7 @@ func TestATLS(t *testing.T) {
 				assert := require.New(t)
 				require := require.New(t)
 
+				// TODO(burgerdev): should this test use Manifest.CoordinatorValidator()?
 				kdsCache := memstore.New[string, []byte]()
 				kdsGetter := certcache.NewCachedHTTPSGetter(kdsCache, certcache.NeverGCTicker, logger.WithGroup("kds-getter"))
 				opts, err := manifestParsed.SNPValidateOpts(kdsGetter)
@@ -169,7 +170,7 @@ func TestATLS(t *testing.T) {
 					allValidators = append(allValidators, v)
 				}
 
-				dialer := dialer.New(atls.NoIssuer, allValidators, atls.NoMetrics, nil, logger)
+				dialer := dialer.New(atls.NoIssuer, validators.Any(allValidators...), atls.NoMetrics, nil, logger)
 				conn, err := dialer.Dial(ctx, addr)
 				require.NoError(err, "dialing coordinator")
 				defer conn.Close()

--- a/e2e/attestation/attestation_test.go
+++ b/e2e/attestation/attestation_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/internal/userapi"
-	"github.com/edgelesssys/contrast/sdk"
 	"github.com/google/go-tdx-guest/validate"
 	"github.com/google/go-tdx-guest/verify"
 	"github.com/spf13/afero"
@@ -186,12 +185,12 @@ func TestAttestation(t *testing.T) {
 				logger := slog.Default()
 				store := fsstore.New(afero.NewMemMapFs(), logger)
 				cache := certcache.NewCachedHTTPSGetter(store, certcache.NeverGCTicker, logger)
-				validators, err := sdk.ValidatorsFromManifest(cache, &m, logger)
+				validator, err := m.CoordinatorValidator(logger, cache)
 				require.NoError(err)
 
 				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 				require.NoError(err)
-				cfg, err := atls.CreateAttestationClientTLSConfig(ctx, nil, validators, key)
+				cfg, err := atls.CreateAttestationClientTLSConfig(ctx, nil, validator, key)
 				require.NoError(err)
 
 				require.ErrorContains(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-coordinator", userapi.Port, func(addr string) error {

--- a/e2e/attestation/attestation_test.go
+++ b/e2e/attestation/attestation_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/internal/atls"
-	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/attestation/tdx"
@@ -245,7 +244,7 @@ func TestAttestation(t *testing.T) {
 
 		validator := tdx.NewValidatorWithReportSetter(verifyOpts, validateOptsGen, nil, logger, &reportRecorder, "tdx-collateral-test")
 
-		cfg, err := atls.CreateAttestationClientTLSConfig(ctx, nil, []validators.Validator{validator}, nil)
+		cfg, err := atls.CreateAttestationClientTLSConfig(ctx, nil, validator, nil)
 		require.NoError(err)
 
 		require.NoError(ct.Kubeclient.WithForwardedPort(ctx, ct.Namespace, "port-forwarder-coordinator", userapi.Port, func(addr string) error {

--- a/initializer/main.go
+++ b/initializer/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/edgelesssys/contrast/internal/atls"
 	"github.com/edgelesssys/contrast/internal/atls/issuer"
-	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/defaultdeny"
 	"github.com/edgelesssys/contrast/internal/grpc/dialer"
@@ -114,9 +113,9 @@ func run(cmd *cobra.Command, _ []string) (retErr error) {
 	}
 
 	requestCert := func() (*meshapi.NewMeshCertResponse, error) {
-		// Supply an empty list of validators, as the coordinator does not need to be
+		// Supply a nil validator, as the coordinator does not need to be
 		// validated by the initializer.
-		dial := dialer.NewWithKey(issuer, validators.NoValidation(), atls.NoMetrics, nil, privKey, log)
+		dial := dialer.NewWithKey(issuer, nil, atls.NoMetrics, nil, privKey, log)
 		conn, err := dial.Dial(ctx, net.JoinHostPort(coordinatorHostname, meshapi.Port))
 		if err != nil {
 			return nil, fmt.Errorf("dialing: %w", err)

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -42,10 +42,10 @@ var (
 )
 
 // CreateAttestationServerTLSConfig creates a tls.Config object with a self-signed certificate and an embedded attestation document.
-// Pass a list of validators to enable mutual aTLS.
 // If issuer is nil, no attestation will be embedded.
-func CreateAttestationServerTLSConfig(issuer Issuer, validators []validators.Validator, attestationFailures prometheus.Counter) (*tls.Config, error) {
-	getConfigForClient, err := getATLSConfigForClientFunc(issuer, validators, attestationFailures)
+// If validator is nil, no attestation will be requested from the peer. Otherwise, use mutual TLS.
+func CreateAttestationServerTLSConfig(issuer Issuer, validator validators.Validator, attestationFailures prometheus.Counter) (*tls.Config, error) {
+	getConfigForClient, err := getATLSConfigForClientFunc(issuer, validator, attestationFailures)
 	if err != nil {
 		return nil, fmt.Errorf("get aTLS config for client: %w", err)
 	}
@@ -60,24 +60,21 @@ func CreateAttestationServerTLSConfig(issuer Issuer, validators []validators.Val
 // ATTENTION: The returned config is configured with a nonce and uses the input context. It must
 // only be used for a single connection.
 //
-// If no validators are set, the server's attestation document will not be verified.
+// If validator is nil, the server's attestation document will not be verified.
 // If issuer is nil, the client will be unable to perform mutual aTLS.
-func CreateAttestationClientTLSConfig(ctx context.Context, issuer Issuer, validators []validators.Validator, privKey crypto.PrivateKey) (*tls.Config, error) {
+func CreateAttestationClientTLSConfig(ctx context.Context, issuer Issuer, validator validators.Validator, privKey crypto.PrivateKey) (*tls.Config, error) {
 	clientNonce, err := cryptohelpers.GenerateRandomBytes(cryptohelpers.RNGLengthDefault)
 	if err != nil {
 		return nil, err
 	}
 	clientConn := &clientConnection{
 		issuer:      issuer,
-		validators:  validators,
+		validator:   validator,
 		clientNonce: clientNonce,
 		privKey:     privKey,
 	}
 
-	return &tls.Config{
-		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-			return clientConn.verify(ctx, rawCerts, verifiedChains)
-		},
+	cfg := &tls.Config{
 		GetClientCertificate: clientConn.getCertificate, // use custom certificate for mutual aTLS connections
 		InsecureSkipVerify:   true,                      // disable default verification because we use our own verify func
 		MinVersion:           tls.VersionTLS13,
@@ -85,7 +82,17 @@ func CreateAttestationClientTLSConfig(ctx context.Context, issuer Issuer, valida
 			encodeNonceToNextProtos(clientNonce),
 			"h2", // grpc-go requires us to advertise HTTP/2 (h2) over ALPN
 		},
-	}, nil
+	}
+
+	// clientConnection.verify does not consider a nil validator, so we only add it as verifier if
+	// the validator is not nil.
+	if validator != nil {
+		cfg.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			return clientConn.verify(ctx, rawCerts, verifiedChains)
+		}
+	}
+
+	return cfg, nil
 }
 
 // Issuer issues an attestation document.
@@ -97,7 +104,9 @@ type Issuer interface {
 // getATLSConfigForClientFunc returns a config setup function that is called once for every client connecting to the server.
 // This allows for different server configuration for every client.
 // In aTLS this is used to generate unique nonces for every client.
-func getATLSConfigForClientFunc(issuer Issuer, validators []validators.Validator, attestationFailures prometheus.Counter) (func(*tls.ClientHelloInfo) (*tls.Config, error), error) {
+//
+// As a special case, client certificates are not required if the input validator is nil.
+func getATLSConfigForClientFunc(issuer Issuer, validator validators.Validator, attestationFailures prometheus.Counter) (func(*tls.ClientHelloInfo) (*tls.Config, error), error) {
 	// generate key for the server
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -115,7 +124,7 @@ func getATLSConfigForClientFunc(issuer Issuer, validators []validators.Validator
 		serverConn := &serverConnection{
 			privKey:             priv,
 			issuer:              issuer,
-			validators:          validators,
+			validator:           validator,
 			attestationFailures: attestationFailures,
 			serverNonce:         serverNonce,
 		}
@@ -134,7 +143,7 @@ func getATLSConfigForClientFunc(issuer Issuer, validators []validators.Validator
 		}
 
 		// enable mutual aTLS if any validators are set
-		if len(validators) > 0 {
+		if validator != nil {
 			cfg.ClientAuth = tls.RequireAnyClientCert // validity of certificate will be checked by our custom verify function
 			cfg.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 				return serverConn.verify(chi.Context(), rawCerts, verifiedChains)
@@ -218,8 +227,15 @@ func processCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) (*x509.Certi
 
 // verifyEmbeddedReport verifies an aTLS certificate by validating the attestation document embedded in the TLS certificate.
 //
-// It will check against all applicable validator for the type of attestation document, and return success on the first match.
-func verifyEmbeddedReport(ctx context.Context, allValidators []validators.Validator, cert *x509.Certificate, peerPublicKey, nonce []byte) (retErr error) {
+// It walks over all candidate extensions and runs them through the given validator. The
+// peerPublicKey and nonce arguments are used to construct the expected report data.
+//
+// This function returns nil if an attestation extension passed the validator.
+// If the certificate does not contain any recognized attestation extensions, it returns
+// ErrNoValidAttestationExtensions. If the validator does not understand any of the attestation
+// extensions, it returns ErrNoMatchingValidators. Otherwise, it returns a combined error of all
+// applicable but failing validators.
+func verifyEmbeddedReport(ctx context.Context, validator validators.Validator, cert *x509.Certificate, peerPublicKey, nonce []byte) (retErr error) {
 	// For better error reporting, let's keep track of whether we've found a valid extension at all..
 	var foundExtension bool
 	// .. and whether we've found a matching validator.
@@ -235,21 +251,19 @@ func verifyEmbeddedReport(ctx context.Context, allValidators []validators.Valida
 			continue
 		}
 
-		// We have a valid attestation document. Let's check it against all applicable validators.
+		// We have a valid attestation document. Let's check it against the validator.
 		foundExtension = true
-		for _, validator := range allValidators {
-			validationErr := validator.Validate(ctx, ex.Id, ex.Value, expectedReportData[:])
-			if validationErr == nil {
-				// The validator has successfully verified the document. We can exit.
-				return nil
-			} else if errors.Is(validationErr, validators.ErrOIDNotSupported) {
-				// This is the wrong validator, don't include the generic error in the response.
-				continue
-			}
-			// Otherwise, we'll keep track of the error and continue with the next validator.
-			foundMatchingValidator = true
-			retErr = errors.Join(retErr, fmt.Errorf(" validator %s failed: %w", validatorName(validator), validationErr))
+		validationErr := validator.Validate(ctx, ex.Id, ex.Value, expectedReportData[:])
+		if validationErr == nil {
+			// The validator has successfully verified the document. We can exit.
+			return nil
+		} else if errors.Is(validationErr, validators.ErrOIDNotSupported) {
+			// This extension did not match, but maybe another does.
+			continue
 		}
+		// Otherwise, we'll keep track of the error and continue with the next validator.
+		foundMatchingValidator = true
+		retErr = errors.Join(retErr, fmt.Errorf(" validator %s failed: %w", validatorName(validator), validationErr))
 	}
 
 	if !foundExtension {
@@ -370,7 +384,7 @@ func extractNonce(proto string) (string, error) {
 // clientConnection holds state for client to server connections.
 type clientConnection struct {
 	issuer      Issuer
-	validators  []validators.Validator
+	validator   validators.Validator
 	clientNonce []byte
 	privKey     crypto.PrivateKey
 }
@@ -382,12 +396,7 @@ func (c *clientConnection) verify(ctx context.Context, rawCerts [][]byte, verifi
 		return fmt.Errorf("process certificate: %w", err)
 	}
 
-	// don't perform verification of attestation document if no validators are set
-	if len(c.validators) == 0 {
-		return nil
-	}
-
-	return verifyEmbeddedReport(ctx, c.validators, cert, pubBytes, c.clientNonce)
+	return verifyEmbeddedReport(ctx, c.validator, cert, pubBytes, c.clientNonce)
 }
 
 // getCertificate generates a client certificate for mutual aTLS connections.
@@ -429,7 +438,7 @@ func publicKey(key crypto.PrivateKey) crypto.PublicKey {
 // serverConnection holds state for server to client connections.
 type serverConnection struct {
 	issuer              Issuer
-	validators          []validators.Validator
+	validator           validators.Validator
 	attestationFailures prometheus.Counter
 	privKey             crypto.PrivateKey
 	serverNonce         []byte
@@ -443,7 +452,7 @@ func (c *serverConnection) verify(ctx context.Context, rawCerts [][]byte, verifi
 		return fmt.Errorf("process certificate: %w", err)
 	}
 
-	err = verifyEmbeddedReport(ctx, c.validators, cert, pubBytes, c.serverNonce)
+	err = verifyEmbeddedReport(ctx, c.validator, cert, pubBytes, c.serverNonce)
 	if err != nil && c.attestationFailures != nil {
 		c.attestationFailures.Inc()
 	}

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -34,10 +34,10 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := map[string]struct {
-		cert       *x509.Certificate
-		validators []validators.Validator
-		wantErr    bool
-		targetErr  error
+		cert      *x509.Certificate
+		validator validators.Validator
+		wantErr   bool
+		targetErr error
 	}{
 		"success": {
 			cert: &x509.Certificate{
@@ -51,7 +51,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(oid.RawSNPReport),
+			validator: newFakeValidator(oid.RawSNPReport),
 		},
 		"multiple matches": {
 			cert: &x509.Certificate{
@@ -66,21 +66,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(oid.RawSNPReport),
-		},
-		"skip non-matching validator": {
-			cert: &x509.Certificate{
-				Extensions: []pkix.Extension{
-					{
-						Id: []int{4, 5, 6},
-					},
-					{
-						Id:    oid.RawSNPReport,
-						Value: attDocBytes,
-					},
-				},
-			},
-			validators: append(newFakeValidators(oid.RawSNPReport), newFakeValidators(asn1.ObjectIdentifier{1, 2, 3})...),
+			validator: newFakeValidator(oid.RawSNPReport),
 		},
 		"match, error": {
 			cert: &x509.Certificate{
@@ -91,14 +77,14 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: newFakeValidators(oid.RawSNPReport),
-			wantErr:    true,
+			validator: newFakeValidator(oid.RawSNPReport),
+			wantErr:   true,
 		},
 		"no extensions": {
-			cert:       &x509.Certificate{},
-			validators: nil,
-			targetErr:  ErrNoValidAttestationExtensions,
-			wantErr:    true,
+			cert:      &x509.Certificate{},
+			validator: nil,
+			targetErr: ErrNoValidAttestationExtensions,
+			wantErr:   true,
 		},
 		"no matching validator": {
 			cert: &x509.Certificate{
@@ -108,9 +94,9 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 					},
 				},
 			},
-			validators: nil,
-			targetErr:  ErrNoMatchingValidators,
-			wantErr:    true,
+			validator: validators.Any(),
+			targetErr: ErrNoMatchingValidators,
+			wantErr:   true,
 		},
 	}
 
@@ -118,7 +104,7 @@ func TestVerifyEmbeddedReport(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
-			err := verifyEmbeddedReport(t.Context(), tc.validators, tc.cert, nil, nil)
+			err := verifyEmbeddedReport(t.Context(), tc.validator, tc.cert, nil, nil)
 			if tc.wantErr {
 				require.Error(err)
 				if tc.targetErr != nil {
@@ -137,9 +123,9 @@ type fakeValidator struct {
 	err error
 }
 
-// newFakeValidators returns a slice with a single FakeValidator.
-func newFakeValidators(oid asn1.ObjectIdentifier) []validators.Validator {
-	return []validators.Validator{&fakeValidator{oid, nil}}
+// newFakeValidator returns a single FakeValidator.
+func newFakeValidator(oid asn1.ObjectIdentifier) validators.Validator {
+	return &fakeValidator{oid, nil}
 }
 
 func (v fakeValidator) Validate(_ context.Context, id asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
@@ -207,12 +193,11 @@ func TestContextPassdown(t *testing.T) {
 			},
 		},
 	}
-	validators := []validators.Validator{validator}
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	// If the context is not passed down, the select statement in ValidateContext will not return at all.
 	// We expect this function to return because the context was already cancelled.
-	err := verifyEmbeddedReport(ctx, validators, cert, nil, nil)
+	err := verifyEmbeddedReport(ctx, validator, cert, nil, nil)
 	// The contextValidator forwards the context error, so this should be canceled.
 	require.ErrorIs(t, err, context.Canceled)
 }

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -36,11 +36,6 @@ func (f ValidatorFunc) Validate(ctx context.Context, oid asn1.ObjectIdentifier, 
 	return f(ctx, oid, attDoc, reportData)
 }
 
-// NoValidation skips validation of the server's attestation document.
-func NoValidation() []Validator {
-	return []Validator{}
-}
-
 // Any creates a Validator that passes if one of the input Validators passes.
 //
 // The Validators are tried in order, until one succeeds or no more are left.

--- a/internal/grpc/atlscredentials/atlscredentials.go
+++ b/internal/grpc/atlscredentials/atlscredentials.go
@@ -23,28 +23,35 @@ import (
 // Credentials for attested TLS (ATLS).
 type Credentials struct {
 	issuer              atls.Issuer
-	validators          []validators.Validator
+	validator           validators.Validator
 	attestationFailures prometheus.Counter
 	privKey             crypto.PrivateKey
 	logger              *slog.Logger
 }
 
 // New creates new ATLS credentials.
-func New(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, log *slog.Logger) *Credentials {
+//
+// issuer and validator can be nil, which means attestation won't be performed or requested,
+// respectively.
+// The attestationFailures counter will be incremented whenever the validator rejects a connection
+// attempt.
+func New(issuer atls.Issuer, validator validators.Validator, attestationFailures prometheus.Counter, log *slog.Logger) *Credentials {
 	return &Credentials{
 		issuer:              issuer,
 		attestationFailures: attestationFailures,
-		validators:          validators,
+		validator:           validator,
 		logger:              log,
 	}
 }
 
 // NewWithKey creates new ATLS credentials for the given key.
-func NewWithKey(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, key crypto.PrivateKey, log *slog.Logger) *Credentials {
+//
+// See New for details on the other arguments.
+func NewWithKey(issuer atls.Issuer, validator validators.Validator, attestationFailures prometheus.Counter, key crypto.PrivateKey, log *slog.Logger) *Credentials {
 	return &Credentials{
 		privKey:             key,
 		issuer:              issuer,
-		validators:          validators,
+		validator:           validator,
 		attestationFailures: attestationFailures,
 		logger:              log,
 	}
@@ -54,7 +61,7 @@ func NewWithKey(issuer atls.Issuer, validators []validators.Validator, attestati
 func (c *Credentials) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	c.logger.DebugContext(ctx, "ClientHandshake", "authority", authority)
 
-	clientCfg, err := atls.CreateAttestationClientTLSConfig(ctx, c.issuer, c.validators, c.privKey)
+	clientCfg, err := atls.CreateAttestationClientTLSConfig(ctx, c.issuer, c.validator, c.privKey)
 	if err != nil {
 		c.logger.ErrorContext(ctx, "Creating client TLS config failed", "error", err)
 		return nil, nil, err
@@ -67,7 +74,7 @@ func (c *Credentials) ClientHandshake(ctx context.Context, authority string, raw
 func (c *Credentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	c.logger.Debug("ServerHandshake", "peer", rawConn.RemoteAddr())
 
-	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, c.validators, c.attestationFailures)
+	serverCfg, err := atls.CreateAttestationServerTLSConfig(c.issuer, c.validator, c.attestationFailures)
 	if err != nil {
 		c.logger.Error("Error creating server TLS config", "error", err)
 		return nil, nil, err

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -24,7 +24,7 @@ import (
 // Dialer can open grpc client connections with different levels of ATLS encryption / verification.
 type Dialer struct {
 	issuer              atls.Issuer
-	validators          []validators.Validator
+	validator           validators.Validator
 	attestationFailures prometheus.Counter
 	netDialer           NetDialer
 	privKey             crypto.PrivateKey
@@ -32,10 +32,16 @@ type Dialer struct {
 }
 
 // New creates a new Dialer.
-func New(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, log *slog.Logger) *Dialer {
+//
+// issuer and validator can be nil, which means attestation won't be performed or requested,
+// respectively.
+// The attestationFailures counter will be incremented whenever the validator rejects a connection
+// attempt.
+// netDialer can be used to customize TCP connection establishment (e.g., proxies or tests).
+func New(issuer atls.Issuer, validator validators.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, log *slog.Logger) *Dialer {
 	return &Dialer{
 		issuer:              issuer,
-		validators:          validators,
+		validator:           validator,
 		attestationFailures: attestationFailures,
 		netDialer:           netDialer,
 		logger:              log,
@@ -43,10 +49,12 @@ func New(issuer atls.Issuer, validators []validators.Validator, attestationFailu
 }
 
 // NewWithKey creates a new Dialer with the given private key.
-func NewWithKey(issuer atls.Issuer, validators []validators.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, privKey crypto.PrivateKey, log *slog.Logger) *Dialer {
+//
+// See New for details on the other arguments.
+func NewWithKey(issuer atls.Issuer, validator validators.Validator, attestationFailures prometheus.Counter, netDialer NetDialer, privKey crypto.PrivateKey, log *slog.Logger) *Dialer {
 	return &Dialer{
 		issuer:              issuer,
-		validators:          validators,
+		validator:           validator,
 		attestationFailures: attestationFailures,
 		netDialer:           netDialer,
 		privKey:             privKey,
@@ -56,7 +64,7 @@ func NewWithKey(issuer atls.Issuer, validators []validators.Validator, attestati
 
 // Dial creates a new grpc client connection to the given target using the atls validator.
 func (d *Dialer) Dial(_ context.Context, target string) (*grpc.ClientConn, error) {
-	credentials := atlscredentials.NewWithKey(d.issuer, d.validators, d.attestationFailures, d.privKey, logger.NewNamed(d.logger, "atlscredentials"))
+	credentials := atlscredentials.NewWithKey(d.issuer, d.validator, d.attestationFailures, d.privKey, logger.NewNamed(d.logger, "atlscredentials"))
 
 	return grpc.NewClient(
 		target,

--- a/internal/grpc/dialer/dialer.go
+++ b/internal/grpc/dialer/dialer.go
@@ -81,17 +81,6 @@ func (d *Dialer) DialInsecure(_ context.Context, target string) (*grpc.ClientCon
 	)
 }
 
-// DialNoVerify creates a new grpc client connection to the given target without verifying the server's attestation.
-func (d *Dialer) DialNoVerify(_ context.Context, target string) (*grpc.ClientConn, error) {
-	credentials := atlscredentials.New(atls.NoIssuer, validators.NoValidation(), atls.NoMetrics, logger.NewNamed(d.logger, "atlscredentials"))
-
-	return grpc.NewClient(
-		target,
-		d.grpcWithDialer(),
-		grpc.WithTransportCredentials(credentials),
-	)
-}
-
 func (d *Dialer) grpcWithDialer() grpc.DialOption {
 	if d.netDialer == nil {
 		return grpc.EmptyDialOption{}

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -18,6 +18,8 @@ import (
 // Originally an unexported function in the contrast CLI.
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
 // Validators MUST NOT be used concurrently.
+//
+// Deprecated: This low-level API is not intended for direct use, use the sdk.Client methods instead.
 func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) (validators.Validator, error) {
 	v, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -18,10 +18,10 @@ import (
 // Originally an unexported function in the contrast CLI.
 // Can be made unexported again, if we decide to move all userapi calls from the CLI to the SDK.
 // Validators MUST NOT be used concurrently.
-func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) ([]validators.Validator, error) {
+func ValidatorsFromManifest(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) (validators.Validator, error) {
 	v, err := m.CoordinatorValidator(log, kdsGetter)
 	if err != nil {
 		return nil, fmt.Errorf("creating coordinator validator: %w", err)
 	}
-	return []validators.Validator{v}, nil
+	return v, nil
 }

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -159,7 +159,9 @@ func (c Client) ValidateAttestation(ctx context.Context, nonce []byte, attestati
 	}
 
 	kdsGetter := certcache.NewCachedHTTPSGetter(c.fsstore, certcache.NeverGCTicker, c.log.WithGroup("kds-getter"))
-	validatorsFromManifest := ValidatorsFromManifest
+	validatorsFromManifest := func(kdsGetter *certcache.CachedHTTPSGetter, m *manifest.Manifest, log *slog.Logger) (validators.Validator, error) {
+		return m.CoordinatorValidator(log, kdsGetter)
+	}
 	if c.validatorsFromManifestOverride != nil {
 		validatorsFromManifest = c.validatorsFromManifestOverride
 	}

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -38,7 +37,7 @@ type Client struct {
 	log *slog.Logger
 
 	// validatorsFromManifestOverride is used by tests to replace the validators.
-	validatorsFromManifestOverride func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) ([]validators.Validator, error)
+	validatorsFromManifestOverride func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) (validators.Validator, error)
 }
 
 // New returns a new [Client].
@@ -164,7 +163,7 @@ func (c Client) ValidateAttestation(ctx context.Context, nonce []byte, attestati
 	if c.validatorsFromManifestOverride != nil {
 		validatorsFromManifest = c.validatorsFromManifestOverride
 	}
-	validators, err := validatorsFromManifest(kdsGetter, &latestManifest, c.log)
+	validator, err := validatorsFromManifest(kdsGetter, &latestManifest, c.log)
 	if err != nil {
 		return nil, fmt.Errorf("getting validators: %w", err)
 	}
@@ -173,19 +172,8 @@ func (c Client) ValidateAttestation(ctx context.Context, nonce []byte, attestati
 	transitionDigest := transitions[len(transitions)-1].Digest()
 	reportData := httpapi.ConstructReportData(nonce, transitionDigest[:], &resp.CoordinatorState)
 
-	validated := false
-	var errs []error
-	for _, v := range validators {
-		if err := v.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
-			c.log.Debug("validator failed", "error", err)
-			errs = append(errs, err)
-			continue
-		}
-		validated = true
-		break
-	}
-	if !validated {
-		return nil, fmt.Errorf("validation failed:\n%w", errors.Join(errs...))
+	if err := validator.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
+		return nil, fmt.Errorf("validation failed: %w", err)
 	}
 	state := CoordinatorState{
 		Manifests: resp.Manifests,

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -158,8 +158,8 @@ func TestValidateAttestation(t *testing.T) {
 
 			c := New()
 
-			c.validatorsFromManifestOverride = func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) ([]validators.Validator, error) {
-				return []validators.Validator{&stubValidator{err: tc.validateErr}}, nil
+			c.validatorsFromManifestOverride = func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) (validators.Validator, error) {
+				return &stubValidator{err: tc.validateErr}, nil
 			}
 			state, err := c.ValidateAttestation(t.Context(), tc.nonce, attestation)
 			if tc.wantErr != "" {


### PR DESCRIPTION
Another continuation of #2483: now that we can combine `Validator`s, use this to simplify the aTLS dialers' and HTTP verifier's APIs to just expect a single validator (which is now a `validators.Any`). Consistent with the `Issuer` argument, skip validation if the validator is `nil`. 

The last commit moves all existing callers of the `sdk.ValidatorsFromManifest` to the `manifest.CoordinatorValidator` function. `sdk.ValidatorsFromManifest` should not have been exported in the first place, as the docstring suggests.

Fixes CON-129.