### PR TITLE
e2e/policy: fix updated error string

### DIFF
--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -199,7 +199,7 @@ func TestPolicy(t *testing.T) {
 		require.NoError(os.WriteFile(ct.ManifestPath(), manifestBytes, 0o644))
 
 		// Verification should fail.
-		require.ErrorContains(ct.RunVerify(t.Context()), "validating report")
+		require.ErrorContains(ct.RunVerify(t.Context()), manifest.ErrWrongCoordinatorPolicyHash.Error())
 
 		// Restore correct coordinator policy hash.
 		delete(m.Policies, policyHashAlt)

--- a/internal/manifest/validators.go
+++ b/internal/manifest/validators.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/asn1"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -63,6 +64,9 @@ func (m *Manifest) Validator(log *slog.Logger, kdsGetter *certcache.CachedHTTPSG
 	return validators.Any(allValidators...), nil
 }
 
+// ErrWrongCoordinatorPolicyHash is returned when the Coordinator policy hash does not match the manifest policy hash.
+var ErrWrongCoordinatorPolicyHash = errors.New("wrong policy hash for Coordinator")
+
 // CoordinatorValidator returns a validator that succeeds only for workloads with the Coordinator role.
 //
 // This is a more restrictive version of Validator, see the warning there.
@@ -91,7 +95,7 @@ func (m *Manifest) CoordinatorValidator(log *slog.Logger, kdsGetter *certcache.C
 			return err
 		}
 		if !slices.Equal(coordPolicyHashBytes, report.HostData()) {
-			return fmt.Errorf("wrong policy hash for Coordinator: got %x, want %x", report.HostData(), coordPolicyHashBytes)
+			return fmt.Errorf("%w: got %x, want %x", ErrWrongCoordinatorPolicyHash, report.HostData(), coordPolicyHashBytes)
 		}
 		return nil
 	}), nil


### PR DESCRIPTION
Fixup for d29ce7cb6c108f919bf6525fd8ea847a48c37d51, after which the expected error message changed. Causes e.g. https://github.com/edgelesssys/contrast/actions/runs/28475275316/job/84398991412