### PR TITLE
kuberesource: export all annotation vars from kuberesource package

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -39,15 +39,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	annotationPrefix              = "contrast.edgeless.systems/"
-	kataAnnotationPrefix          = "io.katacontainers.config.hypervisor."
-	workloadSecretIDAnnotationKey = annotationPrefix + "workload-secret-id"
-	idBlockAnnotation             = kataAnnotationPrefix + "snp_id_block_"
-	idAuthAnnotationKey           = kataAnnotationPrefix + "snp_id_auth_"
-	guestPolicyAnnotationKey      = kataAnnotationPrefix + "snp_guest_policy_"
-)
-
 // NewGenerateCmd creates the contrast generate subcommand.
 func NewGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -488,7 +479,7 @@ func generatePolicies(ctx context.Context, flags *generateFlags, fileMap map[str
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to generate policy for %q in %q: %w", fileMap[path][idx].GetName(), path, err)
 			}
-			meta.Annotations[initdata.InitdataAnnotationKey] = initdataAnno
+			meta.Annotations[kuberesource.InitdataAnnotationKey] = initdataAnno
 
 			if shouldCalculatePodMemory {
 				podMemory, err := calculatePodMemory(spec, layersCache)
@@ -847,9 +838,9 @@ func computeAndAnnotateIDBlockAnnotations(targetPlatform platforms.Platform, cpu
 	}
 
 	// Populate annotations
-	annotations[idBlockAnnotation+productName] = base64.StdEncoding.EncodeToString(idBlkBytes)
-	annotations[idAuthAnnotationKey+productName] = base64.StdEncoding.EncodeToString(idAuthBytes)
-	annotations[guestPolicyAnnotationKey+productName] = strconv.FormatUint(abi.SnpPolicyToBytes(policy), 10)
+	annotations[kuberesource.IDBlockAnnotationKey+productName] = base64.StdEncoding.EncodeToString(idBlkBytes)
+	annotations[kuberesource.IDAuthAnnotationKey+productName] = base64.StdEncoding.EncodeToString(idAuthBytes)
+	annotations[kuberesource.GuestPolicyAnnotationKey+productName] = strconv.FormatUint(abi.SnpPolicyToBytes(policy), 10)
 
 	return nil
 }

--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -27,7 +27,7 @@ func manipulateInitdata(fileMap map[string][]*unstructured.Unstructured, manipul
 				retErr = errors.Join(retErr, err)
 				return meta, spec
 			}
-			annotation := meta.Annotations[initdata.InitdataAnnotationKey]
+			annotation := meta.Annotations[kuberesource.InitdataAnnotationKey]
 			if annotation == "" {
 				return fail(fmt.Errorf("missing initdata annotation in %s", path))
 			}
@@ -52,7 +52,7 @@ func manipulateInitdata(fileMap map[string][]*unstructured.Unstructured, manipul
 			if err != nil {
 				return fail(fmt.Errorf("encoding initdata annotation in %s: %w", path, err))
 			}
-			meta.Annotations[initdata.InitdataAnnotationKey] = annotation
+			meta.Annotations[kuberesource.InitdataAnnotationKey] = annotation
 			return meta, spec
 		}), retErr
 	})
@@ -72,9 +72,9 @@ func policiesFromKubeResources(fileMap map[string][]*unstructured.Unstructured) 
 			if meta == nil {
 				return meta, spec
 			}
-			annotation = meta.Annotations[initdata.InitdataAnnotationKey]
+			annotation = meta.Annotations[kuberesource.InitdataAnnotationKey]
 			role = manifest.Role(meta.Annotations[kuberesource.ContrastRoleAnnotationKey])
-			workloadSecretID = meta.Annotations[workloadSecretIDAnnotationKey]
+			workloadSecretID = meta.Annotations[kuberesource.WorkloadSecretIDAnnotationKey]
 			return meta, spec
 		})
 		if annotation == "" {

--- a/cli/cmd/policies_test.go
+++ b/cli/cmd/policies_test.go
@@ -35,7 +35,7 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
 							WithAnnotations(map[string]string{
-								initdata.InitdataAnnotationKey:         anno,
+								kuberesource.InitdataAnnotationKey:     anno,
 								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
 							}).
 							WithSpec(
@@ -70,7 +70,7 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 			resources: []any{
 				kuberesource.Pod("test", "").
 					WithAnnotations(map[string]string{
-						initdata.InitdataAnnotationKey: "invalid-base64",
+						kuberesource.InitdataAnnotationKey: "invalid-base64",
 					}).
 					WithSpec(
 						kuberesource.PodSpec().
@@ -86,7 +86,7 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
 							WithAnnotations(map[string]string{
-								initdata.InitdataAnnotationKey:         anno,
+								kuberesource.InitdataAnnotationKey:     anno,
 								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
 							}).
 							WithSpec(
@@ -95,7 +95,7 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 							))),
 				kuberesource.Pod("another-pod", "").
 					WithAnnotations(map[string]string{
-						initdata.InitdataAnnotationKey: anno,
+						kuberesource.InitdataAnnotationKey: anno,
 					}).
 					WithSpec(
 						kuberesource.PodSpec().

--- a/cli/verifier/servicemesh_egress.go
+++ b/cli/verifier/servicemesh_egress.go
@@ -25,7 +25,7 @@ func (v *ServiceMeshEgressNotEmpty) Verify(toVerify any) error {
 			return meta, spec
 		}
 		for k, v := range meta.Annotations {
-			if k != "contrast.edgeless.systems/servicemesh-egress" {
+			if k != kuberesource.SmEgressConfigAnnotationKey {
 				continue
 			}
 			if v == "" {

--- a/e2e/imagestore/imagestore_test.go
+++ b/e2e/imagestore/imagestore_test.go
@@ -225,7 +225,7 @@ func TestMain(m *testing.M) {
 func testPod(name, annotation string) any {
 	return kuberesource.Pod(name, "").
 		WithLabels(map[string]string{"app.kubernetes.io/name": name}).
-		WithAnnotations(map[string]string{"contrast.edgeless.systems/image-store-size": annotation}).
+		WithAnnotations(map[string]string{kuberesource.ImageStoreSizeAnnotationKey: annotation}).
 		WithSpec(
 			kuberesource.PodSpec().
 				WithContainers(
@@ -252,7 +252,7 @@ func testPod(name, annotation string) any {
 func tensorflowPod() any {
 	return kuberesource.Pod("tensorflow", "").
 		WithLabels(map[string]string{"app.kubernetes.io/name": "tensorflow"}).
-		WithAnnotations(map[string]string{"contrast.edgeless.systems/image-store-size": "0"}).
+		WithAnnotations(map[string]string{kuberesource.ImageStoreSizeAnnotationKey: "0"}).
 		WithSpec(
 			kuberesource.PodSpec().
 				WithContainers(

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -29,11 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	smIngressConfigAnnotationKey = "contrast.edgeless.systems/servicemesh-ingress"
-	smEgressConfigAnnotationKey  = "contrast.edgeless.systems/servicemesh-egress"
-)
-
 // TestIngressEgress tests that the ingress and egress proxies work as configured.
 func TestIngressEgress(t *testing.T) {
 	platform, err := platforms.FromString(contrasttest.Flags.PlatformStr)
@@ -54,13 +49,13 @@ func TestIngressEgress(t *testing.T) {
 	// Add dummy egress annotation in voting pod with no ingress for the
 	// "egress annotation alone causes ingress to activate" test.
 	serviceMeshAnnotations := map[string]string{
-		smEgressConfigAnnotationKey: "dummy#127.137.0.2:8200#coordinator:8200",
+		kuberesource.SmEgressConfigAnnotationKey: "dummy#127.137.0.2:8200#coordinator:8200",
 	}
 	resources = kuberesource.PatchReplaceServiceMesh(resources, serviceMeshAnnotations, kuberesource.HasNameLabel("voting-svc"))
 
 	// Open service mesh admin port in emoji pod for the "admin interface is available" test.
 	serviceMeshAnnotations = map[string]string{
-		smIngressConfigAnnotationKey: "envoy#9901#true",
+		kuberesource.SmIngressConfigAnnotationKey: "envoy#9901#true",
 	}
 	resources = kuberesource.PatchReplaceServiceMesh(resources, serviceMeshAnnotations, kuberesource.HasNameLabel("emoji-svc"))
 	resources = kuberesource.PatchServiceMeshAdminInterface(resources, 9901, kuberesource.HasNameLabel("emoji-svc"))

--- a/internal/initdata/initdata.go
+++ b/internal/initdata/initdata.go
@@ -24,9 +24,6 @@ import (
 const (
 	// InitdataVersion is the sole supported version of Initdata.
 	InitdataVersion = "0.1.0"
-
-	// InitdataAnnotationKey as specified in: https://github.com/kata-containers/kata-containers/blob/f6ff9cf7176989d414bf3f45a5b0c0b9fdb1bf3a/src/libs/kata-types/src/annotations/mod.rs#L276
-	InitdataAnnotationKey = "io.katacontainers.config.hypervisor.cc_init_data"
 )
 
 var (

--- a/internal/kuberesource/constants.go
+++ b/internal/kuberesource/constants.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package kuberesource
+
+const (
+	annotationPrefix     = "contrast.edgeless.systems/"
+	kataAnnotationPrefix = "io.katacontainers.config."
+)
+
+const (
+	// ContrastRoleAnnotationKey assigns a role to the annotated pod.
+	//
+	// This is used to determine whether a given pod may act as Coordinator.
+	ContrastRoleAnnotationKey = annotationPrefix + "pod-role"
+
+	// ExposeServiceAnnotationKey is the annotation key used to specify whether a Service should be exposed via a LoadBalancer.
+	ExposeServiceAnnotationKey = annotationPrefix + "expose-service"
+
+	// ImageStoreSizeAnnotationKey is the annotation key used to configure the size of the image store volume.
+	ImageStoreSizeAnnotationKey = annotationPrefix + "image-store-size"
+
+	// SecurePVAnnotationKey is the annotation key used to specify a secure persistent volume for a pod.
+	SecurePVAnnotationKey = annotationPrefix + "secure-pv"
+
+	// SkipInitializerAnnotationKey is the annotation key used to specify whether a pod should skip the Contrast initializer injection.
+	SkipInitializerAnnotationKey = annotationPrefix + "skip-initializer"
+
+	// SmAdminInterfaceAnnotationKey is the annotation key used to specify the port of the service mesh admin interface.
+	SmAdminInterfaceAnnotationKey = annotationPrefix + "servicemesh-admin-interface-port"
+
+	// SmEgressConfigAnnotationKey is the annotation key used to specify the egress configuration of the service mesh.
+	SmEgressConfigAnnotationKey = annotationPrefix + "servicemesh-egress"
+
+	// SmIngressConfigAnnotationKey is the annotation key used to specify the ingress configuration of the service mesh.
+	SmIngressConfigAnnotationKey = annotationPrefix + "servicemesh-ingress"
+
+	// WorkloadSecretIDAnnotationKey is the annotation key used to specify the workload secret ID for a pod.
+	WorkloadSecretIDAnnotationKey = annotationPrefix + "workload-secret-id"
+)
+
+const (
+	// GuestPolicyAnnotationKey is the annotation key used to specify the guest policy for a pod.
+	GuestPolicyAnnotationKey = kataAnnotationPrefix + "hypervisor.snp_guest_policy_"
+
+	// IDAuthAnnotationKey is the annotation key used to specify the ID Authentication for a pod.
+	IDAuthAnnotationKey = kataAnnotationPrefix + "hypervisor.snp_id_auth_"
+
+	// IDBlockAnnotationKey is the annotation key used to specify the ID Block for a pod.
+	IDBlockAnnotationKey = kataAnnotationPrefix + "hypervisor.snp_id_block_"
+
+	// InitdataAnnotationKey as specified in: https://github.com/kata-containers/kata-containers/blob/f6ff9cf7176989d414bf3f45a5b0c0b9fdb1bf3a/src/libs/kata-types/src/annotations/mod.rs#L276
+	InitdataAnnotationKey = kataAnnotationPrefix + "hypervisor.cc_init_data"
+)
+
+const (
+	// TDXEnabledNodeLabel is the node-feature-discovery label that marks a node as TDX-capable.
+	TDXEnabledNodeLabel = "feature.node.kubernetes.io/tdx.enabled"
+
+	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
+	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"
+)

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -22,30 +22,6 @@ import (
 	applyrbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 )
 
-const (
-	exposeServiceAnnotation       = "contrast.edgeless.systems/expose-service"
-	skipInitializerAnnotationKey  = "contrast.edgeless.systems/skip-initializer"
-	smIngressConfigAnnotationKey  = "contrast.edgeless.systems/servicemesh-ingress"
-	smEgressConfigAnnotationKey   = "contrast.edgeless.systems/servicemesh-egress"
-	smAdminInterfaceAnnotationKey = "contrast.edgeless.systems/servicemesh-admin-interface-port"
-	securePVAnnotationKey         = "contrast.edgeless.systems/secure-pv"
-	workloadSecretIDAnnotationKey = "contrast.edgeless.systems/workload-secret-id"
-
-	// ImageStoreSizeAnnotationKey is the annotation key used to configure the size of the image store volume.
-	ImageStoreSizeAnnotationKey = "contrast.edgeless.systems/image-store-size"
-
-	// TDXEnabledNodeLabel is the node-feature-discovery label that marks a node as TDX-capable.
-	TDXEnabledNodeLabel = "feature.node.kubernetes.io/tdx.enabled"
-
-	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
-	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"
-
-	// ContrastRoleAnnotationKey assigns a role to the annotated pod.
-	//
-	// This is used to determine whether a given pod may act as Coordinator.
-	ContrastRoleAnnotationKey = "contrast.edgeless.systems/pod-role"
-)
-
 // CollateralProxyDefaultService is the default in-cluster URL of the collateral-proxy.
 const CollateralProxyDefaultService = "http://collateral-proxy.default.svc"
 
@@ -71,14 +47,14 @@ func AddInitializer(
 	initializer *applycorev1.ContainerApplyConfiguration,
 ) (res any, retErr error) {
 	res = MapPodSpecWithMeta(resource, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
-		if meta != nil && meta.Annotations[skipInitializerAnnotationKey] == "true" {
+		if meta != nil && meta.Annotations[SkipInitializerAnnotationKey] == "true" {
 			return meta, spec
 		}
 		if !IsContrastPod(spec) {
 			return meta, spec
 		}
-		if meta != nil && meta.Annotations[securePVAnnotationKey] != "" {
-			securePVValues := strings.Split(meta.Annotations[securePVAnnotationKey], ":")
+		if meta != nil && meta.Annotations[SecurePVAnnotationKey] != "" {
+			securePVValues := strings.Split(meta.Annotations[SecurePVAnnotationKey], ":")
 			if len(securePVValues) != 2 {
 				retErr = fmt.Errorf("secure PV annotation has to be in the format 'device-name:mount-name'")
 				return nil, nil
@@ -212,9 +188,9 @@ func AddServiceMesh(
 			return meta, spec
 		}
 
-		ingressConfig := meta.Annotations[smIngressConfigAnnotationKey]
-		egressConfig := meta.Annotations[smEgressConfigAnnotationKey]
-		portAnnotation := meta.Annotations[smAdminInterfaceAnnotationKey]
+		ingressConfig := meta.Annotations[SmIngressConfigAnnotationKey]
+		egressConfig := meta.Annotations[SmEgressConfigAnnotationKey]
+		portAnnotation := meta.Annotations[SmAdminInterfaceAnnotationKey]
 
 		// Remove already existing init containers with unique service mesh name.
 		spec.InitContainers = slices.DeleteFunc(spec.InitContainers, func(c applycorev1.ContainerApplyConfiguration) bool {
@@ -502,7 +478,7 @@ func AddLoadBalancers(resources []any) []any {
 	for _, resource := range resources {
 		switch obj := resource.(type) {
 		case *applycorev1.ServiceApplyConfiguration:
-			if obj.Annotations[exposeServiceAnnotation] == "true" {
+			if obj.Annotations[ExposeServiceAnnotationKey] == "true" {
 				if obj.Spec != nil {
 					obj.Spec.WithType("LoadBalancer")
 				}
@@ -729,11 +705,11 @@ func PatchServiceMeshAdminInterface(resources []any, port int32, shouldPatch Res
 				return meta, spec
 			}
 
-			_, ingressOk := meta.Annotations[smIngressConfigAnnotationKey]
-			_, egressOk := meta.Annotations[smEgressConfigAnnotationKey]
+			_, ingressOk := meta.Annotations[SmIngressConfigAnnotationKey]
+			_, egressOk := meta.Annotations[SmEgressConfigAnnotationKey]
 			if ingressOk || egressOk {
-				meta.WithAnnotations(map[string]string{smAdminInterfaceAnnotationKey: fmt.Sprint(port)})
-				meta.Annotations[smIngressConfigAnnotationKey] += fmt.Sprintf("##admin#%d#true", port)
+				meta.WithAnnotations(map[string]string{SmAdminInterfaceAnnotationKey: fmt.Sprint(port)})
+				meta.Annotations[SmIngressConfigAnnotationKey] += fmt.Sprintf("##admin#%d#true", port)
 			}
 			return meta, spec
 		}))
@@ -901,9 +877,9 @@ func needsServiceMesh(meta *applymetav1.ObjectMetaApplyConfiguration) bool {
 	if meta == nil {
 		return false
 	}
-	_, ingressOk := meta.Annotations[smIngressConfigAnnotationKey]
-	_, egressOk := meta.Annotations[smEgressConfigAnnotationKey]
-	_, portOk := meta.Annotations[smAdminInterfaceAnnotationKey]
+	_, ingressOk := meta.Annotations[SmIngressConfigAnnotationKey]
+	_, egressOk := meta.Annotations[SmEgressConfigAnnotationKey]
+	_, portOk := meta.Annotations[SmAdminInterfaceAnnotationKey]
 
 	return ingressOk || egressOk || portOk
 }

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -254,7 +254,7 @@ func TestAddInitializer(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
+						WithAnnotations(map[string]string{SecurePVAnnotationKey: "device:mount"}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -272,7 +272,7 @@ func TestAddInitializer(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{securePVAnnotationKey: "test"}).
+						WithAnnotations(map[string]string{SecurePVAnnotationKey: "test"}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -285,7 +285,7 @@ func TestAddInitializer(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
+						WithAnnotations(map[string]string{SecurePVAnnotationKey: "device:mount"}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -298,7 +298,7 @@ func TestAddInitializer(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{securePVAnnotationKey: "device:mount"}).
+						WithAnnotations(map[string]string{SecurePVAnnotationKey: "device:mount"}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -329,8 +329,8 @@ func TestAddInitializer(t *testing.T) {
 			require.NotEmpty(tc.d.Spec.Template.Spec.InitContainers[0].VolumeMounts)
 			require.Equal(expectedInitializerVolumeMountName, *tc.d.Spec.Template.Spec.InitContainers[0].VolumeMounts[0].Name)
 
-			if tc.d.Annotations[securePVAnnotationKey] != "" {
-				securePVValue := strings.Split(tc.d.Annotations[securePVAnnotationKey], ":")
+			if tc.d.Annotations[SecurePVAnnotationKey] != "" {
+				securePVValue := strings.Split(tc.d.Annotations[SecurePVAnnotationKey], ":")
 				_, mountName := securePVValue[0], securePVValue[1]
 				sharedVolumeMountCount := 0
 				for _, v := range tc.d.Spec.Template.Spec.InitContainers[0].VolumeMounts {
@@ -409,7 +409,7 @@ func TestAddServiceMesh(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
+						WithAnnotations(map[string]string{SmIngressConfigAnnotationKey: ""}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -435,7 +435,7 @@ func TestAddServiceMesh(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
+						WithAnnotations(map[string]string{SmIngressConfigAnnotationKey: ""}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -449,7 +449,7 @@ func TestAddServiceMesh(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
+						WithAnnotations(map[string]string{SmIngressConfigAnnotationKey: ""}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).
@@ -467,7 +467,7 @@ func TestAddServiceMesh(t *testing.T) {
 			d: applyappsv1.Deployment("test", "default").
 				WithSpec(applyappsv1.DeploymentSpec().
 					WithTemplate(applycorev1.PodTemplateSpec().
-						WithAnnotations(map[string]string{smIngressConfigAnnotationKey: ""}).
+						WithAnnotations(map[string]string{SmIngressConfigAnnotationKey: ""}).
 						WithSpec(
 							applycorev1.PodSpec().
 								WithContainers(applycorev1.Container()).

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -120,7 +120,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*applyappsv1.
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": name}).
 						WithAnnotations(map[string]string{
-							"contrast.edgeless.systems/pod-role": "contrast-node-installer",
+							ContrastRoleAnnotationKey:            string(manifest.RoleNodeInstaller),
 							"contrast.edgeless.systems/platform": platform.String(),
 						}).
 						WithSpec(
@@ -310,7 +310,7 @@ func Coordinator(namespace string) *CoordinatorConfig {
 				WithTemplate(
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "coordinator"}).
-						WithAnnotations(map[string]string{"contrast.edgeless.systems/pod-role": "coordinator"}).
+						WithAnnotations(map[string]string{ContrastRoleAnnotationKey: string(manifest.RoleCoordinator)}).
 						WithSpec(
 							PodSpec().
 								WithServiceAccountName("coordinator").

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -21,7 +21,7 @@ func CoordinatorBundle() []any {
 	coordinator := Coordinator("")
 
 	coordinatorService := ServiceForStatefulSet(coordinator.StatefulSetApplyConfiguration).
-		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"})
+		WithAnnotations(map[string]string{ExposeServiceAnnotationKey: "true"})
 	coordinatorService.Spec.WithPublishNotReadyAddresses(true)
 
 	coordinatorReadyService := ServiceForStatefulSet(coordinator.StatefulSetApplyConfiguration).
@@ -558,7 +558,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 
 	webService := ServiceForDeployment(web).
 		WithName("web-svc").
-		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"}).
+		WithAnnotations(map[string]string{ExposeServiceAnnotationKey: "true"}).
 		WithSpec(
 			ServiceSpec().
 				WithSelector(
@@ -608,18 +608,18 @@ func Emojivoto(smMode serviceMeshMode) []any {
 	}
 
 	emoji.Spec.Template.WithAnnotations(map[string]string{
-		smIngressConfigAnnotationKey: "",
+		SmIngressConfigAnnotationKey: "",
 	})
 	voting.Spec.Template.WithAnnotations(map[string]string{
-		smIngressConfigAnnotationKey: "",
+		SmIngressConfigAnnotationKey: "",
 	})
 	web.Spec.Template.WithAnnotations(map[string]string{
-		smIngressConfigAnnotationKey: "web#8080#false",
-		smEgressConfigAnnotationKey:  "emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080",
+		SmIngressConfigAnnotationKey: "web#8080#false",
+		SmEgressConfigAnnotationKey:  "emoji#127.137.0.1:8081#emoji-svc:8080##voting#127.137.0.2:8081#voting-svc:8080",
 	})
 	voteBot.Spec.Template.WithAnnotations(map[string]string{
-		smIngressConfigAnnotationKey: "DISABLED",
-		smEgressConfigAnnotationKey:  "web#127.137.0.3:8081#web-svc:443",
+		SmIngressConfigAnnotationKey: "DISABLED",
+		SmEgressConfigAnnotationKey:  "web#127.137.0.3:8081#web-svc:443",
 	})
 
 	return resources
@@ -643,7 +643,7 @@ func VolumeStatefulSet() []any {
 				WithTemplate(
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "volume-tester"}).
-						WithAnnotations(map[string]string{securePVAnnotationKey: "state:share"}).
+						WithAnnotations(map[string]string{SecurePVAnnotationKey: "state:share"}).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -705,8 +705,8 @@ func MySQL() []any {
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "mysql-backend"}).
 						WithAnnotations(map[string]string{
-							smIngressConfigAnnotationKey: "",
-							securePVAnnotationKey:        "state:share",
+							SmIngressConfigAnnotationKey: "",
+							SecurePVAnnotationKey:        "state:share",
 						}).
 						WithSpec(
 							PodSpec().
@@ -779,7 +779,7 @@ done
 				WithTemplate(
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "mysql-client"}).
-						WithAnnotations(map[string]string{smEgressConfigAnnotationKey: "mysql-backend#127.137.0.1:3306#mysql-backend:3306"}).
+						WithAnnotations(map[string]string{SmEgressConfigAnnotationKey: "mysql-backend#127.137.0.1:3306#mysql-backend:3306"}).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -946,8 +946,8 @@ seal "transit" {
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "vault"}).
 						WithAnnotations(map[string]string{
-							workloadSecretIDAnnotationKey: "vault_unsealing",
-							securePVAnnotationKey:         "state:share",
+							WorkloadSecretIDAnnotationKey: "vault_unsealing",
+							SecurePVAnnotationKey:         "state:share",
 						}).
 						WithSpec(
 							PodSpec().
@@ -1018,7 +1018,7 @@ seal "transit" {
 				),
 		)
 	vaultService := ServiceForStatefulSet(vaultSfSets).
-		WithAnnotations(map[string]string{exposeServiceAnnotation: "true"})
+		WithAnnotations(map[string]string{ExposeServiceAnnotationKey: "true"})
 	vaultService.Spec.WithPublishNotReadyAddresses(true)
 
 	configMap := ConfigMap("vault-config", namespace).WithData(
@@ -1096,7 +1096,7 @@ func MemDump() []any {
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "listener"}).
 						WithAnnotations(map[string]string{
-							smIngressConfigAnnotationKey: "netcat#8000#false",
+							SmIngressConfigAnnotationKey: "netcat#8000#false",
 						}).
 						WithSpec(
 							PodSpec().
@@ -1142,7 +1142,7 @@ func MemDump() []any {
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": "sender"}).
 						WithAnnotations(map[string]string{
-							smEgressConfigAnnotationKey: "netcat#127.137.0.1:8000#listener:8000",
+							SmEgressConfigAnnotationKey: "netcat#127.137.0.1:8000#listener:8000",
 						}).
 						WithSpec(
 							PodSpec().


### PR DESCRIPTION
We define constants for contrast specific K8s annotation keys in multiple locations, mainly the `cli` and `kuberesource` packages. Since there are also multiple duplicate definitions, it makes sense to put them into one location. I put every annotation key variable we define into the `kuberesource` package and exported them. Any future definitions can then go there as well.

Fixes CON-192