### PR TITLE
coordinator: domain-separate transit engine keys from workload secrets

### DIFF
--- a/coordinator/internal/transitengineapi/transitengineapi.go
+++ b/coordinator/internal/transitengineapi/transitengineapi.go
@@ -137,7 +137,7 @@ func getEncryptHandler(guard stateGuard, logger *slog.Logger) http.HandlerFunc {
 			}, logger)
 			return
 		}
-		key, err := deriveEncryptionKey(r.Context(), guard, fmt.Sprintf("%d_%s", encReq.KeyVersion, workloadSecretID))
+		key, err := deriveEncryptionKey(r.Context(), guard, encReq.KeyVersion, workloadSecretID)
 		if err != nil {
 			writeHTTPError(w, httpError{
 				code:          http.StatusInternalServerError,
@@ -209,7 +209,7 @@ func getDecryptHandler(guard stateGuard, logger *slog.Logger) http.HandlerFunc {
 			}, logger)
 			return
 		}
-		key, err := deriveEncryptionKey(r.Context(), guard, fmt.Sprintf("%d_%s", decReq.CiphertextContainer.keyVersion, workloadSecretID))
+		key, err := deriveEncryptionKey(r.Context(), guard, decReq.CiphertextContainer.keyVersion, workloadSecretID)
 		if err != nil {
 			writeHTTPError(w, httpError{
 				code:          http.StatusInternalServerError,
@@ -263,21 +263,21 @@ func authorizeWorkloadSecret(workloadSecretID string, r *http.Request, logger *s
 	return fmt.Errorf("mismatching workloadSecretIDs: name:%s, extension:%s", workloadSecretID, extensionWSID)
 }
 
-// deriveEncryptionKey derives the workload secret used as the encryption key by receiving the seedengine of the current state.
-func deriveEncryptionKey(ctx context.Context, guard stateGuard, workloadSecretID string) ([]byte, error) {
+// deriveEncryptionKey derives the transit engine encryption key from the current state's seed engine.
+func deriveEncryptionKey(ctx context.Context, guard stateGuard, keyVersion uint32, name string) ([]byte, error) {
 	// TODO(burgerdev): we should be using the state from the request context here!
 	state, err := guard.GetState(ctx)
 	if err != nil {
 		return nil, err
 	}
-	derivedWorkloadSecret, err := state.SeedEngine().DeriveWorkloadSecret(workloadSecretID)
+	key, err := state.SeedEngine().DeriveTransitEngineKey(keyVersion, name)
 	if err != nil {
 		return nil, err
 	}
-	if len(derivedWorkloadSecret) < aesGCMKeySize {
+	if len(key) < aesGCMKeySize {
 		return nil, fmt.Errorf("derived key too small, expected key length: %d", aesGCMKeySize)
 	}
-	return derivedWorkloadSecret[:aesGCMKeySize], nil
+	return key[:aesGCMKeySize], nil
 }
 
 // writeJSONResponse wraps any payload inside a "data" object and sends it as an HTTP response.

--- a/coordinator/internal/transitengineapi/transitengineapi_test.go
+++ b/coordinator/internal/transitengineapi/transitengineapi_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -210,6 +211,46 @@ func TestAdversarialDecryptInputs(t *testing.T) {
 			require.Equal(tc.wantCode, res.StatusCode, string(body))
 		})
 	}
+}
+
+// TestRejectLegacyCiphertext ensures the transit engine does NOT decrypt ciphertext wrapped with the legacy,
+// pre-domain-separation key (DeriveWorkloadSecret("<version>_<name>")). Honoring that key on the decrypt path
+// would let an attacker who derives it via a matching WorkloadSecretID forge auto-unseal blobs the Coordinator
+// accepts. This test guards against a fallback being reintroduced and silently reopening that hole.
+func TestRejectLegacyCiphertext(t *testing.T) {
+	require := require.New(t)
+
+	guard, err := newTestGuard()
+	require.NoError(err)
+	mux := newMockTransitEngineMux(guard)
+
+	const name = "vault_unsealing"
+
+	// Forge a ciphertext as the pre-fix transit engine would have: wrapped with the legacy workload-secret key.
+	state, err := guard.GetState(t.Context())
+	require.NoError(err)
+	legacyKey, err := state.SeedEngine().DeriveWorkloadSecret(fmt.Sprintf("%d_%s", 0, name))
+	require.NoError(err)
+
+	container, err := symmetricEncryptRaw(legacyKey[:aesGCMKeySize], []byte("super-secret"), nil)
+	require.NoError(err)
+	ciphertext, err := json.Marshal(container) // "vault:v0:<base64>"
+	require.NoError(err)
+
+	decryptReqBody, err := json.Marshal(map[string]string{"ciphertext": string(bytes.Trim(ciphertext, `"`))})
+	require.NoError(err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/v1/transit/decrypt/"+name, bytes.NewReader(decryptReqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	res := rec.Result()
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(err)
+	require.Equal(http.StatusBadRequest, res.StatusCode, string(body))
 }
 
 type fakeStateGuard struct {

--- a/internal/seedengine/seedengine.go
+++ b/internal/seedengine/seedengine.go
@@ -27,8 +27,9 @@ type SeedEngine struct {
 	seed    []byte
 	salt    []byte
 
-	podStateSeed []byte
-	historySeed  []byte
+	podStateSeed      []byte
+	historySeed       []byte
+	transitEngineSeed []byte
 
 	rootCAKey             *ecdsa.PrivateKey
 	transactionSigningKey *ecdsa.PrivateKey
@@ -60,6 +61,10 @@ func New(secretSeed []byte, salt []byte) (*SeedEngine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("deriving seed: %w", err)
 	}
+	se.transitEngineSeed, err = se.hkdfDerive(secretSeed, "TRANSIT ENGINE SECRET")
+	if err != nil {
+		return nil, fmt.Errorf("deriving seed: %w", err)
+	}
 	transactionSigningSeed, err := se.hkdfDerive(secretSeed, "TRANSACTION SIGNING SECRET")
 	if err != nil {
 		return nil, fmt.Errorf("deriving seed: %w", err)
@@ -87,6 +92,14 @@ func (s *SeedEngine) DeriveWorkloadSecret(workloadSecretID string) ([]byte, erro
 		return nil, errors.New("workload secret ID must not be empty")
 	}
 	return s.hkdfDerive(s.podStateSeed, fmt.Sprintf("WORKLOAD SECRET ID: %s", workloadSecretID))
+}
+
+// DeriveTransitEngineKey derives a symmetric key for the transit engine API from a key version and name.
+func (s *SeedEngine) DeriveTransitEngineKey(keyVersion uint32, name string) ([]byte, error) {
+	if name == "" {
+		return nil, errors.New("transit engine key name must not be empty")
+	}
+	return s.hkdfDerive(s.transitEngineSeed, fmt.Sprintf("TRANSIT ENGINE KEY: %d %s", keyVersion, name))
 }
 
 // GenerateMeshCAKey generates a new random key for the mesh authority.

--- a/internal/seedengine/seedengine_test.go
+++ b/internal/seedengine/seedengine_test.go
@@ -124,3 +124,67 @@ func TestSeedEngine_DeriveWorkloadSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestSeedEngine_DeriveTransitEngineKey(t *testing.T) {
+	require := require.New(t)
+
+	testCases := map[string]struct {
+		keyVersion uint32
+		name       string
+		want       string // hex encoded
+		err        bool
+	}{
+		/*
+			Crypto-determinism regression test cases.
+
+			DO NOT CHANGE!
+		*/
+		"v0 vault_unsealing": {keyVersion: 0, name: "vault_unsealing", want: "9c402681fb939a40cc956e49cec12f533b40198a5cf74acc3ae7ea0a0241a532"},
+		"v2 autounseal":      {keyVersion: 2, name: "autounseal", want: "890718bce191aca942cdb9a766bd89503711fe007c272176da49061085f0dcd7"},
+		"v0 workload-1":      {keyVersion: 0, name: "workload-1", want: "13842ea44839b525ab5a3eb2a15d6303b86faae4f6f820dfe56d126216b11f16"},
+		"v2000 special char": {keyVersion: 2000, name: "thi$$hoU_ld+*work", want: "f2f22ada9cbf5b2f462e06def0d7cbd8e38dd42ef5331d9359aab13b59331650"},
+		"empty name errors":  {keyVersion: 0, name: "", err: true},
+	}
+
+	secretSeed, err := hex.DecodeString("9c7f285a46704602f8b6d9d4a89193579a979f144a9d8733fddd4f2bbcecd77f")
+	require.NoError(err)
+	salt, err := hex.DecodeString("6227b2cae740349beaff040af74aa1566ac330e9b54ce0e58f8d5ee47281745a")
+	require.NoError(err)
+
+	se, err := New(secretSeed, salt)
+	require.NoError(err)
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			key, err := se.DeriveTransitEngineKey(tc.keyVersion, tc.name)
+
+			if tc.err {
+				require.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tc.want, hex.EncodeToString(key))
+		})
+	}
+
+	// Domain separation: a transit engine key is addressed on the transit API by a key_name (plus key_version),
+	// whereas a workload secret is addressed by the WorkloadSecretID from the manifest. The two are drawn from
+	// separate key domains and must never derive to the same bytes. Otherwise a workload could obtain a transit
+	// key just by being deployed with a matching WorkloadSecretID, without ever calling the transit API.
+	//
+	// The pairing below is the exact pre-fix collision: the transit key for key_name "vault_unsealing" at
+	// version 0 used to be DeriveWorkloadSecret("0_vault_unsealing") (from the old "%d_%s" derivation input),
+	// so a pod with the crafted WorkloadSecretID "0_vault_unsealing" received the transit key as its own
+	// workload secret. This assertion fails against that old derivation and passes only once the domains split.
+	t.Run("transit key never equals a workload secret", func(t *testing.T) {
+		assert := assert.New(t)
+
+		transitKey, err := se.DeriveTransitEngineKey(0, "vault_unsealing")
+		require.NoError(err)
+		craftedWorkloadSecret, err := se.DeriveWorkloadSecret("0_vault_unsealing")
+		require.NoError(err)
+		assert.NotEqual(hex.EncodeToString(craftedWorkloadSecret), hex.EncodeToString(transitKey))
+	})
+}


### PR DESCRIPTION
The transit engine derived its AES keys with DeriveWorkloadSecret("<version>_<name>"), the same HKDF namespace that hands each pod its workload secret. A pod deployed with WorkloadSecretID "0_vault_unsealing" thus received, in its own workload secret, the exact key the transit engine uses to wrap OpenBao's master key. That defeats the transit API's per-workload authorization on both directions: the pod can unwrap the auto-unseal blob offline, and (since it holds the key) forge a blob the Coordinator will decrypt, injecting an attacker-chosen master key on OpenBao's untrusted storage.

Derive transit keys from a dedicated seed and HKDF label so their keyspace can never alias a workload secret. No decrypt-side fallback to the old derivation is provided on purpose: honoring the legacy key would keep the forgery path open, since the server cannot tell an original legacy blob from an attacker-forged one. This is a breaking change for existing OpenBao auto-unseal deployments, which must migrate their master key (seal-migration or re-init) onto the new key on upgrade.

Fixes CON-201

TODO
- [x] ~~Decide on rollout/backwards compatibility as this is a breaking change!~~ This is now tagged as a breaking change for the release notes.

# Migrating an existing Vault after this upgrade

This release changes the transit engine key derivation, so a Vault that uses transit auto-unsealing won't auto-unseal after you upgrade across this version. Migrate by bracketing the upgrade with a Shamir seal. This only re-wraps Vault's root key; the stored data is never touched. You need a threshold of the recovery keys you saved when you initialized the Vault (3 of 5 by default). Run the `bao` commands from your workspace against the Vault endpoint (`VAULT_ADDR`/`VAULT_CACERT` as in the initial setup), the same way you initialized it. The Vault config is policy-pinned, so config changes go through `contrast generate` + `contrast set`, not `kubectl edit`.

**Before upgrading (transit -> Shamir).** In the Vault config (the `VAULT_CONFIG` value of the `vault-config` ConfigMap), add the line `disabled = "true"` inside the `seal "transit"` block (the stanza with `key_name = "vault_unsealing"` and `address = "https://coordinator:8200"`), leaving its other fields unchanged. Then:

```sh
contrast generate --reference-values <platform> resources/
contrast set -c "${coordinator}:1313" resources/
kubectl rollout restart statefulset/vault
bao operator unseal -migrate <recovery-key>   # repeat for the threshold (3)
```

`bao status` should now show `Seal Type: shamir`, `Sealed: false`.

**Deploy the new Coordinator** (and the rest of the release). Because the Vault is Shamir-sealed at this point, the transit key change doesn't affect it.

**After upgrading (Shamir -> transit).** Remove the `disabled = "true"` line, then run the same four commands again (same recovery keys). Vault re-wraps its root key under the new transit key and auto-unseals; `bao status` should show `Seal Type: transit`, `Sealed: false`.
