### PR TITLE
lib, packages: add and use package meta helper

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -3,4 +3,7 @@
 
 { lib }:
 
-import ./matrix.nix { inherit lib; }
+(import ./matrix.nix { inherit lib; })
+// {
+  ourMeta = import ./meta.nix { inherit lib; };
+}

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -1,0 +1,25 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{ lib }:
+
+{
+  mainProgram ? null,
+  description ? null,
+  license ? lib.licenses.bsl11,
+  homepage ? "https://github.com/edgelesssys/contrast",
+  maintainerName ? "Edgeless Systems",
+  maintainerEmail ? "contact@edgeless.systems",
+}:
+
+{
+  inherit license homepage;
+  maintainers = [
+    {
+      name = maintainerName;
+      email = maintainerEmail;
+    }
+  ];
+}
+// lib.optionalAttrs (mainProgram != null) { inherit mainProgram; }
+// lib.optionalAttrs (description != null) { inherit description; }

--- a/packages/by-name/collateral-proxy/package.nix
+++ b/packages/by-name/collateral-proxy/package.nix
@@ -44,5 +44,5 @@ buildGoModule (finalAttrs: {
     runHook postCheck
   '';
 
-  meta.mainProgram = "collateral-proxy";
+  meta = lib.contrast.ourMeta { mainProgram = "collateral-proxy"; };
 })

--- a/packages/by-name/contrast/cli/package.nix
+++ b/packages/by-name/contrast/cli/package.nix
@@ -102,5 +102,5 @@ buildGoModule (finalAttrs: {
   # need any other fixup, saving some seconds.
   dontFixup = true;
 
-  meta.mainProgram = "contrast";
+  meta = lib.contrast.ourMeta { mainProgram = "contrast"; };
 })

--- a/packages/by-name/contrast/coordinator/package.nix
+++ b/packages/by-name/contrast/coordinator/package.nix
@@ -1,4 +1,8 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }: contrast.coordinator
+{ lib, contrast }:
+
+contrast.coordinator.overrideAttrs (_: {
+  meta = lib.contrast.ourMeta { mainProgram = "coordinator"; };
+})

--- a/packages/by-name/contrast/initializer/package.nix
+++ b/packages/by-name/contrast/initializer/package.nix
@@ -1,4 +1,8 @@
 # Copyright 2025 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ contrast }: contrast.initializer
+{ lib, contrast }:
+
+contrast.initializer.overrideAttrs (_: {
+  meta = lib.contrast.ourMeta { mainProgram = "initializer"; };
+})

--- a/packages/by-name/contrast/nodeinstaller/package.nix
+++ b/packages/by-name/contrast/nodeinstaller/package.nix
@@ -57,5 +57,5 @@ buildGoModule (finalAttrs: {
     mv "$out/bin/nodeinstaller" "$out/bin/node-installer"
   '';
 
-  meta.mainProgram = "node-installer";
+  meta = lib.contrast.ourMeta { mainProgram = "node-installer"; };
 })

--- a/packages/by-name/contrast/resourcegen/package.nix
+++ b/packages/by-name/contrast/resourcegen/package.nix
@@ -71,8 +71,5 @@ buildGoModule (_finalAttrs: {
   # need any other fixup, saving some seconds.
   dontFixup = true;
 
-  meta = {
-    description = "Resource generator for Contrast";
-    mainProgram = "resourcegen";
-  };
+  meta = lib.contrast.ourMeta { mainProgram = "resourcegen"; };
 })

--- a/packages/by-name/debugshell/package.nix
+++ b/packages/by-name/debugshell/package.nix
@@ -65,5 +65,5 @@ buildGoModule {
       cp ${lib.getExe debugshell} $out/bin/debugshell
     '';
 
-  meta.mainProgram = "debugshell-server";
+  meta = lib.contrast.ourMeta { mainProgram = "debugshell-server"; };
 }

--- a/packages/by-name/fifo/package.nix
+++ b/packages/by-name/fifo/package.nix
@@ -1,7 +1,10 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ buildGoModule }:
+{
+  lib,
+  buildGoModule,
+}:
 
 buildGoModule {
   pname = "fifo";
@@ -16,5 +19,5 @@ buildGoModule {
 
   ldflags = [ "-s" ];
 
-  meta.mainProgram = "fifo";
+  meta = lib.contrast.ourMeta { mainProgram = "fifo"; };
 }

--- a/packages/by-name/imagepuller-benchmark/package.nix
+++ b/packages/by-name/imagepuller-benchmark/package.nix
@@ -36,5 +36,5 @@ buildGoModule (finalAttrs: {
 
   doCheck = false;
 
-  meta.mainProgram = "imagepuller-benchmark";
+  meta = lib.contrast.ourMeta { mainProgram = "imagepuller-benchmark"; };
 })

--- a/packages/by-name/imagepuller/package.nix
+++ b/packages/by-name/imagepuller/package.nix
@@ -35,5 +35,5 @@ buildGoModule (finalAttrs: {
     "-X main.version=v${finalAttrs.version}"
   ];
 
-  meta.mainProgram = "imagepuller";
+  meta = lib.contrast.ourMeta { mainProgram = "imagepuller"; };
 })

--- a/packages/by-name/imagestore/package.nix
+++ b/packages/by-name/imagestore/package.nix
@@ -36,5 +36,5 @@ buildGoModule (finalAttrs: {
     "-X main.version=v${finalAttrs.version}"
   ];
 
-  meta.mainProgram = "imagestore";
+  meta = lib.contrast.ourMeta { mainProgram = "imagestore"; };
 })

--- a/packages/by-name/initdata-processor/package.nix
+++ b/packages/by-name/initdata-processor/package.nix
@@ -83,5 +83,5 @@ buildGoModule (finalAttrs: {
     runHook postCheck
   '';
 
-  meta.mainProgram = "initdata-processor";
+  meta = lib.contrast.ourMeta { mainProgram = "initdata-processor"; };
 })

--- a/packages/by-name/kata/sev-snp-measure/package.nix
+++ b/packages/by-name/kata/sev-snp-measure/package.nix
@@ -33,5 +33,5 @@ buildGoModule (finalAttrs: {
 
   doCheck = false;
 
-  meta.mainProgram = "sev-snp-measure-go";
+  meta = lib.contrast.ourMeta { mainProgram = "sev-snp-measure-go"; };
 })

--- a/packages/by-name/kernelconfig/package.nix
+++ b/packages/by-name/kernelconfig/package.nix
@@ -28,5 +28,5 @@ buildGoModule (finalAttrs: {
 
   ldflags = [ "-s" ];
 
-  meta.mainProgram = "kernelconfig";
+  meta = lib.contrast.ourMeta { mainProgram = "kernelconfig"; };
 })

--- a/packages/by-name/service-mesh/package.nix
+++ b/packages/by-name/service-mesh/package.nix
@@ -51,5 +51,5 @@ buildGoModule (finalAttrs: {
     runHook postCheck
   '';
 
-  meta.mainProgram = "service-mesh";
+  meta = lib.contrast.ourMeta { mainProgram = "service-mesh"; };
 })

--- a/packages/by-name/tdx-measure/package.nix
+++ b/packages/by-name/tdx-measure/package.nix
@@ -1,7 +1,10 @@
 # Copyright 2024 Edgeless Systems GmbH
 # SPDX-License-Identifier: BUSL-1.1
 
-{ buildGoModule }:
+{
+  lib,
+  buildGoModule,
+}:
 
 buildGoModule (finalAttrs: {
   pname = "tdx-measure";
@@ -31,5 +34,5 @@ buildGoModule (finalAttrs: {
     runHook postCheck
   '';
 
-  meta.mainProgram = "tdx-measure";
+  meta = lib.contrast.ourMeta { mainProgram = "tdx-measure"; };
 })


### PR DESCRIPTION
Precursor to the SBOM PR. We don't really *need* this on its own, but it's necessary for filling the SBOMs.