### PR TITLE
coordinator: fix anti-affinity by moving pod-role to label

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -336,8 +336,7 @@ func isCoordinator(resource any) bool {
 		r.Spec != nil &&
 		r.Spec.Template != nil &&
 		r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
-		r.Spec.Template.Annotations != nil &&
-		r.Spec.Template.Annotations[kuberesource.ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
+		r.Spec.Template.Labels[kuberesource.ContrastRoleLabelKey] == string(manifest.RoleCoordinator) {
 		return true
 	}
 	return false

--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -73,7 +73,7 @@ func policiesFromKubeResources(fileMap map[string][]*unstructured.Unstructured) 
 				return meta, spec
 			}
 			annotation = meta.Annotations[kuberesource.InitdataAnnotationKey]
-			role = manifest.Role(meta.Annotations[kuberesource.ContrastRoleAnnotationKey])
+			role = manifest.Role(meta.Labels[kuberesource.ContrastRoleLabelKey])
 			workloadSecretID = meta.Annotations[kuberesource.WorkloadSecretIDAnnotationKey]
 			return meta, spec
 		})

--- a/cli/cmd/policies_test.go
+++ b/cli/cmd/policies_test.go
@@ -34,9 +34,11 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 				kuberesource.Deployment("test", "").
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
+							WithLabels(map[string]string{
+								kuberesource.ContrastRoleLabelKey: string(manifest.RoleCoordinator),
+							}).
 							WithAnnotations(map[string]string{
-								kuberesource.InitdataAnnotationKey:     anno,
-								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
+								kuberesource.InitdataAnnotationKey: anno,
 							}).
 							WithSpec(
 								kuberesource.PodSpec().
@@ -85,9 +87,11 @@ func TestPoliciesFromKubeResources(t *testing.T) {
 				kuberesource.Deployment("test", "").
 					WithSpec(kuberesource.DeploymentSpec().
 						WithTemplate(kuberesource.PodTemplateSpec().
+							WithLabels(map[string]string{
+								kuberesource.ContrastRoleLabelKey: string(manifest.RoleCoordinator),
+							}).
 							WithAnnotations(map[string]string{
-								kuberesource.InitdataAnnotationKey:     anno,
-								kuberesource.ContrastRoleAnnotationKey: string(manifest.RoleCoordinator),
+								kuberesource.InitdataAnnotationKey: anno,
 							}).
 							WithSpec(
 								kuberesource.PodSpec().

--- a/cli/verifier/versions_match.go
+++ b/cli/verifier/versions_match.go
@@ -40,8 +40,8 @@ func (v *VersionsMatch) Verify(toVerify any) error {
 		}
 
 		var podRole string
-		if meta != nil && meta.Annotations != nil {
-			podRole = meta.Annotations[kuberesource.ContrastRoleAnnotationKey]
+		if meta != nil {
+			podRole = meta.Labels[kuberesource.ContrastRoleLabelKey]
 		}
 		for _, container := range spec.Containers {
 			if !needsImageVersionCheck(*container.Name, podRole) {

--- a/cli/verifier/versions_match_test.go
+++ b/cli/verifier/versions_match_test.go
@@ -19,8 +19,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: test
-  annotations:
-    %s: %s
+  labels:
+    %q: %q
 spec:
   runtimeClassName: contrast-cc
   containers:
@@ -66,7 +66,7 @@ func TestVerifyVersionsMatch(t *testing.T) {
 			version:       "v1.13.0",
 		},
 		"versions match with pod-role": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleCoordinator, "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleLabelKey, manifest.RoleCoordinator, "v1.13.0"),
 			version:       "v1.13.0",
 		},
 		"cli version newer": {
@@ -80,12 +80,12 @@ func TestVerifyVersionsMatch(t *testing.T) {
 			wantErr:       true,
 		},
 		"cli version mismatch with pod-role": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleCoordinator, "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleLabelKey, manifest.RoleCoordinator, "v1.13.0"),
 			version:       "v1.12.0",
 			wantErr:       true,
 		},
 		"cli version mismatch with differing pod-role unaffected": {
-			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleAnnotationKey, manifest.RoleNone, "v1.13.0"),
+			k8sObjectYAML: fmt.Appendf(nil, coordinatorWithVersionTemplate, kuberesource.ContrastRoleLabelKey, manifest.RoleNone, "v1.13.0"),
 			version:       "v1.12.0",
 		},
 		"resource missing version skipped": {

--- a/coordinator/internal/peerdiscovery/peerdiscovery.go
+++ b/coordinator/internal/peerdiscovery/peerdiscovery.go
@@ -34,15 +34,14 @@ func New(client kubernetes.Interface, namespace string) *Discovery {
 func (d *Discovery) GetPeers(ctx context.Context) ([]string, error) {
 	// TODO(burgerdev): this should be an informer with cache.
 	pods, err := d.client.CoreV1().Pods(d.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set{"app.kubernetes.io/name": "coordinator"}.String(),
+		LabelSelector: labels.Set{kuberesource.ContrastRoleLabelKey: string(manifest.RoleCoordinator)}.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing coordinator pods: %w", err)
 	}
 	var peers []string
 	for _, pod := range pods.Items {
-		if pod.Annotations[kuberesource.ContrastRoleAnnotationKey] != string(manifest.RoleCoordinator) ||
-			pod.Name == os.Getenv("HOSTNAME") {
+		if pod.Name == os.Getenv("HOSTNAME") {
 			continue
 		}
 		if isReady(&pod) {

--- a/coordinator/internal/peerdiscovery/peerdiscovery_test.go
+++ b/coordinator/internal/peerdiscovery/peerdiscovery_test.go
@@ -30,36 +30,29 @@ func TestGetPeers(t *testing.T) {
 		},
 		"no peers": {
 			pods: []runtime.Object{
-				newPod(host, namespace, "coordinator", "coordinator", "1.2.3.4", true),
+				newPod(host, namespace, "coordinator", "1.2.3.4", true),
 			},
 			expected: nil,
 		},
 		"multiple peers": {
 			pods: []runtime.Object{
-				newPod(host, namespace, "coordinator", "coordinator", "1.2.3.4", true),
-				newPod("coordinator-1", namespace, "coordinator", "coordinator", "5.6.7.8", true),
-				newPod("coordinator-2", namespace, "coordinator", "coordinator", "9.10.11.12", true),
+				newPod(host, namespace, "coordinator", "1.2.3.4", true),
+				newPod("coordinator-1", namespace, "coordinator", "5.6.7.8", true),
+				newPod("coordinator-2", namespace, "coordinator", "9.10.11.12", true),
 			},
 			expected: []string{"5.6.7.8", "9.10.11.12"},
 		},
 		"peer not ready": {
 			pods: []runtime.Object{
-				newPod(host, namespace, "coordinator", "coordinator", "1.2.3.4", true),
-				newPod("coordinator-1", namespace, "coordinator", "coordinator", "5.6.7.8", false),
+				newPod(host, namespace, "coordinator", "1.2.3.4", true),
+				newPod("coordinator-1", namespace, "coordinator", "5.6.7.8", false),
 			},
 			expected: nil,
 		},
 		"peer has no coordinator role": {
 			pods: []runtime.Object{
-				newPod(host, namespace, "coordinator", "coordinator", "1.2.3.4", true),
-				newPod("coordinator-1", namespace, "coordinator", "worker", "5.6.7.8", true),
-			},
-			expected: nil,
-		},
-		"peer has no coordinator label": {
-			pods: []runtime.Object{
-				newPod(host, namespace, "coordinator", "coordinator", "1.2.3.4", true),
-				newPod("coordinator-1", namespace, "worker", "coordinator", "5.6.7.8", true),
+				newPod(host, namespace, "coordinator", "1.2.3.4", true),
+				newPod("coordinator-1", namespace, "worker", "5.6.7.8", true),
 			},
 			expected: nil,
 		},
@@ -80,13 +73,12 @@ func TestGetPeers(t *testing.T) {
 	}
 }
 
-func newPod(name, namespace, labelName string, role manifest.Role, ip string, isReady bool) runtime.Object {
+func newPod(name, namespace string, role manifest.Role, ip string, isReady bool) runtime.Object {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      map[string]string{"app.kubernetes.io/name": labelName},
-			Annotations: map[string]string{kuberesource.ContrastRoleAnnotationKey: string(role)},
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{kuberesource.ContrastRoleLabelKey: string(role)},
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},

--- a/internal/kuberesource/constants.go
+++ b/internal/kuberesource/constants.go
@@ -9,10 +9,10 @@ const (
 )
 
 const (
-	// ContrastRoleAnnotationKey assigns a role to the annotated pod.
+	// ContrastRoleLabelKey assigns a role to the labeled pod.
 	//
 	// This is used to determine whether a given pod may act as Coordinator.
-	ContrastRoleAnnotationKey = annotationPrefix + "pod-role"
+	ContrastRoleLabelKey = annotationPrefix + "pod-role"
 
 	// ExposeServiceAnnotationKey is the annotation key used to specify whether a Service should be exposed via a LoadBalancer.
 	ExposeServiceAnnotationKey = annotationPrefix + "expose-service"

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -300,7 +300,7 @@ func SetCollateralProxyEnv(resources []any, proxyURL string) []any {
 	out := make([]any, 0, len(resources))
 	for _, resource := range resources {
 		out = append(out, MapPodSpecWithMeta(resource, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
-			if meta == nil || meta.Annotations[ContrastRoleAnnotationKey] != string(manifest.RoleCoordinator) {
+			if meta == nil || meta.Labels[ContrastRoleLabelKey] != string(manifest.RoleCoordinator) {
 				return meta, spec
 			}
 			for i := range spec.Containers {
@@ -494,8 +494,8 @@ func AddLogging(resources []any, level, subsystem string) []any {
 	for _, resource := range resources {
 		switch r := resource.(type) {
 		case *applyappsv1.StatefulSetApplyConfiguration:
-			if r.Spec != nil && r.Spec.Template != nil &&
-				r.Spec.Template.Annotations[ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
+			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
+				r.Spec.Template.Labels[ContrastRoleLabelKey] == string(manifest.RoleCoordinator) {
 				r.Spec.Template.Spec.Containers[0].WithEnv(
 					NewEnvVar("CONTRAST_LOG_LEVEL", level),
 					NewEnvVar("CONTRAST_LOG_SUBSYSTEMS", subsystem),
@@ -724,7 +724,8 @@ func PatchCoordinatorMetrics(resources []any) []any {
 		case *applyappsv1.StatefulSetApplyConfiguration:
 			if r.Spec != nil && r.Spec.Template != nil && r.Spec.Template.Spec != nil &&
 				len(r.Spec.Template.Spec.Containers) > 0 &&
-				r.Spec.Template.Annotations[ContrastRoleAnnotationKey] == string(manifest.RoleCoordinator) {
+				r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
+				r.Spec.Template.Labels[ContrastRoleLabelKey] == string(manifest.RoleCoordinator) {
 				r.Spec.Template.Spec.Containers[0].WithEnv(NewEnvVar("CONTRAST_METRICS", "1"))
 				r.Spec.Template.Spec.Containers[0].WithPorts(
 					ContainerPort().

--- a/internal/kuberesource/mutators_test.go
+++ b/internal/kuberesource/mutators_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/contrast/internal/constants"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -809,7 +810,7 @@ func TestSetCollateralProxyEnv(t *testing.T) {
 	assert := assert.New(t)
 
 	coordinatorPod := applycorev1.Pod("coordinator", "default").
-		WithAnnotations(map[string]string{ContrastRoleAnnotationKey: "coordinator"}).
+		WithLabels(map[string]string{ContrastRoleLabelKey: string(manifest.RoleCoordinator)}).
 		WithSpec(applycorev1.PodSpec().
 			WithRuntimeClassName("contrast-cc-foo").
 			WithContainers(applycorev1.Container().WithName("coordinator").WithImage("coordinator")))

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -118,10 +118,9 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*applyappsv1.
 				).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": name}).
-						WithAnnotations(map[string]string{
-							ContrastRoleAnnotationKey:            string(manifest.RoleNodeInstaller),
-							"contrast.edgeless.systems/platform": platform.String(),
+						WithLabels(map[string]string{
+							ContrastRoleLabelKey:     string(manifest.RoleNodeInstaller),
+							"app.kubernetes.io/name": name,
 						}).
 						WithSpec(
 							PodSpec().
@@ -309,8 +308,10 @@ func Coordinator(namespace string) *CoordinatorConfig {
 					WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)). // TODO(burgerdev): this should be RETAIN for released coordinators.
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "coordinator"}).
-						WithAnnotations(map[string]string{ContrastRoleAnnotationKey: string(manifest.RoleCoordinator)}).
+						WithLabels(map[string]string{
+							"app.kubernetes.io/name": "coordinator",
+							ContrastRoleLabelKey:     string(manifest.RoleCoordinator),
+						}).
 						WithSpec(
 							PodSpec().
 								WithServiceAccountName("coordinator").
@@ -384,7 +385,7 @@ func Coordinator(namespace string) *CoordinatorConfig {
 															applycorev1.PodAffinityTerm().
 																WithLabelSelector(
 																	LabelSelector().
-																		WithMatchLabels(map[string]string{"contrast.edgeless.systems/pod-role": "coordinator"}),
+																		WithMatchLabels(map[string]string{ContrastRoleLabelKey: string(manifest.RoleCoordinator)}),
 																).
 																WithTopologyKey("kubernetes.io/hostname"),
 														),

--- a/packages/cleanup-bare-metal.sh
+++ b/packages/cleanup-bare-metal.sh
@@ -45,7 +45,11 @@ for resource in "${resourcesToCheck[@]}"; do
 done
 
 # Extract runtime class names from running node installers
-kubectl get pods --all-namespaces -o jsonpath='{.items[?(@.metadata.annotations.contrast\.edgeless\.systems/pod-role=="contrast-node-installer")].metadata.name}' |
+{
+  # TODO(burgerdev): checking the annotation is a fallback for older runtimes, can be removed in Q4 2026.
+  kubectl get pods --all-namespaces -o jsonpath='{.items[?(@.metadata.annotations.contrast\.edgeless\.systems/pod-role=="contrast-node-installer")].metadata.name}'
+  kubectl get pods --all-namespaces --selector contrast.edgeless.systems/pod-role=contrast-node-installer -o jsonpath='{.items[*].metadata.name}'
+} |
   tr ' ' '\n' |
   grep -o "contrast-cc-.\+" |
   sed "s/-nodeinstaller.*//g" >>usedRuntimeClasses || true


### PR DESCRIPTION
The Contrast Coordinator used to specify  an anti-affinity based on pod role label, which was ineffective because the pod role was, in fact, an annotation. With this change, we're moving the pod role to a label.

---

Labels are a bit more restrictive than annotations, but we can easily fit the pod role into a label. Doing so allows using the pod role in selectors, such as for anti-affinity (where we're already selecting by the label, which did not have an effect) or in the peerdiscovery watcher. Having a label that is separate from the pod selector labels also allows exposing Coordinator's from different controllers with services.

Fixes CON-213.
Fixes CON-206.