### PR TITLE
initdata-processor: always signal READY=1

### DIFF
--- a/initdata-processor/main.go
+++ b/initdata-processor/main.go
@@ -300,4 +300,8 @@ func failf(format string, v ...any) {
 		log.Printf("Error moving file: %v", err)
 		return
 	}
+
+	// We signal readiness only after successfully writing the fake policy to avoid a race between
+	// us writing and the Kata agent reading.
+	sdNotifyReady()
 }


### PR DESCRIPTION
We changed the type of the initdata-processor service from oneshot to notify in ab4d6128aa0671f8e2dc6c394cdaafeb60da3214. This means that systemd will wait for the signal, regardless of the service exiting early due to a failure, before starting the Kata agent. This was not what we intended: the overall idea is that the initdata-processor always 'suceeds' (in the eyes of systemd), to then let the Kata agent convey the actual problem to the user.

This commit fixes this issue by signaling ready in the failure path, too.

- [x] [policy test](https://github.com/edgelesssys/contrast/actions/runs/28776883061)