### PR TITLE
kuberesource: remove pod-role annotation from runtime

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -120,7 +120,6 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*applyappsv1.
 					PodTemplateSpec().
 						WithLabels(map[string]string{"app.kubernetes.io/name": name}).
 						WithAnnotations(map[string]string{
-							ContrastRoleLabelKey:                 string(manifest.RoleNodeInstaller),
 							"contrast.edgeless.systems/platform": platform.String(),
 						}).
 						WithSpec(

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -391,8 +391,6 @@ const (
 	RoleNone Role = ""
 	// RoleCoordinator is the coordinator role.
 	RoleCoordinator Role = "coordinator"
-	// RoleNodeInstaller is the node installer DaemonSet.
-	RoleNodeInstaller Role = "contrast-node-installer"
 )
 
 // Validate checks the validity of the role.


### PR DESCRIPTION
The pod role is used in the manifest to apply special considerations to some pods (notably, Coordinators). Since the runtime is never a confidential pod, it does not make sense to annotate it with a pod role. https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/ are a more natural fit for this. 