### PR TITLE
kubeclient: add ExecRetry to compensate transient failures

### DIFF
--- a/e2e/internal/kubeclient/kubeclient.go
+++ b/e2e/internal/kubeclient/kubeclient.go
@@ -17,7 +17,9 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/edgelesssys/contrast/internal/retry"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -232,6 +234,23 @@ func (c *Kubeclient) ExecDeployment(ctx context.Context, namespace, deployment s
 	}
 	c.log.Debug("executing command in deployment pod", "namespace", namespace, "deployment", deployment)
 	return c.Exec(ctx, namespace, pods[0].Name, argv)
+}
+
+// ExecRetry executes the command in the container periodically until it succeeds or the context expires.
+func (c *Kubeclient) ExecRetry(ctx context.Context, namespace, pod, container string, argv []string, interval time.Duration) (
+	stdout string, stderr string, err error,
+) {
+	retrier := retry.NewIntervalRetrier(retry.DoerFunc(func(ctx context.Context) error {
+		stdout, stderr, err = c.ExecContainer(ctx, namespace, pod, container, argv)
+		if err != nil {
+			c.log.Debug("executing command in container failed", "namespace", namespace, "pod", pod, "container", container, "error", err)
+		}
+		return err
+	}), interval, retry.Always)
+
+	// Override the last error with the retrier error, but keep stdout and stderr.
+	err = retrier.Do(ctx)
+	return
 }
 
 // LogDebugInfo collects pod information from the cluster and writes it to the logger.

--- a/e2e/memdump/memdump_test.go
+++ b/e2e/memdump/memdump_test.go
@@ -81,8 +81,10 @@ func TestMemDump(t *testing.T) {
 		require.Len(senderPods, 1, "pod not found: %s/%s", ct.Namespace, senderDeployment)
 
 		// Send canary string from sender to listener via socat over TCP, encrypted via Contrast Service Mesh
+		ctxForSocat, cancel := context.WithTimeout(ctx, 20*time.Second)
+		t.Cleanup(cancel)
 		argv := []string{"/bin/sh", "-c", "printf %s '" + canaryString + "' | socat - TCP:127.137.0.1:8000"}
-		_, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, senderPods[0].Name, argv)
+		_, stderr, err := ct.Kubeclient.ExecRetry(ctxForSocat, ct.Namespace, senderPods[0].Name, "sender", argv, 5*time.Second)
 		require.NoError(err, "stderr: %q", stderr)
 
 		listenerPods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, listenerDeployment)

--- a/e2e/openssl/openssl_test.go
+++ b/e2e/openssl/openssl_test.go
@@ -98,8 +98,10 @@ func TestOpenSSL(t *testing.T) {
 			_ = ct.Kubeclient.Client.CoreV1().Pods(ct.Namespace).Delete(context.Background(), "port-forwarder-coordinator-metrics", metav1.DeleteOptions{})
 		})
 
+		ctxForMetrics, cancel := context.WithTimeout(ctx, 20*time.Second)
+		t.Cleanup(cancel)
 		argv := []string{"/bin/sh", "-c", "curl --fail " + net.JoinHostPort(coordinatorPods[0].Status.PodIP, "9102") + "/metrics"}
-		_, stderr, err := ct.Kubeclient.Exec(ctx, ct.Namespace, frontendPods[0].Name, argv)
+		_, stderr, err := ct.Kubeclient.ExecRetry(ctxForMetrics, ct.Namespace, frontendPods[0].Name, "openssl-frontend", argv, 5*time.Second)
 		require.NoError(err, "stderr: %q", stderr)
 
 		for _, endpoint := range []string{"/probe/startup", "/probe/liveness", "/probe/readiness"} {

--- a/e2e/policy/policy_test.go
+++ b/e2e/policy/policy_test.go
@@ -108,7 +108,9 @@ func TestPolicy(t *testing.T) {
 		require.NoError(c.WaitForDeployment(ctx, ct.Namespace, opensslFrontend))
 
 		// get the attestation failures before removing a policy
-		initialFailures := getFailures(ctx, t, ct)
+		ctxForMetrics, cancel := context.WithTimeout(ctx, 20*time.Second)
+		t.Cleanup(cancel)
+		initialFailures := getFailures(ctxForMetrics, t, ct)
 
 		t.Log("Initial failures:", initialFailures)
 
@@ -168,7 +170,10 @@ func TestPolicy(t *testing.T) {
 		// The container may be running, but it's hard to tell whether it already had a chance to
 		// connect to the Coordinator. Thus, retry for some time until an attestation failure happens.
 		require.EventuallyWithT(func(t *assert.CollectT) {
-			newFailures := getFailures(ctx, t, ct)
+			// Set a timeout low enough to not trigger a retry, since we're in an Eventually.
+			ctxForMetrics, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			newFailures := getFailures(ctxForMetrics, t, ct)
 			assert.Greater(t, newFailures, initialFailures, "pod not covered by manifest should cause attestation failure")
 		}, 1*time.Minute, time.Second)
 	})
@@ -231,7 +236,7 @@ func getFailures(ctx context.Context, t require.TestingT, ct *contrasttest.Contr
 	backendPods, err := ct.Kubeclient.PodsFromDeployment(ctx, ct.Namespace, opensslBackend)
 	require.NoError(err)
 	require.NotEmpty(backendPods, "pod not found: %s/%s", ct.Namespace, opensslBackend)
-	metricsString, _, err := ct.Kubeclient.Exec(ctx, ct.Namespace, backendPods[0].Name, []string{"curl", coordIP + ":9102/metrics"})
+	metricsString, _, err := ct.Kubeclient.ExecRetry(ctx, ct.Namespace, backendPods[0].Name, "openssl-backend", []string{"curl", coordIP + ":9102/metrics"}, 5*time.Second)
 	require.NoError(err)
 
 	// parse the logs

--- a/e2e/servicemesh/servicemesh_test.go
+++ b/e2e/servicemesh/servicemesh_test.go
@@ -117,9 +117,9 @@ func TestIngressEgress(t *testing.T) {
 
 		c := kubeclient.NewForTest(t)
 
-		frontendPods, err := c.PodsFromDeployment(ctx, ct.Namespace, "web")
+		webPods, err := c.PodsFromDeployment(ctx, ct.Namespace, "web")
 		require.NoError(err)
-		require.Len(frontendPods, 1, "pod not found: %s/%s", ct.Namespace, "web")
+		require.Len(webPods, 1, "pod not found: %s/%s", ct.Namespace, "web")
 
 		emojiConnection := net.JoinHostPort(c.FirstPodIP(ctx, t, ct.Namespace, "emoji"), "8801")
 
@@ -129,11 +129,13 @@ func TestIngressEgress(t *testing.T) {
 		// because we're running the commands on a pod with enabled proxy.
 
 		argv := []string{"curl", "-sS", "--cacert", "/contrast/tls-config/mesh-ca.pem", fmt.Sprintf("https://%s/metrics", emojiConnection)}
-		stdout, stderr, err := c.Exec(ctx, ct.Namespace, frontendPods[0].Name, argv)
+		stdout, stderr, err := c.Exec(ctx, ct.Namespace, webPods[0].Name, argv)
 		require.Error(err, "Expected call without client certificate to fail.\nstdout: %s\nstderr: %q", stdout, stderr)
 
+		ctxForCurl, cancel := context.WithTimeout(ctx, 20*time.Second)
+		t.Cleanup(cancel)
 		argv = append(argv, "--cert", "/contrast/tls-config/certChain.pem", "--key", "/contrast/tls-config/key.pem")
-		stdout, stderr, err = c.Exec(ctx, ct.Namespace, frontendPods[0].Name, argv)
+		stdout, stderr, err = c.ExecRetry(ctxForCurl, ct.Namespace, webPods[0].Name, "web-svc", argv, 5*time.Second)
 		require.NoError(err, "Expected call with client certificate to succeed.\nstdout: %s\nstderr: %q", stdout, stderr)
 	})
 
@@ -146,12 +148,14 @@ func TestIngressEgress(t *testing.T) {
 
 		c := kubeclient.NewForTest(t)
 
-		frontendPods, err := c.PodsFromDeployment(ctx, ct.Namespace, "voting")
+		votingPods, err := c.PodsFromDeployment(ctx, ct.Namespace, "voting")
 		require.NoError(err)
-		require.Len(frontendPods, 1, "pod not found: %s/%s", ct.Namespace, "voting")
+		require.Len(votingPods, 1, "pod not found: %s/%s", ct.Namespace, "voting")
 
+		ctxForCurl, cancel := context.WithTimeout(ctx, 20*time.Second)
+		t.Cleanup(cancel)
 		argv := []string{"curl", "-fsS", net.JoinHostPort(c.FirstPodIP(ctx, t, ct.Namespace, "emoji"), "9901") + "/stats/prometheus"}
-		stdout, stderr, err := c.Exec(ctx, ct.Namespace, frontendPods[0].Name, argv)
+		stdout, stderr, err := c.ExecRetry(ctxForCurl, ct.Namespace, votingPods[0].Name, "voting-svc", argv, 5*time.Second)
 		require.NoError(err, "Expected Service Mesh admin interface to be reachable.\nstdout: %s\nstderr: %q", stdout, stderr)
 	})
 


### PR DESCRIPTION
Some commands passed to Exec, notably networked ones, may fail transiently. Adding a retry for each individual one would be a bit involved, hence we're adding a helper function ExecRetry to the kubeclient. The function is applied to all existing call sites of ExecContainer or Exec that

- depend on a remote system
- are not expected to fail

This should fix failures such as this one: https://github.com/edgelesssys/contrast/actions/runs/28822567861/job/85478255238#step:10:242.

- [x] [memdump test](https://github.com/edgelesssys/contrast/actions/runs/28853981477)
- [x] [policy test](https://github.com/edgelesssys/contrast/actions/runs/28854038934)