### PR TITLE
kuberesource: use common labeling strategy

### DIFF
--- a/e2e/imagestore/imagestore_test.go
+++ b/e2e/imagestore/imagestore_test.go
@@ -231,7 +231,6 @@ func TestMain(m *testing.M) {
 
 func testPod(name, annotation string) any {
 	return kuberesource.Pod(name, "").
-		WithLabels(map[string]string{"app.kubernetes.io/name": name}).
 		WithAnnotations(map[string]string{kuberesource.ImageStoreSizeAnnotationKey: annotation}).
 		WithSpec(
 			kuberesource.PodSpec().
@@ -258,7 +257,6 @@ func testPod(name, annotation string) any {
 
 func postgresPod() any {
 	return kuberesource.Pod("postgres", "").
-		WithLabels(map[string]string{"app.kubernetes.io/name": "postgres"}).
 		WithAnnotations(map[string]string{kuberesource.ImageStoreSizeAnnotationKey: "0"}).
 		WithSpec(
 			kuberesource.PodSpec().

--- a/internal/history/configmapstore/configmapstore.go
+++ b/internal/history/configmapstore/configmapstore.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -30,6 +29,11 @@ import (
 
 // timeout is the timeout for Kubernetes API calls.
 const timeout = 10 * time.Second
+
+const (
+	appName      = "kvstore"
+	appComponent = "coordinator"
+)
 
 // ConfigMapStore is a Store implementation backed by Kubernetes Config Maps.
 type ConfigMapStore struct {
@@ -159,7 +163,6 @@ func (s *ConfigMapStore) Watch(key string) (<-chan []byte, func(), error) {
 		return nil, nil, err
 	}
 	watcher, err := s.client.CoreV1().ConfigMaps(s.namespace).Watch(context.Background(), metav1.ListOptions{
-		LabelSelector: labels.Set(map[string]string{"app.kubernetes.io/managed-by": "contrast.edgeless.systems"}).AsSelector().String(),
 		FieldSelector: fields.OneTermEqualSelector("metadata.name", cmName).String(),
 	})
 	if err != nil {
@@ -246,11 +249,13 @@ func RecoverConfigMaps(manifests [][]byte, policies [][]byte, latestTransitionHa
 }
 
 func (s *ConfigMapStore) newEntry(cmName, key string, value []byte) *corev1.ConfigMap {
+	labels := kuberesource.ContrastLabels(appName, appComponent)
+	labels[kuberesource.KubernetesAppManagedByLabel] = "contrast.edgeless.systems"
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: s.namespace,
-			Labels:    map[string]string{"app.kubernetes.io/managed-by": "contrast.edgeless.systems"},
+			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "apps/v1",

--- a/internal/kuberesource/constants.go
+++ b/internal/kuberesource/constants.go
@@ -59,4 +59,17 @@ const (
 
 	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
 	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"
+
+	// Labels defined in https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/.
+
+	// KubernetesAppNameLabel is the name of the application.
+	KubernetesAppNameLabel = "app.kubernetes.io/name"
+	// KubernetesAppComponentLabel is the component within the architecture.
+	KubernetesAppComponentLabel = "app.kubernetes.io/component"
+	// KubernetesAppPartOfLabel is the name of a higher level application this one is part of.
+	KubernetesAppPartOfLabel = "app.kubernetes.io/part-of"
+	// KubernetesAppVersionLabel is the current version of the application.
+	KubernetesAppVersionLabel = "app.kubernetes.io/version"
+	// KubernetesAppManagedByLabel is the tool being used to manage the operation of an application.
+	KubernetesAppManagedByLabel = "app.kubernetes.io/managed-by"
 )

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -672,7 +672,7 @@ func HasNameLabel(targetName string) ResourceFilter {
 			return false
 		}
 
-		name, exists := meta.Labels["app.kubernetes.io/name"]
+		name, exists := meta.Labels[KubernetesAppNameLabel]
 		return exists && name == targetName
 	}
 }

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
 	appsv1 "k8s.io/api/apps/v1"
@@ -97,6 +98,7 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*applyappsv1.
 	}
 
 	name := fmt.Sprintf("%s-nodeinstaller", runtimeHandler)
+	const component = "runtime"
 
 	var nodeInstallerImageURL string
 	switch {
@@ -108,20 +110,20 @@ func NodeInstaller(namespace string, platform platforms.Platform) (*applyappsv1.
 		return nil, fmt.Errorf("unsupported platform %q", platform)
 	}
 
+	selector := SelectorLabels(name, component)
+	selector[ContrastRoleLabelKey] = string(manifest.RoleNodeInstaller)
+
 	d := DaemonSet(name, namespace).
-		WithLabels(map[string]string{"app.kubernetes.io/name": name}).
+		WithLabels(ContrastLabels(name, component)).
 		WithSpec(
 			DaemonSetSpec().
 				WithSelector(
 					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": name}),
+						WithMatchLabels(selector),
 				).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{
-							ContrastRoleLabelKey:     string(manifest.RoleNodeInstaller),
-							"app.kubernetes.io/name": name,
-						}).
+						WithLabels(selector).
 						WithSpec(
 							PodSpec().
 								WithHostPID(true).
@@ -252,7 +254,7 @@ func PortForwarder(name, namespace string) *PortForwarderConfig {
 	name = "port-forwarder-" + name
 
 	p := Pod(name, namespace).
-		WithLabels(map[string]string{"app.kubernetes.io/name": name}).
+		WithLabels(ContrastLabels(name, "test-resources")).
 		WithSpec(
 			PodSpec().
 				WithContainers(
@@ -294,24 +296,25 @@ type CoordinatorConfig struct {
 
 // Coordinator constructs a new CoordinatorConfig.
 func Coordinator(namespace string) *CoordinatorConfig {
+	labelSelector := SelectorLabels("coordinator", "coordinator")
+	labelSelector[ContrastRoleLabelKey] = string(manifest.RoleCoordinator)
+
 	c := StatefulSet("coordinator", namespace).
+		WithLabels(ContrastLabels("coordinator", "coordinator")).
 		WithSpec(
 			StatefulSetSpec().
 				WithReplicas(1).
 				WithServiceName("coordinator").
 				WithSelector(
 					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "coordinator"}),
+						WithMatchLabels(labelSelector),
 				).
 				WithPersistentVolumeClaimRetentionPolicy(applyappsv1.StatefulSetPersistentVolumeClaimRetentionPolicy().
 					WithWhenDeleted(appsv1.DeletePersistentVolumeClaimRetentionPolicyType).
 					WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)). // TODO(burgerdev): this should be RETAIN for released coordinators.
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{
-							"app.kubernetes.io/name": "coordinator",
-							ContrastRoleLabelKey:     string(manifest.RoleCoordinator),
-						}).
+						WithLabels(labelSelector).
 						WithSpec(
 							PodSpec().
 								WithServiceAccountName("coordinator").
@@ -645,7 +648,6 @@ func CollateralProxy(namespace, storageClassName string) []any {
 		stateDir = "/var/lib/collateral-proxy"
 		stateVol = "state"
 	)
-	labels := map[string]string{"app.kubernetes.io/name": name}
 
 	pvcSpec := applycorev1.PersistentVolumeClaimSpec().
 		WithAccessModes(corev1.ReadWriteOnce).
@@ -657,12 +659,13 @@ func CollateralProxy(namespace, storageClassName string) []any {
 
 	mem := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")}
 	statefulSet := StatefulSet(name, namespace).
+		WithLabels(ContrastLabels(name, name)).
 		WithSpec(StatefulSetSpec().
 			WithReplicas(1).
 			WithServiceName(name).
-			WithSelector(LabelSelector().WithMatchLabels(labels)).
+			WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, name))).
 			WithTemplate(PodTemplateSpec().
-				WithLabels(labels).
+				WithLabels(SelectorLabels(name, name)).
 				WithSpec(PodSpec().
 					WithContainers(applycorev1.Container().
 						WithName(name).
@@ -686,4 +689,27 @@ func CollateralProxy(namespace, storageClassName string) []any {
 				WithSpec(pvcSpec)))
 
 	return []any{statefulSet, ServiceForStatefulSet(statefulSet)}
+}
+
+// ContrastLabels should be applied to top-level resources.
+// In addition to name and component, it also labels part-of and version with compile-time constants.
+func ContrastLabels(name, component string) map[string]string {
+	// The version must be a label-safe semver: strip the leading "v", and assume
+	// no "+build" metadata, since '+' is invalid in a label value.
+	version, _ := strings.CutPrefix(constants.Version, "v")
+	return map[string]string{
+		KubernetesAppNameLabel:      name,
+		KubernetesAppComponentLabel: component,
+		KubernetesAppPartOfLabel:    "contrast",
+		KubernetesAppVersionLabel:   version,
+	}
+}
+
+// SelectorLabels should be used to construct pod selectors, for example in a Deployment.
+func SelectorLabels(name, component string) map[string]string {
+	return map[string]string{
+		KubernetesAppNameLabel:      name,
+		KubernetesAppComponentLabel: component,
+		KubernetesAppPartOfLabel:    "contrast",
+	}
 }

--- a/internal/kuberesource/sets.go
+++ b/internal/kuberesource/sets.go
@@ -64,10 +64,11 @@ func Runtime(platform platforms.Platform) ([]any, error) {
 func LogCollector() []any {
 	const (
 		name              = "log-collector"
+		component         = "test-resources"
 		priorityClassName = "high-priority-logcollector"
 	)
 
-	labels := map[string]string{"app.kubernetes.io/name": name}
+	labels := SelectorLabels(name, component)
 
 	tolerations := []*applycorev1.TolerationApplyConfiguration{
 		applycorev1.Toleration().
@@ -81,6 +82,7 @@ func LogCollector() []any {
 	}
 
 	ds := DaemonSet(name, "").
+		WithLabels(ContrastLabels(name, component)).
 		WithSpec(
 			DaemonSetSpec().
 				WithSelector(LabelSelector().WithMatchLabels(labels)).
@@ -138,18 +140,24 @@ func LogCollector() []any {
 
 // OpenSSL returns a set of resources for testing with OpenSSL.
 func OpenSSL() []any {
+	const (
+		backendName  = "openssl-backend"
+		frontendName = "openssl-frontend"
+		component    = "openssl"
+	)
 	ns := ""
-	backend := Deployment("openssl-backend", ns).
+	backend := Deployment(backendName, ns).
+		WithLabels(ContrastLabels(backendName, component)).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
 				WithSelector(
 					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "openssl-backend"}),
+						WithMatchLabels(SelectorLabels(backendName, component)),
 				).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "openssl-backend"}).
+						WithLabels(SelectorLabels(backendName, component)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -180,17 +188,18 @@ func OpenSSL() []any {
 
 	backendService := ServiceForDeployment(backend)
 
-	frontend := Deployment("openssl-frontend", ns).
+	frontend := Deployment(frontendName, ns).
+		WithLabels(ContrastLabels(frontendName, component)).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
 				WithSelector(
 					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "openssl-frontend"}),
+						WithMatchLabels(SelectorLabels(frontendName, component)),
 				).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "openssl-frontend"}).
+						WithLabels(SelectorLabels(frontendName, component)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -233,18 +242,20 @@ func OpenSSL() []any {
 
 // MultiCPU returns a deployment that requests 2 CPUs.
 func MultiCPU() []any {
+	const name = "multi-cpu"
 	return []any{
-		Deployment("multi-cpu", "").
+		Deployment(name, "").
+			WithLabels(ContrastLabels(name, name)).
 			WithSpec(
 				DeploymentSpec().
 					WithReplicas(1).
 					WithSelector(
 						LabelSelector().
-							WithMatchLabels(map[string]string{"app.kubernetes.io/name": "multi-cpu"}),
+							WithMatchLabels(SelectorLabels(name, name)),
 					).
 					WithTemplate(
 						PodTemplateSpec().
-							WithLabels(map[string]string{"app.kubernetes.io/name": "multi-cpu"}).
+							WithLabels(SelectorLabels(name, name)).
 							WithSpec(
 								PodSpec().
 									WithContainers(
@@ -272,6 +283,13 @@ func MultiCPU() []any {
 
 // Emojivoto returns resources for deploying Emojivoto application.
 func Emojivoto(smMode serviceMeshMode) []any {
+	const (
+		emojiName   = "emoji"
+		voteBotName = "vote-bot"
+		votingName  = "voting"
+		webName     = "web"
+	)
+
 	ns := ""
 	var emojiSvcImage, emojiVotingSvcImage, emojiWebImage, emojiWebVoteBotImage, emojiSvcHost, votingSvcHost, emojiWebSvcHost string
 	var memoryLimitMiB int64
@@ -301,31 +319,26 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		panic(fmt.Sprintf("unknown service mesh mode: %s", smMode))
 	}
 
-	emoji := Deployment("emoji", ns).
-		WithLabels(map[string]string{
-			"app.kubernetes.io/name":    "emoji",
-			"app.kubernetes.io/part-of": "emojivoto",
+	labels := func(name string) map[string]string {
+		return map[string]string{
+			KubernetesAppNameLabel:      name,
+			KubernetesAppPartOfLabel:    "emojivoto",
 			"app.kubernetes.io/version": "v11",
-		}).
+		}
+	}
+
+	emoji := Deployment(emojiName, ns).
+		WithLabels(labels(emojiName)).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{
-							"app.kubernetes.io/name": "emoji-svc",
-							"version":                "v11",
-						}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(labels(emojiName))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{
-							"app.kubernetes.io/name": "emoji-svc",
-							"version":                "v11",
-						}).
+						WithLabels(labels(emojiName)).
 						WithSpec(
 							PodSpec().
-								WithServiceAccountName("emoji").
+								WithServiceAccountName(emojiName).
 								WithContainers(
 									Container().
 										WithName("emoji-svc").
@@ -360,9 +373,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		WithName("emoji-svc").
 		WithSpec(
 			ServiceSpec().
-				WithSelector(
-					map[string]string{"app.kubernetes.io/name": "emoji-svc"},
-				).
+				WithSelector(labels(emojiName)).
 				WithPorts(
 					ServicePort().
 						WithName("grpc").
@@ -375,32 +386,19 @@ func Emojivoto(smMode serviceMeshMode) []any {
 				),
 		)
 
-	emojiserviceAccount := ServiceAccount("emoji", ns).
+	emojiserviceAccount := ServiceAccount(emojiName, ns).
 		WithAPIVersion("v1").
 		WithKind("ServiceAccount")
 
-	voteBot := Deployment("vote-bot", ns).
-		WithLabels(map[string]string{
-			"app.kubernetes.io/name":    "vote-bot",
-			"app.kubernetes.io/part-of": "emojivoto",
-			"app.kubernetes.io/version": "v11",
-		}).
+	voteBot := Deployment(voteBotName, ns).
+		WithLabels(labels(voteBotName)).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{
-							"app.kubernetes.io/name": "vote-bot",
-							"version":                "v11",
-						}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(labels(voteBotName))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{
-							"app.kubernetes.io/name": "vote-bot",
-							"version":                "v11",
-						}).
+						WithLabels(labels(voteBotName)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -421,31 +419,18 @@ func Emojivoto(smMode serviceMeshMode) []any {
 				),
 		)
 
-	voting := Deployment("voting", ns).
-		WithLabels(map[string]string{
-			"app.kubernetes.io/name":    "voting",
-			"app.kubernetes.io/part-of": "emojivoto",
-			"app.kubernetes.io/version": "v11",
-		}).
+	voting := Deployment(votingName, ns).
+		WithLabels(labels(votingName)).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{
-							"app.kubernetes.io/name": "voting-svc",
-							"version":                "v11",
-						}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(labels(votingName))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{
-							"app.kubernetes.io/name": "voting-svc",
-							"version":                "v11",
-						}).
+						WithLabels(labels(votingName)).
 						WithSpec(
 							PodSpec().
-								WithServiceAccountName("voting").
+								WithServiceAccountName(votingName).
 								WithContainers(
 									Container().
 										WithName("voting-svc").
@@ -480,9 +465,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		WithName("voting-svc").
 		WithSpec(
 			ServiceSpec().
-				WithSelector(
-					map[string]string{"app.kubernetes.io/name": "voting-svc"},
-				).
+				WithSelector(labels(votingName)).
 				WithPorts(
 					ServicePort().
 						WithName("grpc").
@@ -495,35 +478,22 @@ func Emojivoto(smMode serviceMeshMode) []any {
 				),
 		)
 
-	votingserviceAccount := ServiceAccount("voting", ns).
+	votingserviceAccount := ServiceAccount(votingName, ns).
 		WithAPIVersion("v1").
 		WithKind("ServiceAccount")
 
-	web := Deployment("web", ns).
-		WithLabels(map[string]string{
-			"app.kubernetes.io/name":    "web",
-			"app.kubernetes.io/part-of": "emojivoto",
-			"app.kubernetes.io/version": "v11",
-		}).
+	web := Deployment(webName, ns).
+		WithLabels(labels(webName)).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{
-							"app.kubernetes.io/name": "web-svc",
-							"version":                "v11",
-						}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(labels(webName))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{
-							"app.kubernetes.io/name": "web-svc",
-							"version":                "v11",
-						}).
+						WithLabels(labels(webName)).
 						WithSpec(
 							PodSpec().
-								WithServiceAccountName("web").
+								WithServiceAccountName(webName).
 								WithContainers(
 									Container().
 										WithName("web-svc").
@@ -561,9 +531,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 		WithAnnotations(map[string]string{ExposeServiceAnnotationKey: "true"}).
 		WithSpec(
 			ServiceSpec().
-				WithSelector(
-					map[string]string{"app.kubernetes.io/name": "web-svc"},
-				).
+				WithSelector(labels(webName)).
 				WithType("ClusterIP").
 				WithPorts(
 					ServicePort().
@@ -573,7 +541,7 @@ func Emojivoto(smMode serviceMeshMode) []any {
 				),
 		)
 
-	webserviceAccount := ServiceAccount("web", ns).
+	webserviceAccount := ServiceAccount(webName, ns).
 		WithAPIVersion("v1").
 		WithKind("ServiceAccount")
 
@@ -628,21 +596,19 @@ func Emojivoto(smMode serviceMeshMode) []any {
 // VolumeStatefulSet returns a stateful set for testing volume mounts and the
 // mounting of encrypted luks volumes using the workload-secret.
 func VolumeStatefulSet() []any {
-	vss := StatefulSet("volume-tester", "").
+	const name = "volume-tester"
+	vss := StatefulSet(name, "").
 		WithSpec(
 			StatefulSetSpec().
 				WithPersistentVolumeClaimRetentionPolicy(applyappsv1.StatefulSetPersistentVolumeClaimRetentionPolicy().
 					WithWhenDeleted(appsv1.DeletePersistentVolumeClaimRetentionPolicyType).
 					WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)).
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "volume-tester"}),
-				).
-				WithServiceName("volume-tester").
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, name))).
+				WithServiceName(name).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "volume-tester"}).
+						WithLabels(SelectorLabels(name, name)).
 						WithAnnotations(map[string]string{SecurePVAnnotationKey: "state:share"}).
 						WithSpec(
 							PodSpec().
@@ -689,6 +655,11 @@ func VolumeStatefulSet() []any {
 // MySQL returns the resources for deploying a MySQL database
 // with an encrypted luks volume using the workload-secret.
 func MySQL() []any {
+	const (
+		backendName = "mysql-backend"
+		clientName  = "mysql-client"
+		component   = "mysql"
+	)
 	backend := StatefulSet("mysql-backend", "").
 		WithSpec(
 			StatefulSetSpec().
@@ -696,14 +667,11 @@ func MySQL() []any {
 					WithWhenDeleted(appsv1.DeletePersistentVolumeClaimRetentionPolicyType).
 					WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)).
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "mysql-backend"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(backendName, component))).
 				WithServiceName("mysql-backend").
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "mysql-backend"}).
+						WithLabels(SelectorLabels(backendName, component)).
 						WithAnnotations(map[string]string{
 							SmIngressConfigAnnotationKey: "",
 							SecurePVAnnotationKey:        "state:share",
@@ -768,17 +736,14 @@ while true; do
 done
 `
 
-	client := Deployment("mysql-client", "").
+	client := Deployment(clientName, "").
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "mysql-client"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(clientName, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "mysql-client"}).
+						WithLabels(SelectorLabels(clientName, component)).
 						WithAnnotations(map[string]string{SmEgressConfigAnnotationKey: "mysql-backend#127.137.0.1:3306#mysql-backend:3306"}).
 						WithSpec(
 							PodSpec().
@@ -809,17 +774,15 @@ done
 // gpuClass must be a vendor/class pair, like nvidia.com/GB100_B200.
 // gpuQuantity is the number of GPUs.
 func GPU(name string, gpuClass string, gpuQuantity int64) []any {
+	component := "gpu-test"
 	tester := Deployment(name, "").
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": name}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": name}).
+						WithLabels(SelectorLabels(name, component)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -889,6 +852,10 @@ func GPU(name string, gpuClass string, gpuQuantity int64) []any {
 // Vault returns the resources for deploying a user managed vault.
 func Vault(namespace string) []any {
 	const (
+		serverName = "vault"
+		clientName = "vault-client"
+		component  = "vault"
+
 		vaultImage = "quay.io/openbao/openbao:2.5.2@sha256:6c75c97223873807260352f269640935a07db0c26b3dbf12a98a36ec43ad9878"
 
 		vaultServerEntrypoint = `set -e
@@ -930,21 +897,18 @@ seal "transit" {
 `
 	)
 
-	vaultSfSets := StatefulSet("vault", namespace).
+	vaultSfSets := StatefulSet(serverName, namespace).
 		WithSpec(
 			StatefulSetSpec().
 				WithPersistentVolumeClaimRetentionPolicy(applyappsv1.StatefulSetPersistentVolumeClaimRetentionPolicy().
 					WithWhenDeleted(appsv1.DeletePersistentVolumeClaimRetentionPolicyType).
 					WithWhenScaled(appsv1.DeletePersistentVolumeClaimRetentionPolicyType)).
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "vault"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(serverName, component))).
 				WithServiceName("vault").
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "vault"}).
+						WithLabels(SelectorLabels(serverName, component)).
 						WithAnnotations(map[string]string{
 							WorkloadSecretIDAnnotationKey: "vault_unsealing",
 							SecurePVAnnotationKey:         "state:share",
@@ -1027,17 +991,14 @@ seal "transit" {
 		},
 	)
 
-	client := Deployment("vault-client", namespace).
+	client := Deployment(clientName, namespace).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "vault-client"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(clientName, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "vault-client"}).
+						WithLabels(SelectorLabels(clientName, component)).
 						WithSpec(
 							PodSpec().
 								WithVolumes(
@@ -1083,18 +1044,20 @@ seal "transit" {
 
 // MemDump returns the resources for the memdump test.
 func MemDump() []any {
+	const (
+		listenerName = "listener"
+		senderName   = "sender"
+		component    = "memdump"
+	)
 	ns := ""
-	listener := Deployment("listener", ns).
+	listener := Deployment(listenerName, ns).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "listener"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(listenerName, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "listener"}).
+						WithLabels(SelectorLabels(listenerName, component)).
 						WithAnnotations(map[string]string{
 							SmIngressConfigAnnotationKey: "netcat#8000#false",
 						}).
@@ -1130,17 +1093,14 @@ func MemDump() []any {
 
 	listenerService := ServiceForDeployment(listener)
 
-	sender := Deployment("sender", ns).
+	sender := Deployment(senderName, ns).
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "sender"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(senderName, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "sender"}).
+						WithLabels(SelectorLabels(senderName, component)).
 						WithAnnotations(map[string]string{
 							SmEgressConfigAnnotationKey: "netcat#127.137.0.1:8000#listener:8000",
 						}).
@@ -1171,17 +1131,18 @@ func MemDump() []any {
 
 // MemDumpTester returns the non-cc resources for the memdump test.
 func MemDumpTester() []any {
-	memdump := Deployment("memdump", "").
+	const (
+		name      = "memdump"
+		component = "memdump"
+	)
+	memdump := Deployment(name, "").
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "memdump"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "memdump"}).
+						WithLabels(SelectorLabels(name, component)).
 						WithSpec(
 							PodSpec().
 								WithHostPID(true).
@@ -1213,17 +1174,15 @@ func MemDumpTester() []any {
 
 // AuthenticatedPullTester returns the resources for the imagepuller-auth test.
 func AuthenticatedPullTester(name string) any {
+	const component = "imagepuller-auth-test"
 	deployment := Deployment(name, "").
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": name}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": name}).
+						WithLabels(SelectorLabels(name, component)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -1245,18 +1204,16 @@ func AuthenticatedPullTester(name string) any {
 
 // Containerd11644ReproducerTesters returns the resources for the reproducer test for containerd issue #11644.
 func Containerd11644ReproducerTesters(name string) (*applyappsv1.DeploymentApplyConfiguration, *applyappsv1.DeploymentApplyConfiguration) {
+	const component = "containerd-11644-reproducer"
 	runcName := fmt.Sprintf("%s-runc", name)
 	runc := Deployment(runcName, "").
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": runcName}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(runcName, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": runcName}).
+						WithLabels(SelectorLabels(runcName, component)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -1278,13 +1235,10 @@ func Containerd11644ReproducerTesters(name string) (*applyappsv1.DeploymentApply
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": ccName}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(ccName, component))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": ccName}).
+						WithLabels(SelectorLabels(ccName, component)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -1306,17 +1260,15 @@ func Containerd11644ReproducerTesters(name string) (*applyappsv1.DeploymentApply
 
 // IPSec returns the resources for testing IPSec tunnels with strongSwan.
 func IPSec() []any {
-	deploy := Deployment("ipsec", "").
+	const name = "ipsec"
+	deploy := Deployment(name, "").
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(2).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": "ipsec"}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, name))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": "ipsec"}).
+						WithLabels(SelectorLabels(name, name)).
 						WithSpec(
 							PodSpec().
 								WithContainers(
@@ -1342,13 +1294,10 @@ func DeploymentWithRuntimeClass(name, runtimeClassName string) any {
 		WithSpec(
 			DeploymentSpec().
 				WithReplicas(1).
-				WithSelector(
-					LabelSelector().
-						WithMatchLabels(map[string]string{"app.kubernetes.io/name": name}),
-				).
+				WithSelector(LabelSelector().WithMatchLabels(SelectorLabels(name, name))).
 				WithTemplate(
 					PodTemplateSpec().
-						WithLabels(map[string]string{"app.kubernetes.io/name": name}).
+						WithLabels(SelectorLabels(name, name)).
 						WithSpec(
 							PodSpec().
 								WithContainers(

--- a/justfile
+++ b/justfile
@@ -423,10 +423,10 @@ wait-for-workload target=default_deploy_target set=default_set:
             nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns openssl-frontend
         ;;
         "emojivoto" | "emojivoto-sm-ingress")
-            nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns emoji-svc
+            nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns emoji
             nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns vote-bot
-            nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns voting-svc
-            nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns web-svc
+            nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns voting
+            nix run -L .#{{ set }}.scripts.kubectl-wait-ready -- $ns web
         ;;
         "volume-stateful-set")
             nix run .#{{ set }}.scripts.kubectl-wait-ready -- $ns volume-tester


### PR DESCRIPTION
This PR centralizes the definition of labels and label selectors, which used to be ad-hoc. As a result, labels for individual API resources may differ after this change, but the labels should at least be consistent. 