### PR TITLE
coordinator: remove ownerreference from configmaps

### DIFF
--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -113,10 +113,7 @@ func run() (retErr error) {
 	promRegistry := prometheus.NewRegistry()
 	serverMetrics := newServerMetrics(promRegistry)
 
-	store, err := configmapstore.New(clientset, string(namespace), logger.WithGroup("history-store"))
-	if err != nil {
-		return fmt.Errorf("creating history store: %w", err)
-	}
+	store := configmapstore.New(clientset, string(namespace), logger.WithGroup("history-store"))
 
 	hist := history.NewWithStore(logger.WithGroup("history"), store)
 

--- a/docs/docs/architecture/components/coordinator.md
+++ b/docs/docs/architecture/components/coordinator.md
@@ -27,13 +27,13 @@ For example, a manifest with hash `a591a6d40bf420404a011733cfb7b190d62c65bf0bcda
 Starting from the signed latest manifest, the Coordinator retrieves all referenced content by hash and verifies that the content hashes match.
 The entire manifest history thus forms a Merkle tree, chaining back to the signed latest manifest.
 
-The `ConfigMap`s used to store manifests and initdata documents are owned by the Contrast Coordinator `StatefulSet`.
-When that resource is removed from the cluster, the history will be removed with it.
-If you need to clear the history without removing the Coordinator, you can do so with the following command:
+If you need to manually clear the Coordinator's history, you can do so with the following command:
 
 ```sh
 kubectl delete configmap --selector app.kubernetes.io/managed-by=contrast.edgeless.systems
 ```
+
+Restart the Coordinator afterward to start with a fresh history.
 
 ## State
 

--- a/docs/docs/howto/incident-response.md
+++ b/docs/docs/howto/incident-response.md
@@ -56,8 +56,13 @@ In this scenario, you assume that the Contrast Coordinator has a vulnerability a
 The Coordinator has access to all Contrast secrets, by design, which implies that all secrets need to be assumed compromised, too.
 
 Since the existing secrets can't be trusted anymore, the only remediation is to create an entirely new Coordinator.
-For that, first delete the existing Coordinator `StatefulSet`.
-This should automatically clear the Coordinator's state in cluster `ConfigMaps`.
+For that, first delete the existing Coordinator `StatefulSet` and its `ConfigMap` store.
+
+```sh
+kubectl delete statefulset coordinator
+kubectl delete configmap --selector app.kubernetes.io/managed-by=contrast.edgeless.systems
+```
+
 Then, apply the new Coordinator from the release containing the fix and set it up with a manifest.
 
 Naturally, the new Coordinator shouldn't be configured with a manifest that would allow a vulnerable Coordinator.

--- a/docs/docs/howto/workload-deployment/recover-coordinator.md
+++ b/docs/docs/howto/workload-deployment/recover-coordinator.md
@@ -44,7 +44,7 @@ All workloads should be restarted after the recovery succeeded.
 
 The Coordinator uses a key-value store backed by Kubernetes ConfigMaps to store the manifest history and policy information.
 This key-value store is what allows the Coordinator to recover after a restart.
-If the Coordinator StatefulSet is deleted, for example if the entire namespace is deleted, the ConfigMap store is lost and normal recovery isn't possible.
+If these ConfigMaps are deleted, for example if the entire namespace is deleted, the ConfigMap store is lost and normal recovery isn't possible.
 In order to recover the Coordinator state in this case, you can use the manifest history obtained by a previous `contrast verify` once the Coordinator is reapplied.
 
 ```sh

--- a/e2e/coordinator/coordinator_test.go
+++ b/e2e/coordinator/coordinator_test.go
@@ -22,12 +22,15 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
+	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
 	"github.com/edgelesssys/contrast/internal/httpapi"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/sdk"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestCoordinator(t *testing.T) {
@@ -53,16 +56,17 @@ func TestCoordinator(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
 		t.Cleanup(cancel)
 
-		unstructured, err := kuberesource.ResourcesToUnstructured(resources)
-		require.NoError(err)
-
-		// Delete whole statefulset so the owned configmap store is also deleted.
-		require.NoError(ct.Kubeclient.Delete(ctx, unstructured...))
-		// Wait until all objects are deleted before applying the resources again,
-		// otherwise some resources may be deleted after being reapplied.
-		require.NoError(ct.Kubeclient.WaitForDeletion(ctx, unstructured...))
-		require.True(t.Run("apply resources after deleting them", ct.Apply), "Kubernetes resources need to be applied for subsequent tests")
-
+		// Delete the Coordinator history.
+		// This is the documented procedure, if changes are needed here make sure to reflect that
+		// in the docs.
+		deleteOpts := metav1.DeleteOptions{
+			PropagationPolicy: toPtr(metav1.DeletePropagationForeground),
+		}
+		listOpts := metav1.ListOptions{
+			LabelSelector: labels.Set(map[string]string{kuberesource.KubernetesAppManagedByLabel: "contrast.edgeless.systems"}).AsSelector().String(),
+		}
+		require.NoError(ct.Kubeclient.Client.CoreV1().ConfigMaps(ct.Namespace).DeleteCollection(ctx, deleteOpts, listOpts))
+		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
 		require.NoError(ct.Kubeclient.WaitForCoordinator(ctx, ct.Namespace))
 
 		require.ErrorContains(ct.RunRecover(ctx), "no state to recover from")
@@ -233,6 +237,10 @@ func TestCoordinator(t *testing.T) {
 		require.Error(err)
 		require.Nil(state)
 	})
+}
+
+func toPtr[A any](a A) *A {
+	return &a
 }
 
 func TestMain(m *testing.M) {

--- a/internal/history/configmapstore/configmapstore.go
+++ b/internal/history/configmapstore/configmapstore.go
@@ -95,7 +95,7 @@ func (s *ConfigMapStore) Set(key string, value []byte) error {
 		return err
 	}
 	if errors.IsNotFound(err) {
-		cm = s.newEntry(cmName, key, value)
+		cm = newEntry(s.namespace, cmName, key, value)
 		_, err := s.client.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{})
 		return err
 	}
@@ -119,7 +119,7 @@ func (s *ConfigMapStore) CompareAndSwap(key string, oldVal, newVal []byte) error
 	}
 	// Treat non-existing config map as empty to allow initial set.
 	if errors.IsNotFound(err) {
-		cm = s.newEntry(cmName, key, newVal)
+		cm = newEntry(s.namespace, cmName, key, newVal)
 		_, err := s.client.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{})
 		return err
 	}
@@ -195,7 +195,7 @@ func RecoverConfigMaps(manifests [][]byte, policies [][]byte, latestTransitionHa
 		if err != nil {
 			return err
 		}
-		hist = append(hist, kuberesource.ConfigMap(cmName, "").WithBinaryData(map[string][]byte{hashStr: content}))
+		hist = append(hist, newEntry("", cmName, hashStr, content))
 		return nil
 	}
 	for _, m := range manifests {
@@ -223,17 +223,21 @@ func RecoverConfigMaps(manifests [][]byte, policies [][]byte, latestTransitionHa
 	if err != nil {
 		return nil, fmt.Errorf("creating config map for latest transition: %w", err)
 	}
-	cm := kuberesource.ConfigMap(cmName, "").WithBinaryData(map[string][]byte{"latest": latest.MarshalBinary()})
+	cm := newEntry("", cmName, "latest", latest.MarshalBinary())
 	return append(hist, cm), nil
 }
 
-func (s *ConfigMapStore) newEntry(cmName, key string, value []byte) *corev1.ConfigMap {
+func newEntry(namespace, cmName, key string, value []byte) *corev1.ConfigMap {
 	labels := kuberesource.ContrastLabels(appName, appComponent)
 	labels[kuberesource.KubernetesAppManagedByLabel] = "contrast.edgeless.systems"
 	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
-			Namespace: s.namespace,
+			Namespace: namespace,
 			Labels:    labels,
 		},
 		BinaryData: map[string][]byte{filepath.Base(key): value},

--- a/internal/history/configmapstore/configmapstore.go
+++ b/internal/history/configmapstore/configmapstore.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
@@ -39,35 +37,16 @@ const (
 type ConfigMapStore struct {
 	client    kubernetes.Interface
 	namespace string
-	uid       types.UID
 	logger    *slog.Logger
 }
 
 // New creates a new [ConfigMapStore] instance with the given Kubernetes client.
-func New(client kubernetes.Interface, namespace string, log *slog.Logger) (*ConfigMapStore, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	self, err := client.CoreV1().Pods(namespace).Get(ctx, os.Getenv("HOSTNAME"), metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	ownerRefs := self.GetOwnerReferences()
-	var statefulset metav1.OwnerReference
-	for _, ownerRef := range ownerRefs {
-		if ownerRef.Kind == "StatefulSet" && ownerRef.Name == "coordinator" {
-			statefulset = ownerRef
-			break
-		}
-	}
-	if statefulset.UID == "" {
-		return nil, fmt.Errorf("coordinator statefulset not found")
-	}
+func New(client kubernetes.Interface, namespace string, log *slog.Logger) *ConfigMapStore {
 	return &ConfigMapStore{
 		client:    client,
-		namespace: self.Namespace,
-		uid:       statefulset.UID,
+		namespace: namespace,
 		logger:    log,
-	}, nil
+	}
 }
 
 // Get the value for key.
@@ -256,14 +235,6 @@ func (s *ConfigMapStore) newEntry(cmName, key string, value []byte) *corev1.Conf
 			Name:      cmName,
 			Namespace: s.namespace,
 			Labels:    labels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "apps/v1",
-					Kind:       "StatefulSet",
-					Name:       "coordinator",
-					UID:        s.uid,
-				},
-			},
 		},
 		BinaryData: map[string][]byte{filepath.Base(key): value},
 	}

--- a/internal/history/configmapstore/configmapstore_test.go
+++ b/internal/history/configmapstore/configmapstore_test.go
@@ -10,38 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
-
-func coordinatorPod() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "coordinator-0",
-			Namespace: "test",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind: "StatefulSet",
-					Name: "coordinator",
-					UID:  "00000000-0000-0000-0000-000000000000",
-				},
-			},
-		},
-	}
-}
 
 func TestGetSet(t *testing.T) {
 	require := require.New(t)
 
-	t.Setenv("HOSTNAME", "coordinator-0")
-	s, err := New(fake.NewClientset(coordinatorPod()), "test", slog.Default())
-	require.NoError(err)
+	s := New(fake.NewClientset(), "test", slog.Default())
 
 	key := "foo/bar"
 	val1 := []byte("val1")
 	val2 := []byte("val2")
 
-	_, err = s.Get("invalid-key")
+	_, err := s.Get("invalid-key")
 	require.ErrorContains(err, "invalid key")
 
 	x, err := s.Get(key)
@@ -66,9 +47,7 @@ func TestGetSet(t *testing.T) {
 func TestHas(t *testing.T) {
 	require := require.New(t)
 
-	t.Setenv("HOSTNAME", "coordinator-0")
-	s, err := New(fake.NewClientset(coordinatorPod()), "test", slog.Default())
-	require.NoError(err)
+	s := New(fake.NewClientset(), "test", slog.Default())
 
 	key := "foo/bar"
 	val := []byte("val")
@@ -83,9 +62,7 @@ func TestHas(t *testing.T) {
 func TestCompareAndSwap(t *testing.T) {
 	require := require.New(t)
 
-	t.Setenv("HOSTNAME", "coordinator-0")
-	s, err := New(fake.NewClientset(coordinatorPod()), "test", slog.Default())
-	require.NoError(err)
+	s := New(fake.NewClientset(), "test", slog.Default())
 
 	key := "foo/bar"
 	val1 := []byte("val1")
@@ -116,15 +93,13 @@ func TestCompareAndSwap(t *testing.T) {
 func TestWatch(t *testing.T) {
 	require := require.New(t)
 
-	t.Setenv("HOSTNAME", "coordinator-0")
-	s, err := New(fake.NewClientset(coordinatorPod()), "test", slog.Default())
-	require.NoError(err)
+	s := New(fake.NewClientset(), "test", slog.Default())
 
 	key := "foo/bar"
 	val1 := []byte("val1")
 	val2 := []byte("val2")
 
-	_, _, err = s.Watch("invalid-key")
+	_, _, err := s.Watch("invalid-key")
 	require.ErrorContains(err, "invalid key")
 
 	ch, cancel, err := s.Watch(key)

--- a/internal/history/configmapstore/configmapstore_test.go
+++ b/internal/history/configmapstore/configmapstore_test.go
@@ -5,8 +5,10 @@ package configmapstore
 
 import (
 	"log/slog"
+	"regexp"
 	"testing"
 
+	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -150,4 +152,31 @@ func TestObjectName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRecoverConfigMaps(t *testing.T) {
+	require := require.New(t)
+	manifests := [][]byte{{}}
+	policies := [][]byte{{}}
+
+	cms, err := RecoverConfigMaps(manifests, policies, make([]byte, 32), make([]byte, 64))
+	require.NoError(err)
+	// A policy, a manifest, a transition and a latest transition.
+	require.Len(cms, 4)
+
+	configmapNamesRE := regexp.MustCompile("^contrast-store-((policies|manifests|transitions)-[0-9a-f]{64}|transitions-latest)$")
+
+	for _, a := range cms {
+		cm, ok := a.(*corev1.ConfigMap)
+		require.Truef(ok, "unexpected configmap type: %T", a)
+		require.Regexp(configmapNamesRE, cm.GetName())
+		require.Contains(cm.GetLabels(), kuberesource.KubernetesAppManagedByLabel)
+	}
+
+	// Ensure that the resources are fully specified, including TypeMeta.
+	encoded, err := kuberesource.EncodeResources(cms...)
+	require.NoError(err)
+	decoded, err := kuberesource.UnmarshalApplyConfigurations(encoded)
+	require.NoError(err)
+	require.Len(decoded, len(cms))
 }


### PR DESCRIPTION
The `ConfigMap`s  used to store Coordiantor history are not owned by the Coordinator `StatefulSet` anymore. Cleaning them up now requires manual deletion, but the ConfigMaps can now be used by more than one Coordinator set and restored `ConfigMap`s are consistent with the ones created by the Coordinator. 

Fixes CON-208.
Fixes CON-220.
Fixes CON-205.