### PR TITLE
cli/generate: normalize image ref before accessing layers cache

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -36,6 +36,7 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 
+	"github.com/distribution/reference"
 	"github.com/spf13/cobra"
 )
 
@@ -522,9 +523,13 @@ func calculatePodMemory(spec *applycorev1.PodSpecApplyConfiguration, podLayers *
 	}
 	podMemory := max(containerMemory, initContainerMemory)
 	for _, image := range images {
-		index, ok := podLayers.Index[image]
+		imageRef, err := reference.ParseNormalizedNamed(image)
+		if err != nil {
+			return 0, fmt.Errorf("parsing image reference %s: %w", image, err)
+		}
+		index, ok := podLayers.Index[imageRef.String()]
 		if !ok {
-			return 0, fmt.Errorf("no layer information for image %s", image)
+			return 0, fmt.Errorf("no layer information for image %s", imageRef.String())
 		}
 		for _, layer := range index.Layers {
 			podMemory += int64(layer.CompressedSize)

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -183,7 +183,7 @@ func getHandler(t *testing.T, name string) string {
 func TestCalculatePodMemory(t *testing.T) {
 	layersCache := &genpolicy.LayersCache{
 		Index: map[string]genpolicy.ImageLayerIndex{
-			"some-image": {
+			"docker.io/library/some-image": {
 				ImageRef: "some-image",
 				Layers: []genpolicy.ImageLayerIndexEntry{
 					{
@@ -192,7 +192,7 @@ func TestCalculatePodMemory(t *testing.T) {
 					},
 				},
 			},
-			"other-image": {
+			"ghcr.io/other/image": {
 				ImageRef: "other-image",
 				Layers: []genpolicy.ImageLayerIndexEntry{
 					{
@@ -248,7 +248,7 @@ func TestCalculatePodMemory(t *testing.T) {
 							kuberesource.Container().
 								WithImage("some-image"),
 							kuberesource.Container().
-								WithImage("other-image"),
+								WithImage("ghcr.io/other/image"),
 						),
 				),
 			want: 70,

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/containerd/ttrpc v1.2.8
 	github.com/coreos/go-iptables v0.8.0
 	github.com/coreos/go-systemd/v22 v22.7.0
+	github.com/distribution/reference v0.6.0
 	github.com/elazarl/goproxy v1.8.2
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/google/go-containerregistry v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/edgelesssys/go-sev-guest v0.0.0-20260625102846-50db367a5686 h1:otyw8ZDXu+rjayooly5LrgDru6PXjJQ8xzXe3x8reWA=
 github.com/edgelesssys/go-sev-guest v0.0.0-20260625102846-50db367a5686/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/edgelesssys/go-tdx-guest v0.0.0-20260625102850-ea481d3db249 h1:Tx0olMH9+rqQgXfX8dIzIDN8UadjSJeTev6t4Qcx+J8=

--- a/packages/by-name/contrast/contrast/package.nix
+++ b/packages/by-name/contrast/contrast/package.nix
@@ -53,7 +53,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-oDF9b7wh34DCn52VqYEQ16ytLRFWVXjMRV0V7UfrNUA=";
+  vendorHash = "sha256-ELjY1RHnfTiulialUivs2171jj7zw/81gLF/9nTC15k=";
 
   subPackages = packageOutputs;
 


### PR DESCRIPTION
Genpolicy stores the normalized image reference in the layers cache, converting shortnames like "busybox" into "docker.io/library/busybox". Normalizing these on our side as well avoids mismatches when accessing the layers cache when calculating pod memory.

The `--calculate-pod-memory` flag should therefore now also work for short names.

Fixes CON-216