### PR TITLE
go: 1.26.4 -> 1.26.5

### DIFF
--- a/overlays/nixpkgs.nix
+++ b/overlays/nixpkgs.nix
@@ -15,10 +15,10 @@ final: prev:
 
   go_1_26 = prev.go_1_26.overrideAttrs (
     finalAttrs: _prevAttrs: {
-      version = "1.26.4";
+      version = "1.26.5";
       src = final.fetchurl {
         url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-        hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+        hash = "sha256-SVvkvIcXasVnOS5bQRar2YRm0z17SdQedkzMaXay3EI=";
       };
     }
   );


### PR DESCRIPTION
How do we keep having to bump this *right after* nixpkgs catches up with our used version 😆 