### PR TITLE
attestation: improve error messages on failed validation

### DIFF
--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -263,7 +263,7 @@ func verifyEmbeddedReport(ctx context.Context, validator validators.Validator, c
 		}
 		// Otherwise, we'll keep track of the error and continue with the next validator.
 		foundMatchingValidator = true
-		retErr = errors.Join(retErr, fmt.Errorf(" validator %s failed: %w", validatorName(validator), validationErr))
+		retErr = errors.Join(retErr, fmt.Errorf(" validator %s failed: %w", validator.String(), validationErr))
 	}
 
 	if !foundExtension {
@@ -494,11 +494,4 @@ func getNonce(chi *tls.ClientHelloInfo) ([]byte, error) {
 // Getter returns an ASN.1 Object Identifier.
 type Getter interface {
 	OID() asn1.ObjectIdentifier
-}
-
-func validatorName(v any) string {
-	if s, ok := v.(fmt.Stringer); ok {
-		return s.String()
-	}
-	return fmt.Sprintf("%T", v)
 }

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -183,6 +183,10 @@ func (c *contextValidator) Validate(ctx context.Context, _ asn1.ObjectIdentifier
 	}
 }
 
+func (c *contextValidator) String() string {
+	return "contextValidator"
+}
+
 // TestContextPassdown ensures that the context argument of verifyEmbeddedReport is properly passed down to the validators.
 func TestContextPassdown(t *testing.T) {
 	validator := &contextValidator{make(chan error)}

--- a/internal/atls/validators/validators.go
+++ b/internal/atls/validators/validators.go
@@ -9,6 +9,7 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // ErrOIDNotSupported is returned by a validator when it doesn't understand the OID provided as input.
@@ -16,7 +17,7 @@ var ErrOIDNotSupported = errors.New("OID not supported")
 
 // Validator is able to validate an attestation document.
 //
-// Validators are encouraged to implement the fmt.Stringer interface to improve logging.
+// Validators are required to implement the fmt.Stringer interface to improve logging.
 type Validator interface {
 	// Validate validates an attestation doc and returns an error if validation failed.
 	//
@@ -26,6 +27,8 @@ type Validator interface {
 	// If validation passes, the validator guarantees that the given reportData was present in the
 	// attestation document.
 	Validate(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error
+
+	fmt.Stringer
 }
 
 // ValidatorFunc creates a validator from a func.
@@ -36,32 +39,76 @@ func (f ValidatorFunc) Validate(ctx context.Context, oid asn1.ObjectIdentifier, 
 	return f(ctx, oid, attDoc, reportData)
 }
 
+func (f ValidatorFunc) String() string {
+	return "ValidatorFunc"
+}
+
+type anyOf struct {
+	vs []Validator
+}
+
+func (a *anyOf) Validate(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+	interestingErrors := make([]error, 0, len(a.vs))
+	for i, v := range a.vs {
+		err := v.Validate(ctx, oid, attDoc, reportData)
+		if err == nil {
+			return nil
+		}
+		// A bunch of "unsupported" errors would clutter the output, only add the interesting ones.
+		if !errors.Is(err, ErrOIDNotSupported) {
+			interestingErrors = append(interestingErrors, fmt.Errorf("sub-validator %d: %w", i, err))
+		}
+	}
+	// No validator passed, let's decide what to report back.
+	if len(interestingErrors) == 0 {
+		// If no error was added to the list, all errors were "not supported". Return that to
+		// the caller.
+		return ErrOIDNotSupported
+	}
+	// Bundle all interesting errors into one.
+	return errors.Join(interestingErrors...)
+}
+
+func (a *anyOf) String() string {
+	b := strings.Builder{}
+	b.WriteString("Any(")
+	for i, v := range a.vs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(v.String())
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
 // Any creates a Validator that passes if one of the input Validators passes.
 //
 // The Validators are tried in order, until one succeeds or no more are left.
 // The combined Validator supports all OIDs that are supported by at least one sub-Validator.
 func Any(vs ...Validator) Validator {
-	return ValidatorFunc(func(ctx context.Context, oid asn1.ObjectIdentifier, attDoc, reportData []byte) error {
-		interestingErrors := make([]error, 0, len(vs))
-		for i, v := range vs {
-			err := v.Validate(ctx, oid, attDoc, reportData)
-			if err == nil {
-				return nil
-			}
-			// A bunch of "unsupported" errors would clutter the output, only add the interesting ones.
-			if !errors.Is(err, ErrOIDNotSupported) {
-				interestingErrors = append(interestingErrors, fmt.Errorf("sub-validator %d: %w", i, err))
-			}
-		}
-		// No validator passed, let's decide what to report back.
-		if len(interestingErrors) == 0 {
-			// If no error was added to the list, all errors were "not supported". Return that to
-			// the caller.
-			return ErrOIDNotSupported
-		}
-		// Bundle all interesting errors into one.
-		return errors.Join(interestingErrors...)
-	})
+	// Short-circuit trivial cases: no validators can't succeed, 1 validator can just be passed through.
+	if len(vs) == 0 {
+		return &noValidator{}
+	} else if len(vs) == 1 {
+		return vs[0]
+	}
+	return &anyOf{vs: vs}
+}
+
+type noValidator struct{}
+
+func (n *noValidator) Validate(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
+	return ErrOIDNotSupported
+}
+
+func (n *noValidator) String() string {
+	return "<no validator>"
+}
+
+type withFixedOID struct {
+	oid asn1.ObjectIdentifier
+	v   Validator
 }
 
 // WithFixedOID wraps the given Validator, passing a fixed OID instead of the original one.
@@ -69,7 +116,33 @@ func Any(vs ...Validator) Validator {
 // This is only useful for backwards compatibility in the HTTP API client.
 // TODO(burgerdev): remove once all clients receive the OID from the HTTP API.
 func WithFixedOID(oid asn1.ObjectIdentifier, v Validator) Validator {
-	return ValidatorFunc(func(ctx context.Context, _ asn1.ObjectIdentifier, attDoc, reportData []byte) error {
-		return v.Validate(ctx, oid, attDoc, reportData)
-	})
+	// We're explicitly hiding the fact that we're using an adaptor and just use the name of the
+	// wrapped validator.
+	return &withFixedOID{oid: oid, v: v}
+}
+
+func (w *withFixedOID) Validate(ctx context.Context, _ asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+	return w.v.Validate(ctx, w.oid, attDoc, reportData)
+}
+
+func (w *withFixedOID) String() string {
+	return w.v.String()
+}
+
+type named struct {
+	v    Validator
+	name string
+}
+
+func (n *named) Validate(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+	return n.v.Validate(ctx, oid, attDoc, reportData)
+}
+
+func (n *named) String() string {
+	return n.name
+}
+
+// Named wraps the given Validator and overrides fmt.Stringer with a static string.
+func Named(name string, v Validator) Validator {
+	return &named{v: v, name: name}
 }

--- a/internal/atls/validators/validators_test.go
+++ b/internal/atls/validators/validators_test.go
@@ -21,6 +21,11 @@ func TestAny(t *testing.T) {
 		err        error
 	}{
 		"vacuous truth": {err: ErrOIDNotSupported},
+		"single validator passes through": {
+			validators: []*stubValidator{{err: assert.AnError}},
+			numTried:   1,
+			err:        assert.AnError,
+		},
 		"OID not supported": {
 			validators: []*stubValidator{{err: ErrOIDNotSupported}, {err: ErrOIDNotSupported}},
 			numTried:   2,
@@ -101,8 +106,52 @@ func TestWithFixedOID(t *testing.T) {
 	require.True(expectedOID.Equal(s.oid))
 }
 
+func TestNames(t *testing.T) {
+	for name, tc := range map[string]struct {
+		v        Validator
+		wantName string
+	}{
+		"plain": {
+			v:        &stubValidator{name: "foo"},
+			wantName: "foo",
+		},
+		"Any": {
+			v:        Any(&stubValidator{name: "foo"}, &stubValidator{name: "bar"}),
+			wantName: "Any(foo, bar)",
+		},
+		"Any-0": {
+			v:        Any(),
+			wantName: "<no validator>",
+		},
+		"Any-1": {
+			v:        Any(&stubValidator{name: "foo"}),
+			wantName: "foo",
+		},
+		"WithFixedOID": {
+			v:        WithFixedOID(asn1.ObjectIdentifier{1, 2, 3}, &stubValidator{name: "foo"}),
+			wantName: "foo",
+		},
+		"Nested": {
+			v: Any(
+				Any(&stubValidator{name: "foo"}, &stubValidator{name: "bar"}),
+				WithFixedOID(asn1.ObjectIdentifier{1, 2, 3}, &stubValidator{name: "baz"}),
+			),
+			wantName: "Any(Any(foo, bar), baz)",
+		},
+		"Named": {
+			v:        Named("bar", &stubValidator{name: "foo"}),
+			wantName: "bar",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.wantName, tc.v.String())
+		})
+	}
+}
+
 type stubValidator struct {
-	err error
+	err  error
+	name string
 
 	// saved arguments to Validate
 	oid        asn1.ObjectIdentifier
@@ -120,3 +169,15 @@ func (s *stubValidator) Validate(_ context.Context, oid asn1.ObjectIdentifier, d
 	s.reportData = rd
 	return s.err
 }
+
+func (s *stubValidator) String() string {
+	return s.name
+}
+
+var (
+	_ Validator = ValidatorFunc(nil)
+	_ Validator = (*anyOf)(nil)
+	_ Validator = (*named)(nil)
+	_ Validator = (*withFixedOID)(nil)
+	_ Validator = (*noValidator)(nil)
+)

--- a/internal/manifest/validators.go
+++ b/internal/manifest/validators.go
@@ -95,7 +95,13 @@ func coordinatorValidator(validatorFactory validatorFactory, coordPolicyHashes [
 		allHashes = append(allHashes, b)
 	}
 
-	return validators.ValidatorFunc(func(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
+	// TODO(burgerdev): if Validators returned the report directly we would not need to do this wrapping.
+	v, err := validatorFactory(log, kdsGetter, attestation.ReportSetterFunc(func(attestation.Report) {}))
+	if err != nil {
+		return nil, fmt.Errorf("constructing manifest validator: %w", err)
+	}
+	name := fmt.Sprintf("%s with policy hashes %v", v.String(), coordPolicyHashes)
+	return validators.Named(name, validators.ValidatorFunc(func(ctx context.Context, oid asn1.ObjectIdentifier, attDoc []byte, reportData []byte) error {
 		// We're creating the validator here to make execution reentrant and thread-safe. This way,
 		// the validators and the captured report variable are not shared. Constructing the
 		// validators is anyway orders of magnitude faster than doing the validation.
@@ -118,5 +124,5 @@ func coordinatorValidator(validatorFactory validatorFactory, coordPolicyHashes [
 			return fmt.Errorf("%w: got %x, want %v", ErrWrongCoordinatorPolicyHash, report.HostData(), coordPolicyHashes)
 		}
 		return nil
-	}), nil
+	})), nil
 }

--- a/internal/manifest/validators_test.go
+++ b/internal/manifest/validators_test.go
@@ -87,13 +87,27 @@ func TestCoordinatorValidator(t *testing.T) {
 		}
 
 		v, err := coordinatorValidator(badFactory, nil, nil, nil)
+		require.ErrorIs(err, assert.AnError)
+		require.Nil(v)
+	})
+
+	t.Run("bad validator", func(t *testing.T) {
+		require := require.New(t)
+
+		badFactory := func(*slog.Logger, *certcache.CachedHTTPSGetter, attestation.ReportSetter) (validators.Validator, error) {
+			return validators.ValidatorFunc(func(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
+				return assert.AnError
+			}), nil
+		}
+
+		v, err := coordinatorValidator(badFactory, nil, nil, nil)
 		require.NoError(err)
 		require.NotNil(v)
 
 		require.ErrorIs(v.Validate(t.Context(), nil, nil, nil), assert.AnError)
 	})
 
-	t.Run("bad validator", func(t *testing.T) {
+	t.Run("report setter not called", func(t *testing.T) {
 		require := require.New(t)
 
 		badValidatorFactory := func(*slog.Logger, *certcache.CachedHTTPSGetter, attestation.ReportSetter) (validators.Validator, error) {
@@ -108,6 +122,45 @@ func TestCoordinatorValidator(t *testing.T) {
 
 		require.ErrorIs(v.Validate(t.Context(), nil, nil, nil), ErrBadValidator)
 	})
+}
+
+func TestValidatorNaming(t *testing.T) {
+	require := require.New(t)
+	manifest := newTestManifestSNP()
+	manifest.ReferenceValues.TDX = newTestManifestTDX().ReferenceValues.TDX
+
+	coordinatorValidator, err := manifest.CoordinatorValidator(slog.Default(), nil)
+	require.NoError(err)
+	validator, err := manifest.Validator(slog.Default(), nil, attestation.ReportSetterFunc(func(attestation.Report) {}))
+	require.NoError(err)
+
+	for name, tc := range map[string]struct {
+		v              validators.Validator
+		wantSubstrings []string
+	}{
+		"CoordinatorValidator": {
+			v: coordinatorValidator,
+			wantSubstrings: []string{
+				"snp-0-MILAN",
+				"tdx-0",
+				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+		},
+		"Validator": {
+			v: validator,
+			wantSubstrings: []string{
+				"snp-0-MILAN",
+				"tdx-0",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			name := tc.v.String()
+			for _, wantSubstring := range tc.wantSubstrings {
+				assert.Contains(t, name, wantSubstring)
+			}
+		})
+	}
 }
 
 type stubReport struct {

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -237,3 +237,7 @@ type stubValidator struct {
 func (v *stubValidator) Validate(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
 	return v.err
 }
+
+func (v *stubValidator) String() string {
+	return "stubValidator"
+}


### PR DESCRIPTION
A refactoring in #2494 caused the aTLS validator to only have generic names that don't reflect what they are validating. This PR adds names to validators and combinators such that the nested validation logic is clearer.

An error message from this PR looks like:

```
validator Any(snp-0-GENOA) with policy hashes [967a0eee181382a7cf8a1faf9e3903b60660f6d1c863a0766633f6205dad6950] failed: wrong policy hash for Coordinator: got 977a0eee181382a7cf8a1faf9e3903b60660f6d1c863a0766633f6205dad6950, want [967a0eee181382a7cf8a1faf9e3903b60660f6d1c863a0766633f6205dad6950]
```

Fixes CON-217.