### PR TITLE
e2e: delete history after deleting Coordinator

### DIFF
--- a/e2e/attestation/attestation_test.go
+++ b/e2e/attestation/attestation_test.go
@@ -352,6 +352,7 @@ func TestAttestation(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, ct.Kubeclient.Delete(t.Context(), unstructured...))
 		require.NoError(t, ct.Kubeclient.WaitForDeletion(t.Context(), unstructured...))
+		require.NoError(t, ct.Kubeclient.DeleteHistory(t.Context(), ct.Namespace))
 
 		// Change the guest policy. By default, the minimum required ABIMinor version is 0
 		// (read from packages/by-name/contrast/reference-values/snpGuestPolicyQEMU.json).

--- a/e2e/coordinator/coordinator_test.go
+++ b/e2e/coordinator/coordinator_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/edgelesssys/contrast/internal/platforms"
 	"github.com/edgelesssys/contrast/sdk"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestCoordinator(t *testing.T) {
@@ -59,13 +57,7 @@ func TestCoordinator(t *testing.T) {
 		// Delete the Coordinator history.
 		// This is the documented procedure, if changes are needed here make sure to reflect that
 		// in the docs.
-		deleteOpts := metav1.DeleteOptions{
-			PropagationPolicy: toPtr(metav1.DeletePropagationForeground),
-		}
-		listOpts := metav1.ListOptions{
-			LabelSelector: labels.Set(map[string]string{kuberesource.KubernetesAppManagedByLabel: "contrast.edgeless.systems"}).AsSelector().String(),
-		}
-		require.NoError(ct.Kubeclient.Client.CoreV1().ConfigMaps(ct.Namespace).DeleteCollection(ctx, deleteOpts, listOpts))
+		require.NoError(ct.Kubeclient.DeleteHistory(ctx, ct.Namespace))
 		require.NoError(ct.Kubeclient.Restart(ctx, kubeclient.StatefulSet{}, ct.Namespace, "coordinator"))
 		require.NoError(ct.Kubeclient.WaitForCoordinator(ctx, ct.Namespace))
 
@@ -237,10 +229,6 @@ func TestCoordinator(t *testing.T) {
 		require.Error(err)
 		require.Nil(state)
 	})
-}
-
-func toPtr[A any](a A) *A {
-	return &a
 }
 
 func TestMain(m *testing.M) {

--- a/e2e/internal/kubeclient/deploy.go
+++ b/e2e/internal/kubeclient/deploy.go
@@ -14,12 +14,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/edgelesssys/contrast/internal/kuberesource"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
@@ -412,6 +414,17 @@ func (c *Kubeclient) WaitForDeletion(ctx context.Context, objs ...*unstructured.
 		c.log.Info("object deleted", "namespace", obj.GetNamespace(), "kind", obj.GetKind(), "name", obj.GetName())
 	}
 	return nil
+}
+
+// DeleteHistory deletes the ConfigMaps storing Coordinator history.
+func (c *Kubeclient) DeleteHistory(ctx context.Context, namespace string) error {
+	deleteOpts := metav1.DeleteOptions{
+		PropagationPolicy: toPtr(metav1.DeletePropagationForeground),
+	}
+	listOpts := metav1.ListOptions{
+		LabelSelector: labels.Set(map[string]string{kuberesource.KubernetesAppManagedByLabel: "contrast.edgeless.systems"}).AsSelector().String(),
+	}
+	return c.Client.CoreV1().ConfigMaps(namespace).DeleteCollection(ctx, deleteOpts, listOpts)
 }
 
 // ScaleDeployment scales a deployment to the given number of replicas.


### PR DESCRIPTION
The history used to be owned by the Coordinator and was deleted alongside it. We recently removed ownership from the ConfigMaps, but it turned out that some tests relied implicitly on that behaviour. Update those tests to explicitly clean up the coordinator history.

This caused e2e failures, e.g. https://github.com/edgelesssys/contrast/actions/runs/29049439091.

- [ ] [attestation SNP](https://github.com/edgelesssys/contrast/actions/runs/29077900872)