### PR TITLE
ci: clean up in the default namespace

### DIFF
--- a/e2e/release/release_test.go
+++ b/e2e/release/release_test.go
@@ -111,6 +111,9 @@ func TestRelease(t *testing.T) {
 				t.Logf("deleting resource %s: %v", resource.GetName(), err)
 			}
 		}
+		if err := k.DeleteHistory(ctx, "default"); err != nil {
+			t.Logf("deleting ConfigMap store: %v", err)
+		}
 	})
 
 	// Write namespaces to trigger log collection.

--- a/packages/cleanup-bare-metal.sh
+++ b/packages/cleanup-bare-metal.sh
@@ -98,6 +98,9 @@ for runtimeClass in "${unusedRuntimeClasses[@]}"; do
   yq -i -p toml -o toml "del(.proxy_plugins[\"${SNAPSHOTTER}-${runtimeClass}\"])" "${configFile}" 2>/dev/null || true
 done
 
+# Clean up potential leftovers in the default namespace.
+kubectl delete configmaps --selector app.kubernetes.io/managed-by=contrast.edgeless.systems || true
+
 echo "Cleanup finished"
 
 if nsenter -t 1 -m sh -c "command -v k3s >/dev/null 2>&1"; then


### PR DESCRIPTION
The ConfigMaps don't disappear with the Coordinator anymore since #2515. We need to remember to clean them up, otherwise they mess with the next test. 