### PR TITLE
nixos/kata: set maximum size of /run tmpfs to 100%

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -487,8 +487,7 @@ func generatePolicies(ctx context.Context, flags *generateFlags, fileMap map[str
 				}
 				spec.WithResources(
 					kuberesource.ResourceRequirements().
-						// Double because the /run directory only has 50% of VM memory available
-						WithMemoryLimitAndRequest(2 * podMemory / 1024 / 1024),
+						WithMemoryLimitAndRequest(podMemory / 1024 / 1024),
 				)
 			}
 			return meta, spec, nil

--- a/e2e/imagestore/imagestore_test.go
+++ b/e2e/imagestore/imagestore_test.go
@@ -170,10 +170,10 @@ func TestImageStore(t *testing.T) {
 		// The uncompressed test image is about 2GiB.
 		// The largest VM memory when not using auto-memory limits can be calculated as:
 		//   - default memory (GPU): 1024Mi
-		//   - debugshell memory limit: 1000Mi
+		//   - debugshell memory limit: 650Mi
 		//   - container memory limit: 10Mi
-		// The available memory for image pulling is then at most 1024+1000+10 = 2034M.
-		// The debugshell image is ~400Mi, which leaves ~1600Mi for pulling the test image,
+		// The available memory for image pulling is then at most 1024+1000+10 = 1684Mi.
+		// The debugshell image is ~400Mi, which leaves ~1300Mi for pulling the test image,
 		// so the pod wouldn't be able to start.
 		// This test verifies that the added pod memory limit during generate is enough to pull the image
 		// when the imagestore is disbabled. If the pod comes up, the test passes.

--- a/e2e/imagestore/imagestore_test.go
+++ b/e2e/imagestore/imagestore_test.go
@@ -59,7 +59,7 @@ func TestImageStore(t *testing.T) {
 		resources = append(resources, testPod(tc.name, tc.annotation))
 	}
 
-	resources = append(resources, postgresPod())
+	resources = append(resources, largeCompressedPod())
 
 	resources = kuberesource.PatchRuntimeHandlers(resources, runtimeHandler)
 	resources = kuberesource.AddPortForwarders(resources)
@@ -118,17 +118,17 @@ func TestImageStore(t *testing.T) {
 				// Usually, K8s adjusts the available memory to either be the maximum of (sequential) init containers,
 				// or the sum of (concurrent) normal and sidecar containers
 				minimumMemory := max(initContainerMemory, containerMemory)
-				// Only 50% of the allocated memory is available in /run. Half of the calculated pod memory should then
-				// accommodate for the container limits as defined above, plus additional memory to pull the images.
-				require.Greater(podMemory/2, minimumMemory, "pod memory should be greater than the container limits")
+				// The calculated pod memory should accommodate for the container limits as defined above,
+				// plus additional memory to pull the images.
+				require.Greater(podMemory, minimumMemory, "pod memory should be greater than the container limits")
 
 				defaultMemory := platforms.DefaultMemoryInMebiBytes(platform) * 1024 * 1024
 				totalMemory := defaultMemory + podMemory
-				// When the imagestore is disabled, the expectedKibiBytes are (the total VM memory in KiB - internal VM overhead) / 2
+				// When the imagestore is disabled, the expectedKibiBytes are (the total VM memory in KiB - internal VM overhead)
 				// For more information on the internal VM overhead, see https://github.com/edgelesssys/contrast/pull/1196
 				vmOverheadBytes := 99 * 1024 * 1024
 				vmOverheadBytes += swiotlbSizeBytes(totalMemory)
-				expectedKibiBytes = ((totalMemory - vmOverheadBytes) / 1024) / 2
+				expectedKibiBytes = (totalMemory - vmOverheadBytes) / 1024
 			case "":
 				size := resource.MustParse("10Gi")
 				expectedKibiBytes = int(size.Value()) / 1024
@@ -162,23 +162,22 @@ func TestImageStore(t *testing.T) {
 	}
 
 	t.Run("large image with pod resource limits", func(t *testing.T) {
-		// Increase timeout, as pulling the image may take a while.
-		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(5*time.Minute))
+		ctx, cancel := context.WithTimeout(t.Context(), ct.FactorPlatformTimeout(2*time.Minute))
 		t.Cleanup(cancel)
 
 		require = req.New(t)
 
-		// The uncompressed and compressed postgres image layers together are ~815Mi.
+		// The uncompressed test image is about 2GiB.
 		// The largest VM memory when not using auto-memory limits can be calculated as:
 		//   - default memory (GPU): 1024Mi
 		//   - debugshell memory limit: 1000Mi
 		//   - container memory limit: 10Mi
-		// The available memory for image pulling is then (1024+1000+10) / 2 = 1017Mi.
-		// The debugshell image is ~500-600Mi, which leaves ~400-500Mi for pulling the postgres image,
+		// The available memory for image pulling is then at most 1024+1000+10 = 2034M.
+		// The debugshell image is ~400Mi, which leaves ~1600Mi for pulling the test image,
 		// so the pod wouldn't be able to start.
 		// This test verifies that the added pod memory limit during generate is enough to pull the image
 		// when the imagestore is disbabled. If the pod comes up, the test passes.
-		require.NoError(ct.Kubeclient.WaitForPod(ctx, ct.Namespace, "postgres"))
+		require.NoError(ct.Kubeclient.WaitForPod(ctx, ct.Namespace, "large-compressed"))
 	})
 }
 
@@ -255,30 +254,20 @@ func testPod(name, annotation string) any {
 		)
 }
 
-func postgresPod() any {
-	return kuberesource.Pod("postgres", "").
+func largeCompressedPod() any {
+	return kuberesource.Pod("large-compressed", "").
 		WithAnnotations(map[string]string{kuberesource.ImageStoreSizeAnnotationKey: "0"}).
 		WithSpec(
 			kuberesource.PodSpec().
 				WithContainers(
 					kuberesource.Container().
-						WithName("postgres").
-						WithImage("docker.io/library/postgres@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20").
-						WithCommand("/bin/bash", "-c", "sleep infinity").
+						WithName("large-compressed").
+						WithImage("ghcr.io/edgelesssys/contrast/large-compressed:latest").
+						WithCommand("/bin/sh", "-c", "sleep infinity").
 						WithResources(
 							kuberesource.ResourceRequirements().
 								WithMemoryLimitAndRequest(10),
-						).
-						WithVolumeMounts(
-							kuberesource.VolumeMount().
-								WithName("postgres-data").
-								WithMountPath("/var/lib/postgresql"),
 						),
-				).
-				WithVolumes(
-					kuberesource.Volume().
-						WithName("postgres-data").
-						WithEmptyDir(kuberesource.EmptyDirVolumeSource().Inner()),
 				),
 		)
 }

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -32,19 +32,20 @@ const (
 
 var containerMemoryLimits = map[string]map[MemoryProfile]int64{
 	"contrast-initializer": {
-		// In v1.18.0, the initializer image was 50MiB compressed, 160MiB uncompressed.
-		// Double that because only 50% of the VM memory are available for /run.
-		MemoryProfileFull: 420,
+		// In v1.23.0, the initializer image was 61MiB compressed, 177MiB uncompressed.
+		MemoryProfileFull: 300,
 		// The container's cgroup memory.peak is at about 5MiB.
 		MemoryProfileRuntimeOnly: 20,
 	},
 	"contrast-service-mesh": {
-		MemoryProfileFull: 400,
+		// In v1.23.0, the service mesh image was 89MiB compressed, 268MiB uncompressed.
+		MemoryProfileFull: 500,
 		// When running the emojivoto deployment, the container's cgroup memory.peak is at about 20MiB.
 		MemoryProfileRuntimeOnly: 100,
 	},
 	"contrast-debug-shell": {
-		MemoryProfileFull: 1000,
+		// In v1.23.0, the debugshell image was 115MiB compressed, 287MiB uncompressed.
+		MemoryProfileFull: 650,
 		// Leave enough memory for debugging tasks.
 		MemoryProfileRuntimeOnly: 200,
 	},
@@ -371,10 +372,8 @@ func Coordinator(namespace string) *CoordinatorConfig {
 										).
 										WithResources(
 											ResourceRequirements().
-												// As of v1.18.0, the Coordinator is roughly 200MiB unpacked.
-												// Double that to account for only 50% of VM memory being available
-												// for /run.
-												WithMemoryLimitAndRequest(400),
+												// As of v1.23.0, the Coordinator is roughly 270MiB unpacked.
+												WithMemoryLimitAndRequest(300),
 										),
 								).
 								WithAffinity(

--- a/justfile
+++ b/justfile
@@ -36,6 +36,8 @@ k8s-log-collector: (push "k8s-log-collector")
 
 strongswan: (push "strongswan")
 
+large-compressed: (push "large-compressed")
+
 # Download all logs (pod logs + host journal). Deploys the log-collector if not already running.
 download-logs set=default_set:
     #!/usr/bin/env bash
@@ -108,7 +110,7 @@ e2e target=default_deploy_target platform=default_platform set=default_set:
     echo "Using set=$RESOLVED_SET, debug=$RESOLVED_DEBUG for test '{{ target }}'"
     set="$RESOLVED_SET" debug="$RESOLVED_DEBUG" just _e2e {{ target }} {{ platform }}
 
-_e2e target=default_deploy_target platform=default_platform set=default_set: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy memdump debugshell k8s-log-collector strongswan (node-installer platform)
+_e2e target=default_deploy_target platform=default_platform set=default_set: soft-clean coordinator initializer openssl port-forwarder service-mesh-proxy memdump debugshell k8s-log-collector strongswan large-compressed (node-installer platform)
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ {{ target }} == "gpu" ]] ; then

--- a/packages/containers.nix
+++ b/packages/containers.nix
@@ -197,4 +197,17 @@
       Cmd = [ "${pkgs.strongswan}/libexec/ipsec/charon" ];
     };
   };
+
+  large-compressed = contrastPkgs.buildOciImage {
+    name = "large-compressed";
+    tag = "latest";
+    copyToRoot = with pkgs; [
+      busybox
+      (runCommand "large-file" { } ''
+        mkdir -p $out
+        # Resulting image will be ~2GiB, since we copy the file to root and to the nix store.
+        # Compressed image will only be ~20MiB.
+        dd if=/dev/zero of=$out/large-file bs=1M count=1000'')
+    ];
+  };
 }

--- a/packages/nixos/kata.nix
+++ b/packages/nixos/kata.nix
@@ -106,7 +106,7 @@ in
       options = [
         "nodev"
         "nosuid"
-        "size=50%"
+        "size=100%"
       ];
       neededForBoot = true;
     };


### PR DESCRIPTION
Until now, the tmpfs mounted at `/run` in the guest was limited to 50% of the VM's memory. This would include memory used for the containers, as well as memory used for image pulling, meaning the necessary container limits would essentially have to be doubled, while the rest of the memory is only available to the guest components. The memory for the guest components is already covered by the `defaultMemory`, so we can remove the 50% limit. This allows for more efficient memory usage in the VM and we can reduce some of our configured container limits.

The calculation for the pod memory during auto-memory-limits also gets smaller, now being `imageSizes + max(initContainerLimits, containerLimits)`.

- [x] [imagestore test](https://github.com/edgelesssys/contrast/actions/runs/29410885681)

Fixes CON-215