### PR TITLE
attestation/certcache: log errors from RetryHTTPSGetter

### DIFF
--- a/internal/attestation/certcache/cached_client.go
+++ b/internal/attestation/certcache/cached_client.go
@@ -60,7 +60,7 @@ type CachedHTTPSGetter struct {
 // NewCachedHTTPSGetter returns a new CachedHTTPSGetter.
 func NewCachedHTTPSGetter(s store, ticker clock.Ticker, log *slog.Logger, collateralProxy string) *CachedHTTPSGetter {
 	c := &CachedHTTPSGetter{
-		ContextHTTPSGetter:  NewRetryHTTPSGetter(http.DefaultClient, retryInterval),
+		ContextHTTPSGetter:  NewRetryHTTPSGetter(http.DefaultClient, retryInterval, log),
 		logger:              log,
 		cache:               s,
 		gcTicker:            ticker,

--- a/internal/attestation/certcache/retry_client.go
+++ b/internal/attestation/certcache/retry_client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 type RetryHTTPSGetter struct {
 	client   *http.Client
 	interval time.Duration
+	logger   *slog.Logger
 
 	clock clock.WithTicker
 }
@@ -31,10 +33,11 @@ type RetryHTTPSGetter struct {
 //
 // The getter will use the given client to do individual requests, and the requests will be spaced
 // with the given interval.
-func NewRetryHTTPSGetter(client *http.Client, interval time.Duration) *RetryHTTPSGetter {
+func NewRetryHTTPSGetter(client *http.Client, interval time.Duration, log *slog.Logger) *RetryHTTPSGetter {
 	return &RetryHTTPSGetter{
 		client:   client,
 		interval: interval,
+		logger:   log,
 		clock:    clock.RealClock{},
 	}
 }
@@ -46,6 +49,9 @@ func (g *RetryHTTPSGetter) GetContext(ctx context.Context, url string) (headers 
 	doer := retry.DoerFunc(func(ctx context.Context) error {
 		var err error
 		headers, body, err = g.fetchOnce(ctx, url)
+		if err != nil {
+			g.logger.Debug("Failed to fetch URL", "url", url, "error", err)
+		}
 		return err
 	})
 

--- a/internal/attestation/certcache/retry_client_test.go
+++ b/internal/attestation/certcache/retry_client_test.go
@@ -5,6 +5,7 @@ package certcache
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -109,6 +110,7 @@ func TestRetryHTTPSGetter(t *testing.T) {
 			getter := &RetryHTTPSGetter{
 				client:   srv.Client(),
 				interval: time.Second,
+				logger:   slog.Default(),
 				clock:    clock,
 			}
 


### PR DESCRIPTION
We should log the errors from the individual requests of the `RetryHTTPSGetter`, otherwise we only get a `context deadline exceeded` when setting the manifest fails, as in https://github.com/edgelesssys/contrast/actions/runs/28056557011/job/83060984081. Logging the error now creates more useful logs.

- [x] [kds-pcs-downtime test](https://github.com/edgelesssys/contrast/actions/runs/29420465511)

Fixes CON-191