### PR TITLE
scripts/containers: announce upload size before crane push

### DIFF
--- a/packages/by-name/scripts/containers/package.nix
+++ b/packages/by-name/scripts/containers/package.nix
@@ -18,6 +18,7 @@ let
         imageName="$1"
         containerlookup="''${2:-/dev/null}"
         layersCache="''${3:-$(mktemp)}"
+        echo "$(date '+%Y/%m/%d %H:%M:%S') Pushing ${name} ($(du -shL ${dir} | cut -f1)) to $imageName:${tag}" >&2
         hash=$(crane push "${dir}" "$imageName:${tag}")
         printf "ghcr.io/edgelesssys/contrast/%s:latest=%s\n" "${name}" "$hash" >> "$containerlookup"
         if [ ! -f "$layersCache" ]; then


### PR DESCRIPTION
crane push prints a log line only when a blob finishes uploading, so a multi-hundred-MB layer on a slow uplink looks like a hang for many minutes. Print the image size upfront so the silence is expected.