### PR TITLE
ci: update bm-tcb-specs for dgx-007

### DIFF
--- a/dev-docs/e2e/dgx-007/manifest.json
+++ b/dev-docs/e2e/dgx-007/manifest.json
@@ -8,7 +8,7 @@
     {
       "op": "replace",
       "path": "/MrSeam",
-      "value": "489e585f1c54bc5a02066c8c6ec21619ff0334ec6f21e07e2a35202c59183789c8057e7d97dd591bb08314b185819e72"
+      "value": "346bc77a1846cac214dd2e8edeb9ee4349449d6c3f9ff2c52149a634c27b7fd1bd314c2ef6b973eeebd55742952531a1"
     },
     {
       "op": "replace",
@@ -27,7 +27,7 @@
     {
       "op": "replace",
       "path": "/MrSeam",
-      "value": "489e585f1c54bc5a02066c8c6ec21619ff0334ec6f21e07e2a35202c59183789c8057e7d97dd591bb08314b185819e72"
+      "value": "346bc77a1846cac214dd2e8edeb9ee4349449d6c3f9ff2c52149a634c27b7fd1bd314c2ef6b973eeebd55742952531a1"
     },
     {
       "op": "replace",


### PR DESCRIPTION
Update MrSeam for this machine to the latest module. The hash is [published on Github](https://github.com/intel/confidential-computing.tdx.tdx-module#intel-tdx-module-releases-and-hashes); the module is not yet.