### PR TITLE
[6/8] cli: support insecure manifests behind opt-in

### DIFF
--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,6 +43,13 @@ const (
 	// Coordinator's env var of the same name.
 	allowInsecureEnvVar = "CONTRAST_ALLOW_INSECURE"
 )
+
+// insecureRuntimesAllowed reports whether allowInsecureEnvVar is set to a value that parses as
+// true. Commands only declare the --INSECURE flag when this returns true.
+func insecureRuntimesAllowed() bool {
+	allowed, err := strconv.ParseBool(os.Getenv(allowInsecureEnvVar))
+	return err == nil && allowed
+}
 
 // ReleaseImageReplacements contains the image replacements used by contrast.
 //

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -38,6 +38,9 @@ const (
 	latestTransitionHashFilename = "latest-transition"
 	historyFilename              = "history.yml"
 	verifyDir                    = "verify"
+	// allowInsecureEnvVar gates insecure (non-CC) runtime support and matches the
+	// Coordinator's env var of the same name.
+	allowInsecureEnvVar = "CONTRAST_ALLOW_INSECURE"
 )
 
 // ReleaseImageReplacements contains the image replacements used by contrast.

--- a/cli/cmd/common.go
+++ b/cli/cmd/common.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
 	"github.com/edgelesssys/contrast/internal/fsstore"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -38,7 +40,24 @@ const (
 	latestTransitionHashFilename = "latest-transition"
 	historyFilename              = "history.yml"
 	verifyDir                    = "verify"
+	// allowInsecureEnvVar gates insecure (non-CC) runtime support and matches the
+	// Coordinator's env var of the same name.
+	allowInsecureEnvVar = "CONTRAST_ALLOW_INSECURE"
 )
+
+// insecureRuntimesAllowed reports whether allowInsecureEnvVar is set to a value that parses as
+// true. Commands only declare the --INSECURE flag when this returns true.
+func insecureRuntimesAllowed() bool {
+	allowed, err := strconv.ParseBool(os.Getenv(allowInsecureEnvVar))
+	return err == nil && allowed
+}
+
+func validateInsecureManifest(mnf *manifest.Manifest, allowInsecure bool) error {
+	if mnf.HasInsecurePlatforms() && !allowInsecure {
+		return fmt.Errorf("manifest contains insecure platforms but --INSECURE flag not set (the flag is only available with the %s environment variable set to true)", allowInsecureEnvVar)
+	}
+	return nil
+}
 
 // ReleaseImageReplacements contains the image replacements used by contrast.
 //

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -330,9 +330,7 @@ func mapContrastWorkloads(fileMap map[string][]*unstructured.Unstructured, f fun
 
 func isContrastWorkload(resource any) (ret bool) {
 	kuberesource.MapPodSpec(resource, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
-		if kuberesource.IsContrastPod(spec) {
-			ret = true
-		}
+		ret = kuberesource.IsContrastPod(spec)
 		return spec
 	})
 	return ret

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -93,6 +93,7 @@ subcommands.`,
 	cmd.Flags().Bool("insecure-enable-debug-shell-access", false, "enable the debug shell service in the pod CVM to get access from container to guest VM")
 	cmd.Flags().Bool("calculate-pod-memory", false, "calculate pod memory based on image layer sizes and container resource limits")
 	cmd.Flags().StringP("output", "o", "", "output file for generated YAML")
+	cmd.Flags().Bool("INSECURE", false, "allow generation for insecure (non-CC) runtimes (also requires the CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable to be set)")
 	must(cmd.MarkFlagFilename("policy", "rego"))
 	must(cmd.MarkFlagFilename("settings", "json"))
 	must(cmd.MarkFlagFilename("manifest", "json"))
@@ -142,6 +143,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 	if flags.referenceValuesPlatform != platforms.Unknown {
 		usedPlatforms.Add(flags.referenceValuesPlatform)
+	}
+
+	if err := validateInsecurePlatforms(usedPlatforms, flags.allowInsecureRuntimes); err != nil {
+		return err
 	}
 
 	// generate a manifest by checking if a manifest exists and using that,
@@ -294,7 +299,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// mapContrastWorkloads applies the given function to all workloads with a Contrast runtime class.
+// mapContrastWorkloads applies the given function to all workloads with the 'contrast-cc' or 'contrast-insecure' runtime class.
 // The callback receives an apply configuration together with the file path and index the unstructured object has in the file map.
 // Changes to the apply configuration are not applied to the original unstructured object.
 func mapContrastWorkloads(fileMap map[string][]*unstructured.Unstructured, f func(res any, path string, idx int) (any, error)) error {
@@ -325,7 +330,9 @@ func mapContrastWorkloads(fileMap map[string][]*unstructured.Unstructured, f fun
 
 func isContrastWorkload(resource any) (ret bool) {
 	kuberesource.MapPodSpec(resource, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
-		ret = kuberesource.IsContrastPod(spec)
+		if kuberesource.IsContrastPod(spec) {
+			ret = true
+		}
 		return spec
 	})
 	return ret
@@ -341,6 +348,16 @@ func isCoordinator(resource any) bool {
 		return true
 	}
 	return false
+}
+
+func patchCoordinatorAllowInsecure(resource any) {
+	r, ok := resource.(*applyappsv1.StatefulSetApplyConfiguration)
+	if !ok || !isCoordinator(resource) {
+		return
+	}
+	if len(r.Spec.Template.Spec.Containers) > 0 {
+		r.Spec.Template.Spec.Containers[0].WithEnv(kuberesource.NewEnvVar("CONTRAST_ALLOW_INSECURE", "1"))
+	}
 }
 
 func runVerifiers(fileMap map[string][]*unstructured.Unstructured, verifiers []verifier.Verifier) error {
@@ -428,7 +445,7 @@ func extractTargets(paths []string, configFile io.Writer, logger *slog.Logger) (
 		}
 	}
 	if len(fileMap) == 0 {
-		return nil, "", fmt.Errorf("no .yml/.yaml files with 'contrast-cc' runtime found")
+		return nil, "", fmt.Errorf("no .yml/.yaml files with 'contrast-cc' or 'contrast-insecure' runtime found")
 	}
 
 	extraData, err := kuberesource.EncodeUnstructured(extraResources)
@@ -586,6 +603,9 @@ func patchTargets(fileMap map[string][]*unstructured.Unstructured, imageReplacem
 		if flags.injectImageStore {
 			kuberesource.AddImageStore([]any{res})
 		}
+		if flags.allowInsecureRuntimes {
+			patchCoordinatorAllowInsecure(res)
+		}
 
 		kuberesource.PatchImages([]any{res}, replacements)
 
@@ -627,6 +647,19 @@ func injectServiceMesh(resource any, memoryProfile kuberesource.MemoryProfile) e
 	}
 	if _, err := kuberesource.AddServiceMesh(resource, kuberesource.ServiceMeshProxy(memoryProfile)); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateInsecurePlatforms(usedPlatforms kuberesource.PlatformCollection, allowInsecure bool) error {
+	if !slices.ContainsFunc(usedPlatforms.Platforms(), platforms.IsInsecure) {
+		return nil
+	}
+	if !allowInsecure {
+		return fmt.Errorf("insecure runtime platforms detected but --INSECURE flag not set")
+	}
+	if os.Getenv("CONTRAST_ALLOW_INSECURE_RUNTIMES") == "" {
+		return fmt.Errorf("insecure runtime platforms detected but CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable not set")
 	}
 	return nil
 }
@@ -758,7 +791,17 @@ func patchRuntimeClassName(defaultRuntimeHandler string) func(*applycorev1.PodSp
 		if spec == nil || spec.RuntimeClassName == nil {
 			return spec, nil
 		}
-		if *spec.RuntimeClassName == "kata-cc-isolation" || *spec.RuntimeClassName == "contrast-cc" {
+		if *spec.RuntimeClassName == "kata-cc-isolation" || *spec.RuntimeClassName == "contrast-cc" || *spec.RuntimeClassName == "contrast-insecure" {
+			// Only allow the bare runtime class names if the default runtime handler is compatible.
+			// For example, `contrast-cc` should only resolve when `--reference-values` is set to a CC-enabled platform,
+			// and `contrast-insecure` should only resolve when `--reference-values` is set to an insecure platform.
+			if *spec.RuntimeClassName == "contrast-insecure" && !strings.HasPrefix(defaultRuntimeHandler, "contrast-insecure-") {
+				return nil, fmt.Errorf("bare 'contrast-insecure' runtime class requires --reference-values to be set to an insecure platform")
+			}
+			if (*spec.RuntimeClassName == "contrast-cc" || *spec.RuntimeClassName == "kata-cc-isolation") &&
+				strings.HasPrefix(defaultRuntimeHandler, "contrast-insecure-") {
+				return nil, fmt.Errorf("bare %q runtime class is incompatible with insecure --reference-values platform %q", *spec.RuntimeClassName, defaultRuntimeHandler)
+			}
 			spec.RuntimeClassName = &defaultRuntimeHandler
 			if kuberesource.PodSpecRequiresGPU(spec) {
 				platform, err := platforms.FromRuntimeClassString(*spec.RuntimeClassName)
@@ -773,7 +816,7 @@ func patchRuntimeClassName(defaultRuntimeHandler string) func(*applycorev1.PodSp
 			}
 			return spec, nil
 		}
-		if !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc-") {
+		if !kuberesource.IsContrastPod(spec) {
 			return spec, nil
 		}
 		overridePlatform, err := platforms.FromRuntimeClassString(*spec.RuntimeClassName)
@@ -961,6 +1004,7 @@ type generateFlags struct {
 	injectImageStore         bool
 	insecureEnableDebugShell bool
 	calculatePodMemory       bool
+	allowInsecureRuntimes    bool
 	outputFile               string
 }
 
@@ -1066,6 +1110,10 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	allowInsecureRuntimes, err := cmd.Flags().GetBool("INSECURE")
+	if err != nil {
+		return nil, err
+	}
 	outputFile, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return nil, err
@@ -1093,6 +1141,7 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 		injectImageStore:         injectImageStore,
 		insecureEnableDebugShell: insecureEnableDebugShell,
 		calculatePodMemory:       calculatePodMemory,
+		allowInsecureRuntimes:    allowInsecureRuntimes,
 		outputFile:               outputFile,
 	}, nil
 }

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -93,7 +93,9 @@ subcommands.`,
 	cmd.Flags().Bool("insecure-enable-debug-shell-access", false, "enable the debug shell service in the pod CVM to get access from container to guest VM")
 	cmd.Flags().Bool("calculate-pod-memory", false, "calculate pod memory based on image layer sizes and container resource limits")
 	cmd.Flags().StringP("output", "o", "", "output file for generated YAML")
-	cmd.Flags().Bool("INSECURE", false, fmt.Sprintf("allow generation for insecure (non-CC) runtimes (also requires the %s environment variable to be set)", allowInsecureEnvVar))
+	if insecureRuntimesAllowed() {
+		cmd.Flags().Bool("INSECURE", false, "allow generation for insecure (non-CC) runtimes")
+	}
 	must(cmd.MarkFlagFilename("policy", "rego"))
 	must(cmd.MarkFlagFilename("settings", "json"))
 	must(cmd.MarkFlagFilename("manifest", "json"))
@@ -654,10 +656,7 @@ func validateInsecurePlatforms(usedPlatforms kuberesource.PlatformCollection, al
 		return nil
 	}
 	if !allowInsecure {
-		return fmt.Errorf("insecure runtime platforms detected but --INSECURE flag not set")
-	}
-	if os.Getenv(allowInsecureEnvVar) == "" {
-		return fmt.Errorf("insecure runtime platforms detected but %s environment variable not set", allowInsecureEnvVar)
+		return fmt.Errorf("insecure runtime platforms detected but --INSECURE flag not set (the flag is only available with the %s environment variable set to true)", allowInsecureEnvVar)
 	}
 	return nil
 }
@@ -1108,9 +1107,12 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 	if err != nil {
 		return nil, err
 	}
-	allowInsecureRuntimes, err := cmd.Flags().GetBool("INSECURE")
-	if err != nil {
-		return nil, err
+	allowInsecureRuntimes := false
+	if cmd.Flags().Lookup("INSECURE") != nil {
+		allowInsecureRuntimes, err = cmd.Flags().GetBool("INSECURE")
+		if err != nil {
+			return nil, err
+		}
 	}
 	outputFile, err := cmd.Flags().GetString("output")
 	if err != nil {

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -93,7 +93,7 @@ subcommands.`,
 	cmd.Flags().Bool("insecure-enable-debug-shell-access", false, "enable the debug shell service in the pod CVM to get access from container to guest VM")
 	cmd.Flags().Bool("calculate-pod-memory", false, "calculate pod memory based on image layer sizes and container resource limits")
 	cmd.Flags().StringP("output", "o", "", "output file for generated YAML")
-	cmd.Flags().Bool("INSECURE", false, "allow generation for insecure (non-CC) runtimes (also requires the CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable to be set)")
+	cmd.Flags().Bool("INSECURE", false, fmt.Sprintf("allow generation for insecure (non-CC) runtimes (also requires the %s environment variable to be set)", allowInsecureEnvVar))
 	must(cmd.MarkFlagFilename("policy", "rego"))
 	must(cmd.MarkFlagFilename("settings", "json"))
 	must(cmd.MarkFlagFilename("manifest", "json"))
@@ -354,7 +354,7 @@ func patchCoordinatorAllowInsecure(resource any) {
 		return
 	}
 	if len(r.Spec.Template.Spec.Containers) > 0 {
-		r.Spec.Template.Spec.Containers[0].WithEnv(kuberesource.NewEnvVar("CONTRAST_ALLOW_INSECURE", "1"))
+		r.Spec.Template.Spec.Containers[0].WithEnv(kuberesource.NewEnvVar(allowInsecureEnvVar, "1"))
 	}
 }
 
@@ -656,8 +656,8 @@ func validateInsecurePlatforms(usedPlatforms kuberesource.PlatformCollection, al
 	if !allowInsecure {
 		return fmt.Errorf("insecure runtime platforms detected but --INSECURE flag not set")
 	}
-	if os.Getenv("CONTRAST_ALLOW_INSECURE_RUNTIMES") == "" {
-		return fmt.Errorf("insecure runtime platforms detected but CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable not set")
+	if os.Getenv(allowInsecureEnvVar) == "" {
+		return fmt.Errorf("insecure runtime platforms detected but %s environment variable not set", allowInsecureEnvVar)
 	}
 	return nil
 }

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -94,6 +94,9 @@ subcommands.`,
 	cmd.Flags().Bool("calculate-pod-memory", false, "calculate pod memory based on image layer sizes and container resource limits")
 	cmd.Flags().StringP("output", "o", "", "output file for generated YAML")
 	cmd.Flags().StringArray("insecure-registry", []string{}, "registries to access via plain HTTP instead of HTTPS (can be passed more than once)")
+	if insecureRuntimesAllowed() {
+		cmd.Flags().Bool("INSECURE", false, "allow generation for insecure (non-CC) runtimes")
+	}
 	must(cmd.MarkFlagFilename("policy", "rego"))
 	must(cmd.MarkFlagFilename("settings", "json"))
 	must(cmd.MarkFlagFilename("manifest", "json"))
@@ -145,6 +148,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		usedPlatforms.Add(flags.referenceValuesPlatform)
 	}
 
+	if err := validateInsecurePlatforms(usedPlatforms, flags.allowInsecureRuntimes); err != nil {
+		return err
+	}
+
 	// generate a manifest by checking if a manifest exists and using that,
 	// or otherwise using a default.
 	var mnf *manifest.Manifest
@@ -175,6 +182,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("validate existing manifest: %w", err)
 		}
 	}
+	if err := validateInsecureManifest(mnf, flags.allowInsecureRuntimes); err != nil {
+		return err
+	}
 
 	// Inject the APEIP (from the OVMF passed at build time) into every SNP
 	// reference value entry. This allows SNPValidateOpts to derive launch
@@ -202,7 +212,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("get runtime handler: %w", err)
 		}
 	}
-	if err := patchTargets(fileMap, flags.imageReplacementsFile, runtimeHandler, coordinatorNamespace, flags, mnf); err != nil {
+	if err := patchTargets(fileMap, flags.imageReplacementsFile, runtimeHandler, coordinatorNamespace, flags, mnf, usedPlatforms); err != nil {
 		return fmt.Errorf("patch targets: %w", err)
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Patched targets")
@@ -299,7 +309,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// mapContrastWorkloads applies the given function to all workloads with a Contrast runtime class.
+// mapContrastWorkloads applies the given function to all workloads with the 'contrast-cc' or 'contrast-insecure' runtime class.
 // The callback receives an apply configuration together with the file path and index the unstructured object has in the file map.
 // Changes to the apply configuration are not applied to the original unstructured object.
 func mapContrastWorkloads(fileMap map[string][]*unstructured.Unstructured, f func(res any, path string, idx int) (any, error)) error {
@@ -341,11 +351,29 @@ func isCoordinator(resource any) bool {
 	if ok &&
 		r.Spec != nil &&
 		r.Spec.Template != nil &&
+		r.Spec.Template.Spec != nil &&
 		r.Spec.Template.ObjectMetaApplyConfiguration != nil &&
 		r.Spec.Template.Labels[kuberesource.ContrastRoleLabelKey] == string(manifest.RoleCoordinator) {
 		return true
 	}
 	return false
+}
+
+func patchCoordinatorAllowInsecure(resource any, usedPlatforms kuberesource.PlatformCollection, allowInsecure bool) {
+	r, ok := resource.(*applyappsv1.StatefulSetApplyConfiguration)
+	if !ok || !allowInsecure || !isCoordinator(resource) {
+		return
+	}
+	platformList := usedPlatforms.Platforms()
+	if len(platformList) == 0 || slices.ContainsFunc(platformList, func(p platforms.Platform) bool { return !platforms.IsInsecure(p) }) {
+		return
+	}
+	for i := range r.Spec.Template.Spec.Containers {
+		container := &r.Spec.Template.Spec.Containers[i]
+		if container.Name != nil && *container.Name == string(manifest.RoleCoordinator) {
+			kuberesource.SetContainerEnv(container, allowInsecureEnvVar, "1")
+		}
+	}
 }
 
 func runVerifiers(fileMap map[string][]*unstructured.Unstructured, verifiers []verifier.Verifier) error {
@@ -433,7 +461,7 @@ func extractTargets(paths []string, configFile io.Writer, logger *slog.Logger) (
 		}
 	}
 	if len(fileMap) == 0 {
-		return nil, "", fmt.Errorf("no .yml/.yaml files with 'contrast-cc' runtime found")
+		return nil, "", fmt.Errorf("no .yml/.yaml files with 'contrast-cc' or 'contrast-insecure' runtime found")
 	}
 
 	extraData, err := kuberesource.EncodeUnstructured(extraResources)
@@ -546,7 +574,7 @@ func calculatePodMemory(spec *applycorev1.PodSpecApplyConfiguration, podLayers *
 	return podMemory, nil
 }
 
-func patchTargets(fileMap map[string][]*unstructured.Unstructured, imageReplacementsFile, runtimeHandler, coordinatorNamespace string, flags *generateFlags, mnf *manifest.Manifest) error {
+func patchTargets(fileMap map[string][]*unstructured.Unstructured, imageReplacementsFile, runtimeHandler, coordinatorNamespace string, flags *generateFlags, mnf *manifest.Manifest, usedPlatforms kuberesource.PlatformCollection) error {
 	var replacements map[string]string
 	var err error
 	if imageReplacementsFile != "" {
@@ -590,6 +618,7 @@ func patchTargets(fileMap map[string][]*unstructured.Unstructured, imageReplacem
 		if flags.injectImageStore {
 			kuberesource.AddImageStore([]any{res})
 		}
+		patchCoordinatorAllowInsecure(res, usedPlatforms, flags.allowInsecureRuntimes)
 
 		kuberesource.PatchImages([]any{res}, replacements)
 
@@ -631,6 +660,16 @@ func injectServiceMesh(resource any, memoryProfile kuberesource.MemoryProfile) e
 	}
 	if _, err := kuberesource.AddServiceMesh(resource, kuberesource.ServiceMeshProxy(memoryProfile)); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateInsecurePlatforms(usedPlatforms kuberesource.PlatformCollection, allowInsecure bool) error {
+	if !slices.ContainsFunc(usedPlatforms.Platforms(), platforms.IsInsecure) {
+		return nil
+	}
+	if !allowInsecure {
+		return fmt.Errorf("insecure runtime platforms detected but --INSECURE flag not set (the flag is only available with the %s environment variable set to true)", allowInsecureEnvVar)
 	}
 	return nil
 }
@@ -762,7 +801,17 @@ func patchRuntimeClassName(defaultRuntimeHandler string) func(*applycorev1.PodSp
 		if spec == nil || spec.RuntimeClassName == nil {
 			return spec, nil
 		}
-		if *spec.RuntimeClassName == "kata-cc-isolation" || *spec.RuntimeClassName == "contrast-cc" {
+		if *spec.RuntimeClassName == "kata-cc-isolation" || kuberesource.IsBareContrastRuntimeClass(*spec.RuntimeClassName) {
+			// Only allow the bare runtime class names if the default runtime handler is compatible.
+			// For example, `contrast-cc` should only resolve when `--reference-values` is set to a CC-enabled platform,
+			// and `contrast-insecure` should only resolve when `--reference-values` is set to an insecure platform.
+			if *spec.RuntimeClassName == "contrast-insecure" && !strings.HasPrefix(defaultRuntimeHandler, "contrast-insecure-") {
+				return nil, fmt.Errorf("bare 'contrast-insecure' runtime class requires --reference-values to be set to an insecure platform")
+			}
+			if (*spec.RuntimeClassName == "contrast-cc" || *spec.RuntimeClassName == "kata-cc-isolation") &&
+				strings.HasPrefix(defaultRuntimeHandler, "contrast-insecure-") {
+				return nil, fmt.Errorf("bare %q runtime class is incompatible with insecure --reference-values platform %q", *spec.RuntimeClassName, defaultRuntimeHandler)
+			}
 			spec.RuntimeClassName = &defaultRuntimeHandler
 			if kuberesource.PodSpecRequiresGPU(spec) {
 				platform, err := platforms.FromRuntimeClassString(*spec.RuntimeClassName)
@@ -777,7 +826,7 @@ func patchRuntimeClassName(defaultRuntimeHandler string) func(*applycorev1.PodSp
 			}
 			return spec, nil
 		}
-		if !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc-") {
+		if !kuberesource.IsContrastPod(spec) {
 			return spec, nil
 		}
 		overridePlatform, err := platforms.FromRuntimeClassString(*spec.RuntimeClassName)
@@ -966,6 +1015,7 @@ type generateFlags struct {
 	insecureEnableDebugShell bool
 	calculatePodMemory       bool
 	insecureRegistries       []string
+	allowInsecureRuntimes    bool
 	outputFile               string
 }
 
@@ -1075,6 +1125,13 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	allowInsecureRuntimes := false
+	if cmd.Flags().Lookup("INSECURE") != nil {
+		allowInsecureRuntimes, err = cmd.Flags().GetBool("INSECURE")
+		if err != nil {
+			return nil, err
+		}
+	}
 	outputFile, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return nil, err
@@ -1103,6 +1160,7 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 		insecureEnableDebugShell: insecureEnableDebugShell,
 		calculatePodMemory:       calculatePodMemory,
 		insecureRegistries:       insecureRegistries,
+		allowInsecureRuntimes:    allowInsecureRuntimes,
 		outputFile:               outputFile,
 	}, nil
 }

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -287,7 +287,6 @@ func TestValidateInsecurePlatforms(t *testing.T) {
 	testCases := map[string]struct {
 		platforms      []platforms.Platform
 		allowInsecure  bool
-		setEnv         bool
 		wantErr        bool
 		wantErrContain string
 	}{
@@ -301,35 +300,20 @@ func TestValidateInsecurePlatforms(t *testing.T) {
 			wantErr:        true,
 			wantErrContain: "--INSECURE flag not set",
 		},
-		"insecure with flag but no env": {
-			platforms:      []platforms.Platform{platforms.MetalQEMUInsecure},
-			allowInsecure:  true,
-			setEnv:         false,
-			wantErr:        true,
-			wantErrContain: "CONTRAST_ALLOW_INSECURE",
-		},
-		"insecure with flag and env": {
+		"insecure with flag": {
 			platforms:     []platforms.Platform{platforms.MetalQEMUInsecure},
 			allowInsecure: true,
-			setEnv:        true,
 			wantErr:       false,
 		},
-		"mixed with flag and env": {
+		"mixed with flag": {
 			platforms:     []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUInsecure},
 			allowInsecure: true,
-			setEnv:        true,
 			wantErr:       false,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if tc.setEnv {
-				t.Setenv("CONTRAST_ALLOW_INSECURE", "true")
-			} else {
-				os.Unsetenv("CONTRAST_ALLOW_INSECURE")
-			}
-
 			collection := kuberesource.PlatformCollection{}
 			for _, p := range tc.platforms {
 				collection.Add(p)
@@ -342,6 +326,32 @@ func TestValidateInsecurePlatforms(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestInsecureRuntimesAllowed(t *testing.T) {
+	testCases := map[string]struct {
+		set   bool
+		value string
+		want  bool
+	}{
+		"unset":   {set: false, want: false},
+		"empty":   {set: true, value: "", want: false},
+		"true":    {set: true, value: "true", want: true},
+		"one":     {set: true, value: "1", want: true},
+		"false":   {set: true, value: "false", want: false},
+		"garbage": {set: true, value: "yes please", want: false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("CONTRAST_ALLOW_INSECURE", tc.value)
+			if !tc.set {
+				os.Unsetenv("CONTRAST_ALLOW_INSECURE")
+			}
+
+			assert.Equal(t, tc.want, insecureRuntimesAllowed())
 		})
 	}
 }

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/edgelesssys/contrast/cli/genpolicy"
@@ -79,6 +80,40 @@ spec:
 			},
 			want: []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUTDX},
 		},
+		"single insecure": {
+			yaml: map[string]string{
+				"file1.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p1
+spec:
+  runtimeClassName: contrast-insecure-metal-qemu
+`,
+			},
+			want: []platforms.Platform{platforms.MetalQEMUInsecure},
+		},
+		"mixed cc and insecure": {
+			yaml: map[string]string{
+				"file1.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p1
+spec:
+  runtimeClassName: contrast-cc-metal-qemu-snp
+`,
+				"file2.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p2
+spec:
+  runtimeClassName: contrast-insecure-metal-qemu
+`,
+			},
+			want: []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUInsecure},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -101,33 +136,67 @@ spec:
 }
 
 func TestPatchRuntimeClassName(t *testing.T) {
-	defaultHandler := "contrast-cc-metal-qemu-snp"
+	ccHandler := "contrast-cc-metal-qemu-snp"
+	insecureHandler := "contrast-insecure-metal-qemu"
 
 	testCases := map[string]struct {
-		initial       string
-		want          string
-		updateHandler bool
+		defaultHandler string
+		initial        string
+		want           string
+		updateHandler  bool
+		wantErr        bool
 	}{
 		"no runtime class": {
-			initial: "",
-			want:    "",
+			defaultHandler: ccHandler,
+			initial:        "",
+			want:           "",
 		},
 		"irrelevant class": {
-			initial: "runc",
-			want:    "runc",
+			defaultHandler: ccHandler,
+			initial:        "runc",
+			want:           "runc",
 		},
 		"generic kata": {
-			initial: "kata-cc-isolation",
-			want:    defaultHandler,
+			defaultHandler: ccHandler,
+			initial:        "kata-cc-isolation",
+			want:           ccHandler,
 		},
 		"generic contrast": {
-			initial: "contrast-cc",
-			want:    defaultHandler,
+			defaultHandler: ccHandler,
+			initial:        "contrast-cc",
+			want:           ccHandler,
 		},
 		"specific contrast-cc-metal-qemu-tdx": {
-			initial:       "contrast-cc-metal-qemu-tdx",
-			want:          "contrast-cc-metal-qemu-tdx",
-			updateHandler: true,
+			defaultHandler: ccHandler,
+			initial:        "contrast-cc-metal-qemu-tdx",
+			want:           "contrast-cc-metal-qemu-tdx",
+			updateHandler:  true,
+		},
+		"generic contrast-insecure with insecure handler": {
+			defaultHandler: insecureHandler,
+			initial:        "contrast-insecure",
+			want:           insecureHandler,
+		},
+		"generic contrast-insecure with cc handler errors": {
+			defaultHandler: ccHandler,
+			initial:        "contrast-insecure",
+			wantErr:        true,
+		},
+		"generic contrast-cc with insecure handler errors": {
+			defaultHandler: insecureHandler,
+			initial:        "contrast-cc",
+			wantErr:        true,
+		},
+		"generic kata with insecure handler errors": {
+			defaultHandler: insecureHandler,
+			initial:        "kata-cc-isolation",
+			wantErr:        true,
+		},
+		"specific contrast-insecure-metal-qemu": {
+			defaultHandler: ccHandler,
+			initial:        "contrast-insecure-metal-qemu",
+			want:           "contrast-insecure-metal-qemu",
+			updateHandler:  true,
 		},
 	}
 
@@ -143,12 +212,16 @@ func TestPatchRuntimeClassName(t *testing.T) {
 				tc.want = getHandler(t, tc.want)
 			}
 
-			patch := patchRuntimeClassName(tc.want)
+			patch := patchRuntimeClassName(tc.defaultHandler)
 			spec := applycorev1.PodSpec()
 			if tc.initial != "" {
 				spec.WithRuntimeClassName(tc.initial)
 			}
 			_, err := patch(spec)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			if tc.want == "" {
 				assert.Nil(t, spec.RuntimeClassName)
@@ -160,11 +233,117 @@ func TestPatchRuntimeClassName(t *testing.T) {
 	}
 
 	t.Run("nil spec returns nil", func(t *testing.T) {
-		patch := patchRuntimeClassName(defaultHandler)
+		patch := patchRuntimeClassName(ccHandler)
 		result, err := patch(nil)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
+}
+
+func TestIsContrastWorkload(t *testing.T) {
+	testCases := map[string]struct {
+		runtimeClass string
+		want         bool
+	}{
+		"no runtime class": {
+			runtimeClass: "",
+			want:         false,
+		},
+		"non-contrast runtime class": {
+			runtimeClass: "foobar",
+			want:         false,
+		},
+		"contrast-cc": {
+			runtimeClass: "contrast-cc",
+			want:         true,
+		},
+		"contrast-cc-metal-qemu-snp": {
+			runtimeClass: "contrast-cc-metal-qemu-snp",
+			want:         true,
+		},
+		"contrast-insecure": {
+			runtimeClass: "contrast-insecure",
+			want:         true,
+		},
+		"contrast-insecure-metal-qemu": {
+			runtimeClass: "contrast-insecure-metal-qemu",
+			want:         true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			spec := applycorev1.PodSpec()
+			if tc.runtimeClass != "" {
+				spec.WithRuntimeClassName(tc.runtimeClass)
+			}
+			pod := applycorev1.Pod("test", "default").WithSpec(spec)
+			assert.Equal(t, tc.want, isContrastWorkload(pod))
+		})
+	}
+}
+
+func TestValidateInsecurePlatforms(t *testing.T) {
+	testCases := map[string]struct {
+		platforms      []platforms.Platform
+		allowInsecure  bool
+		setEnv         bool
+		wantErr        bool
+		wantErrContain string
+	}{
+		"no insecure platforms": {
+			platforms: []platforms.Platform{platforms.MetalQEMUSNP},
+			wantErr:   false,
+		},
+		"insecure without flag": {
+			platforms:      []platforms.Platform{platforms.MetalQEMUInsecure},
+			allowInsecure:  false,
+			wantErr:        true,
+			wantErrContain: "--INSECURE flag not set",
+		},
+		"insecure with flag but no env": {
+			platforms:      []platforms.Platform{platforms.MetalQEMUInsecure},
+			allowInsecure:  true,
+			setEnv:         false,
+			wantErr:        true,
+			wantErrContain: "CONTRAST_ALLOW_INSECURE_RUNTIMES",
+		},
+		"insecure with flag and env": {
+			platforms:     []platforms.Platform{platforms.MetalQEMUInsecure},
+			allowInsecure: true,
+			setEnv:        true,
+			wantErr:       false,
+		},
+		"mixed with flag and env": {
+			platforms:     []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUInsecure},
+			allowInsecure: true,
+			setEnv:        true,
+			wantErr:       false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv("CONTRAST_ALLOW_INSECURE_RUNTIMES", "true")
+			} else {
+				os.Unsetenv("CONTRAST_ALLOW_INSECURE_RUNTIMES")
+			}
+
+			collection := kuberesource.PlatformCollection{}
+			for _, p := range tc.platforms {
+				collection.Add(p)
+			}
+
+			err := validateInsecurePlatforms(collection, tc.allowInsecure)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func getHandler(t *testing.T, name string) string {

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -306,7 +306,7 @@ func TestValidateInsecurePlatforms(t *testing.T) {
 			allowInsecure:  true,
 			setEnv:         false,
 			wantErr:        true,
-			wantErrContain: "CONTRAST_ALLOW_INSECURE_RUNTIMES",
+			wantErrContain: "CONTRAST_ALLOW_INSECURE",
 		},
 		"insecure with flag and env": {
 			platforms:     []platforms.Platform{platforms.MetalQEMUInsecure},
@@ -325,9 +325,9 @@ func TestValidateInsecurePlatforms(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			if tc.setEnv {
-				t.Setenv("CONTRAST_ALLOW_INSECURE_RUNTIMES", "true")
+				t.Setenv("CONTRAST_ALLOW_INSECURE", "true")
 			} else {
-				os.Unsetenv("CONTRAST_ALLOW_INSECURE_RUNTIMES")
+				os.Unsetenv("CONTRAST_ALLOW_INSECURE")
 			}
 
 			collection := kuberesource.PlatformCollection{}

--- a/cli/cmd/generate_test.go
+++ b/cli/cmd/generate_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/edgelesssys/contrast/cli/genpolicy"
@@ -79,6 +80,40 @@ spec:
 			},
 			want: []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUTDX},
 		},
+		"single insecure": {
+			yaml: map[string]string{
+				"file1.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p1
+spec:
+  runtimeClassName: contrast-insecure-metal-qemu
+`,
+			},
+			want: []platforms.Platform{platforms.MetalQEMUInsecure},
+		},
+		"mixed cc and insecure": {
+			yaml: map[string]string{
+				"file1.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p1
+spec:
+  runtimeClassName: contrast-cc-metal-qemu-snp
+`,
+				"file2.yaml": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: p2
+spec:
+  runtimeClassName: contrast-insecure-metal-qemu
+`,
+			},
+			want: []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUInsecure},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -101,33 +136,67 @@ spec:
 }
 
 func TestPatchRuntimeClassName(t *testing.T) {
-	defaultHandler := "contrast-cc-metal-qemu-snp"
+	ccHandler := "contrast-cc-metal-qemu-snp"
+	insecureHandler := "contrast-insecure-metal-qemu"
 
 	testCases := map[string]struct {
-		initial       string
-		want          string
-		updateHandler bool
+		defaultHandler string
+		initial        string
+		want           string
+		updateHandler  bool
+		wantErr        bool
 	}{
 		"no runtime class": {
-			initial: "",
-			want:    "",
+			defaultHandler: ccHandler,
+			initial:        "",
+			want:           "",
 		},
 		"irrelevant class": {
-			initial: "runc",
-			want:    "runc",
+			defaultHandler: ccHandler,
+			initial:        "runc",
+			want:           "runc",
 		},
 		"generic kata": {
-			initial: "kata-cc-isolation",
-			want:    defaultHandler,
+			defaultHandler: ccHandler,
+			initial:        "kata-cc-isolation",
+			want:           ccHandler,
 		},
 		"generic contrast": {
-			initial: "contrast-cc",
-			want:    defaultHandler,
+			defaultHandler: ccHandler,
+			initial:        "contrast-cc",
+			want:           ccHandler,
 		},
 		"specific contrast-cc-metal-qemu-tdx": {
-			initial:       "contrast-cc-metal-qemu-tdx",
-			want:          "contrast-cc-metal-qemu-tdx",
-			updateHandler: true,
+			defaultHandler: ccHandler,
+			initial:        "contrast-cc-metal-qemu-tdx",
+			want:           "contrast-cc-metal-qemu-tdx",
+			updateHandler:  true,
+		},
+		"generic contrast-insecure with insecure handler": {
+			defaultHandler: insecureHandler,
+			initial:        "contrast-insecure",
+			want:           insecureHandler,
+		},
+		"generic contrast-insecure with cc handler errors": {
+			defaultHandler: ccHandler,
+			initial:        "contrast-insecure",
+			wantErr:        true,
+		},
+		"generic contrast-cc with insecure handler errors": {
+			defaultHandler: insecureHandler,
+			initial:        "contrast-cc",
+			wantErr:        true,
+		},
+		"generic kata with insecure handler errors": {
+			defaultHandler: insecureHandler,
+			initial:        "kata-cc-isolation",
+			wantErr:        true,
+		},
+		"specific contrast-insecure-metal-qemu": {
+			defaultHandler: ccHandler,
+			initial:        "contrast-insecure-metal-qemu",
+			want:           "contrast-insecure-metal-qemu",
+			updateHandler:  true,
 		},
 	}
 
@@ -143,12 +212,16 @@ func TestPatchRuntimeClassName(t *testing.T) {
 				tc.want = getHandler(t, tc.want)
 			}
 
-			patch := patchRuntimeClassName(tc.want)
+			patch := patchRuntimeClassName(tc.defaultHandler)
 			spec := applycorev1.PodSpec()
 			if tc.initial != "" {
 				spec.WithRuntimeClassName(tc.initial)
 			}
 			_, err := patch(spec)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			if tc.want == "" {
 				assert.Nil(t, spec.RuntimeClassName)
@@ -160,11 +233,243 @@ func TestPatchRuntimeClassName(t *testing.T) {
 	}
 
 	t.Run("nil spec returns nil", func(t *testing.T) {
-		patch := patchRuntimeClassName(defaultHandler)
+		patch := patchRuntimeClassName(ccHandler)
 		result, err := patch(nil)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
+}
+
+func TestIsContrastWorkload(t *testing.T) {
+	testCases := map[string]struct {
+		runtimeClass string
+		want         bool
+	}{
+		"no runtime class": {
+			runtimeClass: "",
+			want:         false,
+		},
+		"non-contrast runtime class": {
+			runtimeClass: "foobar",
+			want:         false,
+		},
+		"contrast-cc": {
+			runtimeClass: "contrast-cc",
+			want:         true,
+		},
+		"contrast-cc-metal-qemu-snp": {
+			runtimeClass: "contrast-cc-metal-qemu-snp",
+			want:         true,
+		},
+		"contrast-insecure": {
+			runtimeClass: "contrast-insecure",
+			want:         true,
+		},
+		"contrast-insecure-metal-qemu": {
+			runtimeClass: "contrast-insecure-metal-qemu",
+			want:         true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			spec := applycorev1.PodSpec()
+			if tc.runtimeClass != "" {
+				spec.WithRuntimeClassName(tc.runtimeClass)
+			}
+			pod := applycorev1.Pod("test", "default").WithSpec(spec)
+			assert.Equal(t, tc.want, isContrastWorkload(pod))
+		})
+	}
+}
+
+func TestPatchCoordinatorAllowInsecure(t *testing.T) {
+	insecurePlatforms := kuberesource.PlatformCollection{
+		platforms.MetalQEMUInsecure: {},
+	}
+	securePlatforms := kuberesource.PlatformCollection{
+		platforms.MetalQEMUSNP: {},
+	}
+	mixedPlatforms := kuberesource.PlatformCollection{
+		platforms.MetalQEMUSNP:      {},
+		platforms.MetalQEMUInsecure: {},
+	}
+
+	newCoordinator := func() *applyappsv1.StatefulSetApplyConfiguration {
+		podSpec := applycorev1.PodSpec().WithContainers(
+			applycorev1.Container().WithName("sidecar"),
+			applycorev1.Container().WithName("coordinator").WithEnv(
+				kuberesource.NewEnvVar("KEEP_ME", "value"),
+				kuberesource.NewEnvVar(allowInsecureEnvVar, "false"),
+			),
+		)
+		template := applycorev1.PodTemplateSpec().
+			WithLabels(map[string]string{kuberesource.ContrastRoleLabelKey: string(manifest.RoleCoordinator)}).
+			WithSpec(podSpec)
+		return applyappsv1.StatefulSet("coordinator", "default").
+			WithSpec(applyappsv1.StatefulSetSpec().WithTemplate(template))
+	}
+
+	t.Run("patches named coordinator container idempotently", func(t *testing.T) {
+		coordinator := newCoordinator()
+		patchCoordinatorAllowInsecure(coordinator, insecurePlatforms, true)
+		patchCoordinatorAllowInsecure(coordinator, insecurePlatforms, true)
+
+		containers := coordinator.Spec.Template.Spec.Containers
+		require.Len(t, containers, 2)
+		assert.Empty(t, containers[0].Env)
+		require.Len(t, containers[1].Env, 2)
+
+		env := map[string]string{}
+		for _, envVar := range containers[1].Env {
+			env[*envVar.Name] = *envVar.Value
+		}
+		assert.Equal(t, "value", env["KEEP_ME"])
+		assert.Equal(t, "1", env[allowInsecureEnvVar])
+	})
+
+	t.Run("does not patch secure platforms", func(t *testing.T) {
+		coordinator := newCoordinator()
+		patchCoordinatorAllowInsecure(coordinator, securePlatforms, true)
+		assert.Equal(t, "false", *coordinator.Spec.Template.Spec.Containers[1].Env[1].Value)
+	})
+
+	t.Run("does not patch mixed platforms", func(t *testing.T) {
+		coordinator := newCoordinator()
+		patchCoordinatorAllowInsecure(coordinator, mixedPlatforms, true)
+		assert.Equal(t, "false", *coordinator.Spec.Template.Spec.Containers[1].Env[1].Value)
+	})
+
+	t.Run("does not patch without opt-in", func(t *testing.T) {
+		coordinator := newCoordinator()
+		patchCoordinatorAllowInsecure(coordinator, insecurePlatforms, false)
+		assert.Equal(t, "false", *coordinator.Spec.Template.Spec.Containers[1].Env[1].Value)
+	})
+
+	t.Run("handles missing pod spec", func(t *testing.T) {
+		template := applycorev1.PodTemplateSpec().
+			WithLabels(map[string]string{kuberesource.ContrastRoleLabelKey: string(manifest.RoleCoordinator)})
+		coordinator := applyappsv1.StatefulSet("coordinator", "default").
+			WithSpec(applyappsv1.StatefulSetSpec().WithTemplate(template))
+
+		assert.False(t, isCoordinator(coordinator))
+		assert.NotPanics(t, func() {
+			patchCoordinatorAllowInsecure(coordinator, insecurePlatforms, true)
+		})
+	})
+}
+
+func TestValidateInsecurePlatforms(t *testing.T) {
+	testCases := map[string]struct {
+		platforms      []platforms.Platform
+		allowInsecure  bool
+		wantErr        bool
+		wantErrContain string
+	}{
+		"no insecure platforms": {
+			platforms: []platforms.Platform{platforms.MetalQEMUSNP},
+			wantErr:   false,
+		},
+		"insecure without flag": {
+			platforms:      []platforms.Platform{platforms.MetalQEMUInsecure},
+			allowInsecure:  false,
+			wantErr:        true,
+			wantErrContain: "--INSECURE flag not set",
+		},
+		"insecure with flag": {
+			platforms:     []platforms.Platform{platforms.MetalQEMUInsecure},
+			allowInsecure: true,
+			wantErr:       false,
+		},
+		"mixed with flag": {
+			platforms:     []platforms.Platform{platforms.MetalQEMUSNP, platforms.MetalQEMUInsecure},
+			allowInsecure: true,
+			wantErr:       false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			collection := kuberesource.PlatformCollection{}
+			for _, p := range tc.platforms {
+				collection.Add(p)
+			}
+
+			err := validateInsecurePlatforms(collection, tc.allowInsecure)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateInsecureManifest(t *testing.T) {
+	testCases := map[string]struct {
+		platform      platforms.Platform
+		allowInsecure bool
+		wantErr       bool
+	}{
+		"secure without flag": {
+			platform: platforms.MetalQEMUSNP,
+		},
+		"secure with flag": {
+			platform:      platforms.MetalQEMUSNP,
+			allowInsecure: true,
+		},
+		"insecure without flag": {
+			platform: platforms.MetalQEMUInsecure,
+			wantErr:  true,
+		},
+		"insecure with flag": {
+			platform:      platforms.MetalQEMUInsecure,
+			allowInsecure: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mnf := &manifest.Manifest{
+				ReferenceValues: manifest.ReferenceValues{
+					SNP: []manifest.SNPReferenceValues{{Platform: tc.platform.String()}},
+				},
+			}
+			err := validateInsecureManifest(mnf, tc.allowInsecure)
+			if tc.wantErr {
+				require.ErrorContains(t, err, "--INSECURE flag not set")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInsecureRuntimesAllowed(t *testing.T) {
+	testCases := map[string]struct {
+		set   bool
+		value string
+		want  bool
+	}{
+		"unset":   {set: false, want: false},
+		"empty":   {set: true, value: "", want: false},
+		"true":    {set: true, value: "true", want: true},
+		"one":     {set: true, value: "1", want: true},
+		"false":   {set: true, value: "false", want: false},
+		"garbage": {set: true, value: "yes please", want: false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(allowInsecureEnvVar, tc.value)
+			if !tc.set {
+				require.NoError(t, os.Unsetenv(allowInsecureEnvVar))
+			}
+
+			assert.Equal(t, tc.want, insecureRuntimesAllowed())
+		})
+	}
 }
 
 func getHandler(t *testing.T, name string) string {

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -49,7 +49,9 @@ all policies, and the certificates of the Coordinator certificate authority.`,
 	cmd.Flags().StringP("coordinator", "c", "", "endpoint the coordinator can be reached at")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "coordinator"))
 	addCollateralProxyFlag(cmd)
-	cmd.Flags().Bool("INSECURE", false, fmt.Sprintf("allow verification of insecure (non-CC) deployments (also requires the %s environment variable to be set)", allowInsecureEnvVar))
+	if insecureRuntimesAllowed() {
+		cmd.Flags().Bool("INSECURE", false, "allow verification of insecure (non-CC) deployments")
+	}
 
 	return cmd
 }
@@ -75,13 +77,8 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if err := json.Unmarshal(manifestBytes, &mnfst); err != nil {
 		return fmt.Errorf("unmarshalling manifest: %w", err)
 	}
-	if mnfst.HasInsecurePlatforms() {
-		if !flags.allowInsecureRuntimes {
-			return fmt.Errorf("manifest contains insecure platforms but --INSECURE flag not set")
-		}
-		if os.Getenv(allowInsecureEnvVar) == "" {
-			return fmt.Errorf("manifest contains insecure platforms but %s environment variable not set", allowInsecureEnvVar)
-		}
+	if mnfst.HasInsecurePlatforms() && !flags.allowInsecureRuntimes {
+		return fmt.Errorf("manifest contains insecure platforms but --INSECURE flag not set (the flag is only available with the %s environment variable set to true)", allowInsecureEnvVar)
 	}
 
 	kdsDir, err := cachedir("kds")
@@ -169,9 +166,12 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	if err != nil {
 		return nil, err
 	}
-	allowInsecureRuntimes, err := cmd.Flags().GetBool("INSECURE")
-	if err != nil {
-		return nil, err
+	allowInsecureRuntimes := false
+	if cmd.Flags().Lookup("INSECURE") != nil {
+		allowInsecureRuntimes, err = cmd.Flags().GetBool("INSECURE")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if workspaceDir != "" {

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -49,6 +49,7 @@ all policies, and the certificates of the Coordinator certificate authority.`,
 	cmd.Flags().StringP("coordinator", "c", "", "endpoint the coordinator can be reached at")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "coordinator"))
 	addCollateralProxyFlag(cmd)
+	cmd.Flags().Bool("INSECURE", false, "allow verification of insecure (non-CC) deployments (also requires the CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable to be set)")
 
 	return cmd
 }
@@ -68,6 +69,19 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	manifestBytes, err := os.ReadFile(flags.manifestPath)
 	if err != nil {
 		return fmt.Errorf("failed to read manifest file: %w", err)
+	}
+
+	var mnfst manifest.Manifest
+	if err := json.Unmarshal(manifestBytes, &mnfst); err != nil {
+		return fmt.Errorf("unmarshalling manifest: %w", err)
+	}
+	if mnfst.HasInsecurePlatforms() {
+		if !flags.allowInsecureRuntimes {
+			return fmt.Errorf("manifest contains insecure platforms but --INSECURE flag not set")
+		}
+		if os.Getenv("CONTRAST_ALLOW_INSECURE_RUNTIMES") == "" {
+			return fmt.Errorf("manifest contains insecure platforms but CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable not set")
+		}
 	}
 
 	kdsDir, err := cachedir("kds")
@@ -131,10 +145,11 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 }
 
 type verifyFlags struct {
-	manifestPath       string
-	coordinator        string
-	workspaceDir       string
-	collateralProxyURL string
+	manifestPath          string
+	coordinator           string
+	workspaceDir          string
+	collateralProxyURL    string
+	allowInsecureRuntimes bool
 }
 
 func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
@@ -154,6 +169,10 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	allowInsecureRuntimes, err := cmd.Flags().GetBool("INSECURE")
+	if err != nil {
+		return nil, err
+	}
 
 	if workspaceDir != "" {
 		// Prepend default path with workspaceDir
@@ -163,10 +182,11 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	}
 
 	return &verifyFlags{
-		manifestPath:       manifestPath,
-		coordinator:        coordinator,
-		workspaceDir:       workspaceDir,
-		collateralProxyURL: collateralProxyURL,
+		manifestPath:          manifestPath,
+		coordinator:           coordinator,
+		workspaceDir:          workspaceDir,
+		collateralProxyURL:    collateralProxyURL,
+		allowInsecureRuntimes: allowInsecureRuntimes,
 	}, nil
 }
 

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -49,7 +49,7 @@ all policies, and the certificates of the Coordinator certificate authority.`,
 	cmd.Flags().StringP("coordinator", "c", "", "endpoint the coordinator can be reached at")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "coordinator"))
 	addCollateralProxyFlag(cmd)
-	cmd.Flags().Bool("INSECURE", false, "allow verification of insecure (non-CC) deployments (also requires the CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable to be set)")
+	cmd.Flags().Bool("INSECURE", false, fmt.Sprintf("allow verification of insecure (non-CC) deployments (also requires the %s environment variable to be set)", allowInsecureEnvVar))
 
 	return cmd
 }
@@ -79,8 +79,8 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		if !flags.allowInsecureRuntimes {
 			return fmt.Errorf("manifest contains insecure platforms but --INSECURE flag not set")
 		}
-		if os.Getenv("CONTRAST_ALLOW_INSECURE_RUNTIMES") == "" {
-			return fmt.Errorf("manifest contains insecure platforms but CONTRAST_ALLOW_INSECURE_RUNTIMES environment variable not set")
+		if os.Getenv(allowInsecureEnvVar) == "" {
+			return fmt.Errorf("manifest contains insecure platforms but %s environment variable not set", allowInsecureEnvVar)
 		}
 	}
 

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -87,7 +87,7 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	}
 	log.Debug("Using KDS cache dir", "dir", kdsDir)
 
-	resp, err := getCoordinatorState(cmd.Context(), kdsDir, manifestBytes, flags.coordinator, flags.collateralProxyURL, log)
+	resp, err := getCoordinatorState(cmd.Context(), kdsDir, mnfst, flags.coordinator, flags.collateralProxyURL, log)
 	if err != nil {
 		return fmt.Errorf("getting manifests: %w", err)
 	}
@@ -206,11 +206,7 @@ func writeFilelist(dir string, filelist map[string][]byte) error {
 }
 
 // getCoordinatorState calls GetManifests on the coordinator's userapi via aTLS.
-func getCoordinatorState(ctx context.Context, kdsDir string, manifestBytes []byte, endpoint, collateralProxy string, log *slog.Logger) (sdk.CoordinatorState, error) {
-	var m manifest.Manifest
-	if err := json.Unmarshal(manifestBytes, &m); err != nil {
-		return sdk.CoordinatorState{}, fmt.Errorf("unmarshalling manifest: %w", err)
-	}
+func getCoordinatorState(ctx context.Context, kdsDir string, m manifest.Manifest, endpoint, collateralProxy string, log *slog.Logger) (sdk.CoordinatorState, error) {
 	if err := m.Validate(); err != nil {
 		return sdk.CoordinatorState{}, fmt.Errorf("validating manifest: %w", err)
 	}

--- a/cli/cmd/verify.go
+++ b/cli/cmd/verify.go
@@ -49,6 +49,9 @@ all policies, and the certificates of the Coordinator certificate authority.`,
 	cmd.Flags().StringP("coordinator", "c", "", "endpoint the coordinator can be reached at")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "coordinator"))
 	addCollateralProxyFlag(cmd)
+	if insecureRuntimesAllowed() {
+		cmd.Flags().Bool("INSECURE", false, "allow verification of insecure (non-CC) deployments")
+	}
 
 	return cmd
 }
@@ -70,13 +73,21 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to read manifest file: %w", err)
 	}
 
+	var mnfst manifest.Manifest
+	if err := json.Unmarshal(manifestBytes, &mnfst); err != nil {
+		return fmt.Errorf("unmarshalling manifest: %w", err)
+	}
+	if err := validateInsecureManifest(&mnfst, flags.allowInsecureRuntimes); err != nil {
+		return err
+	}
+
 	kdsDir, err := cachedir("kds")
 	if err != nil {
 		return fmt.Errorf("getting cache dir: %w", err)
 	}
 	log.Debug("Using KDS cache dir", "dir", kdsDir)
 
-	resp, err := getCoordinatorState(cmd.Context(), kdsDir, manifestBytes, flags.coordinator, flags.collateralProxyURL, log)
+	resp, err := getCoordinatorState(cmd.Context(), kdsDir, mnfst, flags.coordinator, flags.collateralProxyURL, log)
 	if err != nil {
 		return fmt.Errorf("getting manifests: %w", err)
 	}
@@ -131,10 +142,11 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 }
 
 type verifyFlags struct {
-	manifestPath       string
-	coordinator        string
-	workspaceDir       string
-	collateralProxyURL string
+	manifestPath          string
+	coordinator           string
+	workspaceDir          string
+	collateralProxyURL    string
+	allowInsecureRuntimes bool
 }
 
 func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
@@ -154,6 +166,13 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	allowInsecureRuntimes := false
+	if cmd.Flags().Lookup("INSECURE") != nil {
+		allowInsecureRuntimes, err = cmd.Flags().GetBool("INSECURE")
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if workspaceDir != "" {
 		// Prepend default path with workspaceDir
@@ -163,10 +182,11 @@ func parseVerifyFlags(cmd *cobra.Command) (*verifyFlags, error) {
 	}
 
 	return &verifyFlags{
-		manifestPath:       manifestPath,
-		coordinator:        coordinator,
-		workspaceDir:       workspaceDir,
-		collateralProxyURL: collateralProxyURL,
+		manifestPath:          manifestPath,
+		coordinator:           coordinator,
+		workspaceDir:          workspaceDir,
+		collateralProxyURL:    collateralProxyURL,
+		allowInsecureRuntimes: allowInsecureRuntimes,
 	}, nil
 }
 
@@ -186,11 +206,7 @@ func writeFilelist(dir string, filelist map[string][]byte) error {
 }
 
 // getCoordinatorState calls GetManifests on the coordinator's userapi via aTLS.
-func getCoordinatorState(ctx context.Context, kdsDir string, manifestBytes []byte, endpoint, collateralProxy string, log *slog.Logger) (sdk.CoordinatorState, error) {
-	var m manifest.Manifest
-	if err := json.Unmarshal(manifestBytes, &m); err != nil {
-		return sdk.CoordinatorState{}, fmt.Errorf("unmarshalling manifest: %w", err)
-	}
+func getCoordinatorState(ctx context.Context, kdsDir string, m manifest.Manifest, endpoint, collateralProxy string, log *slog.Logger) (sdk.CoordinatorState, error) {
 	if err := m.Validate(); err != nil {
 		return sdk.CoordinatorState{}, fmt.Errorf("validating manifest: %w", err)
 	}

--- a/cli/genpolicy/genpolicy.go
+++ b/cli/genpolicy/genpolicy.go
@@ -56,6 +56,7 @@ func New(rulesPath, settingsPath, cachePath string, bin []byte) (*Runner, error)
 func (r *Runner) Run(ctx context.Context, res any, extraPath string, needLayersCache bool, logger *slog.Logger) (string, *LayersCache, error) {
 	args := []string{
 		"--runtime-class-names=contrast-cc",
+		"--runtime-class-names=contrast-insecure",
 		"--rego-rules-path=" + r.rulesPath,
 		"--json-settings-path=" + r.settingsPath,
 		"--layers-cache-file-path=" + r.cachePath,

--- a/cli/genpolicy/genpolicy.go
+++ b/cli/genpolicy/genpolicy.go
@@ -58,6 +58,7 @@ func New(rulesPath, settingsPath, cachePath string, insecureRegistries []string,
 func (r *Runner) Run(ctx context.Context, res any, extraPath string, needLayersCache bool, logger *slog.Logger) (string, *LayersCache, error) {
 	args := []string{
 		"--runtime-class-names=contrast-cc",
+		"--runtime-class-names=contrast-insecure",
 		"--rego-rules-path=" + r.rulesPath,
 		"--json-settings-path=" + r.settingsPath,
 		"--layers-cache-file-path=" + r.cachePath,

--- a/cli/verifier/image_ref_valid.go
+++ b/cli/verifier/image_ref_valid.go
@@ -26,6 +26,7 @@ func (v *ImageRefValid) Verify(toVerify any) error {
 		spec *applycorev1.PodSpecApplyConfiguration,
 	) *applycorev1.PodSpecApplyConfiguration {
 		if !kuberesource.IsContrastPod(spec) {
+			// Non-Contrast pods are not subject to this verification.
 			return spec
 		}
 

--- a/cli/verifier/no_shared_fs_mount.go
+++ b/cli/verifier/no_shared_fs_mount.go
@@ -25,7 +25,7 @@ func (v *NoSharedFSMount) Verify(toVerify any) error {
 	isNonCC := false
 	kuberesource.MapPodSpec(toVerify, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
 		if !kuberesource.IsContrastPod(spec) {
-			// this isn't a confidential pod so we don't need to check further
+			// this isn't a Contrast pod so we don't need to check further
 			isNonCC = true
 			return spec
 		}

--- a/cli/verifier/no_shared_fs_mount.go
+++ b/cli/verifier/no_shared_fs_mount.go
@@ -26,7 +26,7 @@ func (v *NoSharedFSMount) Verify(toVerify any) error {
 	isNonCC := false
 	kuberesource.MapPodSpec(toVerify, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
 		if !kuberesource.IsContrastPod(spec) {
-			// this isn't a confidential pod so we don't need to check further
+			// this isn't a Contrast pod so we don't need to check further
 			isNonCC = true
 			return spec
 		}

--- a/cli/verifier/runtimeclasses_exist.go
+++ b/cli/verifier/runtimeclasses_exist.go
@@ -6,7 +6,6 @@ package verifier
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/platforms"
@@ -15,12 +14,12 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
-// RuntimeClassesExist verifies that all used contrast-cc -prefixed runtimeClassNames are valid.
+// RuntimeClassesExist verifies that all used contrast-cc or contrast-insecure prefixed runtimeClassNames are valid.
 type RuntimeClassesExist struct {
 	Command *cobra.Command
 }
 
-// Verify verifies that all used contrast-cc -prefixed runtimeClassNames are valid.
+// Verify verifies that all used contrast-cc or contrast-insecure prefixed runtimeClassNames are valid.
 func (r *RuntimeClassesExist) Verify(toVerify any) error {
 	var collectedErrs error
 	collectedMissingRuntimes := map[string]error{}
@@ -31,14 +30,15 @@ func (r *RuntimeClassesExist) Verify(toVerify any) error {
 	}
 
 	kuberesource.MapPodSpec(toVerify, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
-		if spec == nil || spec.RuntimeClassName == nil {
+		if !kuberesource.IsContrastPod(spec) {
 			return spec
 		}
-		if defaultRuntimeClass == "" && *spec.RuntimeClassName == "contrast-cc" {
-			collectedMissingRuntimes["contrast-cc"] = fmt.Errorf("no default platform was specified using --reference-values")
-			return spec
-		}
-		if !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc-") {
+		// Bare runtime class names (without hash suffix) are placeholders that
+		// get resolved during generate. They can't be parsed as platforms.
+		if *spec.RuntimeClassName == "contrast-cc" || *spec.RuntimeClassName == "contrast-insecure" {
+			if defaultRuntimeClass == "" {
+				collectedMissingRuntimes[*spec.RuntimeClassName] = fmt.Errorf("no default platform was specified using --reference-values")
+			}
 			return spec
 		}
 

--- a/cli/verifier/runtimeclasses_exist.go
+++ b/cli/verifier/runtimeclasses_exist.go
@@ -6,7 +6,6 @@ package verifier
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/edgelesssys/contrast/internal/kuberesource"
 	"github.com/edgelesssys/contrast/internal/platforms"
@@ -15,12 +14,12 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
-// RuntimeClassesExist verifies that all used contrast-cc -prefixed runtimeClassNames are valid.
+// RuntimeClassesExist verifies that all used contrast-cc or contrast-insecure prefixed runtimeClassNames are valid.
 type RuntimeClassesExist struct {
 	Command *cobra.Command
 }
 
-// Verify verifies that all used contrast-cc -prefixed runtimeClassNames are valid.
+// Verify verifies that all used contrast-cc or contrast-insecure prefixed runtimeClassNames are valid.
 func (r *RuntimeClassesExist) Verify(toVerify any) error {
 	var collectedErrs error
 	collectedMissingRuntimes := map[string]error{}
@@ -31,14 +30,15 @@ func (r *RuntimeClassesExist) Verify(toVerify any) error {
 	}
 
 	kuberesource.MapPodSpec(toVerify, func(spec *applycorev1.PodSpecApplyConfiguration) *applycorev1.PodSpecApplyConfiguration {
-		if spec == nil || spec.RuntimeClassName == nil {
+		if !kuberesource.IsContrastPod(spec) {
 			return spec
 		}
-		if defaultRuntimeClass == "" && *spec.RuntimeClassName == "contrast-cc" {
-			collectedMissingRuntimes["contrast-cc"] = fmt.Errorf("no default platform was specified using --reference-values")
-			return spec
-		}
-		if !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc-") {
+		// Bare runtime class names (without hash suffix) are placeholders that
+		// get resolved during generate. They can't be parsed as platforms.
+		if kuberesource.IsBareContrastRuntimeClass(*spec.RuntimeClassName) {
+			if defaultRuntimeClass == "" {
+				collectedMissingRuntimes[*spec.RuntimeClassName] = fmt.Errorf("no default platform was specified using --reference-values")
+			}
 			return spec
 		}
 

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -128,7 +128,7 @@ func run() (retErr error) {
 	userAPICredentials := atlscredentials.New(issuer, nil, atls.NoMetrics, loggerpkg.NewNamed(logger, "atlscredentials"))
 	userAPIServer := newGRPCServer(userAPICredentials, serverMetrics)
 	userapiService := userapiserver.New(logger, meshAuth, discovery)
-	if os.Getenv(allowInsecureEnvVar) != "" {
+	if insecureRuntimesAllowed() {
 		logger.Warn("Coordinator is configured to allow insecure manifests")
 		userapiService.MakeInsecure()
 	}
@@ -296,6 +296,12 @@ func run() (retErr error) {
 	})
 
 	return eg.Wait()
+}
+
+// insecureRuntimesAllowed reports whether allowInsecureEnvVar is set to a value that parses as true.
+func insecureRuntimesAllowed() bool {
+	allowed, err := strconv.ParseBool(os.Getenv(allowInsecureEnvVar))
+	return err == nil && allowed
 }
 
 func newServerMetrics(reg *prometheus.Registry) *grpcprometheus.ServerMetrics {

--- a/coordinator/main_test.go
+++ b/coordinator/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsecureRuntimesAllowed(t *testing.T) {
+	testCases := map[string]struct {
+		value string
+		want  bool
+	}{
+		"empty":   {value: "", want: false},
+		"true":    {value: "true", want: true},
+		"one":     {value: "1", want: true},
+		"false":   {value: "false", want: false},
+		"garbage": {value: "yes please", want: false},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(allowInsecureEnvVar, tc.value)
+			assert.Equal(t, tc.want, insecureRuntimesAllowed())
+		})
+	}
+}

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -26,7 +26,7 @@ import (
 const CollateralProxyDefaultService = "http://collateral-proxy.default.svc"
 
 // contrastRuntimeClassPrefixes lists runtime class prefixes that identify Contrast pods.
-var contrastRuntimeClassPrefixes = []string{"contrast-cc"}
+var contrastRuntimeClassPrefixes = []string{"contrast-cc", "contrast-insecure"}
 
 // IsContrastPod reports whether a pod uses a Contrast runtime.
 func IsContrastPod(spec *applycorev1.PodSpecApplyConfiguration) bool {

--- a/internal/kuberesource/mutators.go
+++ b/internal/kuberesource/mutators.go
@@ -26,7 +26,12 @@ import (
 const CollateralProxyDefaultService = "http://collateral-proxy.default.svc"
 
 // contrastRuntimeClassPrefixes lists runtime class prefixes that identify Contrast pods.
-var contrastRuntimeClassPrefixes = []string{"contrast-cc"}
+var contrastRuntimeClassPrefixes = []string{"contrast-cc", "contrast-insecure"}
+
+// IsBareContrastRuntimeClass reports whether name is a Contrast runtime class without a platform suffix.
+func IsBareContrastRuntimeClass(name string) bool {
+	return slices.Contains(contrastRuntimeClassPrefixes, name)
+}
 
 // IsContrastPod reports whether a pod uses a Contrast runtime.
 func IsContrastPod(spec *applycorev1.PodSpecApplyConfiguration) bool {
@@ -304,7 +309,7 @@ func SetCollateralProxyEnv(resources []any, proxyURL string) []any {
 				return meta, spec
 			}
 			for i := range spec.Containers {
-				setEnv(&spec.Containers[i], constants.CollateralProxyEnvVar, proxyURL)
+				SetContainerEnv(&spec.Containers[i], constants.CollateralProxyEnvVar, proxyURL)
 			}
 			return meta, spec
 		}))
@@ -312,11 +317,11 @@ func SetCollateralProxyEnv(resources []any, proxyURL string) []any {
 	return out
 }
 
-// setEnv sets the environment variable name to value on c, replacing any existing value.
-func setEnv(c *applycorev1.ContainerApplyConfiguration, name, value string) {
+// SetContainerEnv sets the environment variable name to value on c, replacing any existing value.
+func SetContainerEnv(c *applycorev1.ContainerApplyConfiguration, name, value string) {
 	for i := range c.Env {
 		if c.Env[i].Name != nil && *c.Env[i].Name == name {
-			c.Env[i].Value = &value
+			c.Env[i] = *NewEnvVar(name, value)
 			return
 		}
 	}

--- a/internal/kuberesource/runtimeclasses.go
+++ b/internal/kuberesource/runtimeclasses.go
@@ -90,7 +90,12 @@ func (p PlatformCollection) AddFromResources(resources []any) error {
 	for _, resource := range resources {
 		_ = MapPodSpecWithMeta(resource, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration,
 		) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
-			if spec == nil || spec.RuntimeClassName == nil || !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc-") {
+			if !IsContrastPod(spec) {
+				return meta, spec
+			}
+			// Bare runtime class names (e.g. "contrast-cc") are placeholders
+			// that get resolved during generate. Skip them here.
+			if *spec.RuntimeClassName == "contrast-cc" || *spec.RuntimeClassName == "contrast-insecure" {
 				return meta, spec
 			}
 			platform, err := platforms.FromRuntimeClassString(*spec.RuntimeClassName)

--- a/internal/kuberesource/runtimeclasses.go
+++ b/internal/kuberesource/runtimeclasses.go
@@ -90,7 +90,12 @@ func (p PlatformCollection) AddFromResources(resources []any) error {
 	for _, resource := range resources {
 		_ = MapPodSpecWithMeta(resource, func(meta *applymetav1.ObjectMetaApplyConfiguration, spec *applycorev1.PodSpecApplyConfiguration,
 		) (*applymetav1.ObjectMetaApplyConfiguration, *applycorev1.PodSpecApplyConfiguration) {
-			if spec == nil || spec.RuntimeClassName == nil || !strings.HasPrefix(*spec.RuntimeClassName, "contrast-cc-") {
+			if !IsContrastPod(spec) {
+				return meta, spec
+			}
+			// Bare runtime class names (e.g. "contrast-cc") are placeholders
+			// that get resolved during generate. Skip them here.
+			if IsBareContrastRuntimeClass(*spec.RuntimeClassName) {
 				return meta, spec
 			}
 			platform, err := platforms.FromRuntimeClassString(*spec.RuntimeClassName)

--- a/internal/kuberesource/runtimeclasses_test.go
+++ b/internal/kuberesource/runtimeclasses_test.go
@@ -13,6 +13,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsBareContrastRuntimeClass(t *testing.T) {
+	testCases := map[string]struct {
+		runtimeClass string
+		want         bool
+	}{
+		"empty":                   {},
+		"bare cc":                 {runtimeClass: "contrast-cc", want: true},
+		"bare insecure":           {runtimeClass: "contrast-insecure", want: true},
+		"qualified cc":            {runtimeClass: "contrast-cc-metal-qemu-snp"},
+		"qualified insecure":      {runtimeClass: "contrast-insecure-metal-qemu"},
+		"legacy kata":             {runtimeClass: "kata-cc-isolation"},
+		"unrelated runtime class": {runtimeClass: "unrelated-runtime-class"},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsBareContrastRuntimeClass(tc.runtimeClass))
+		})
+	}
+}
+
 func TestNames(t *testing.T) {
 	testCases := map[string]struct {
 		p    PlatformCollection


### PR DESCRIPTION
Re-roll of https://github.com/edgelesssys/contrast/pull/2357, split from #2337 as part of a stacked review series.
Closes CON-245

This PR adds CLI support for insecure manifests behind explicit opt-in:
- generate support
- verify support
- runtime class handling for insecure runtimes
- verifier and mutator updates
- tests