### PR TITLE
scripts: drop content prune from bare metal containerd cleanup

### DIFF
--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -481,7 +481,6 @@
           tail -n +2 |
           cut -d' ' -f1
       )
-      ctr --address "$address" --namespace k8s.io content prune references
     '';
   };
 


### PR DESCRIPTION
The prune removes the labels that link a manifest to its layer blobs.
Any image that exists or is being pulled while the cleanup runs loses
its layer blobs at the next GC, but keeps its image record. Kubelet
then thinks the image is present and never pulls it again, and pulls
that do happen skip the layer download because the unpacked snapshots
still exist. The embedded registry mirror can no longer serve the
layers, so all in-guest pulls on the node fail with MANIFEST_UNKNOWN
until the image record is deleted by hand. This broke all TDX e2e
tests on 2026-07-19 and also explains the 2026-04-30 debugshell
incident.

The image rm --sync loop above already frees everything the cleanup
should free, so the prune is not needed.