### PR TITLE
nodeinstaller: support containerd config v4

### DIFF
--- a/nodeinstaller/internal/containerdconfig/config.go
+++ b/nodeinstaller/internal/containerdconfig/config.go
@@ -57,9 +57,14 @@ func FromPath(path string) (*Config, error) {
 }
 
 // AddRuntime adds a runtime to the containerd config.
-func (c *Config) AddRuntime(handler string, runtime Runtime) {
-	runtimes := ensureMapPath(&c.config.Plugins, criFQDN(c.config.Version), "containerd", "runtimes")
+func (c *Config) AddRuntime(handler string, runtime Runtime) error {
+	fqdn, err := criFQDN(c.config.Version)
+	if err != nil {
+		return err
+	}
+	runtimes := ensureMapPath(&c.config.Plugins, fqdn, "containerd", "runtimes")
 	runtimes[handler] = runtime
+	return nil
 }
 
 // EnableDebug enables debug logging in the containerd config.
@@ -166,12 +171,14 @@ func ContrastRuntime(baseDir string, platform platforms.Platform) (Runtime, erro
 }
 
 // criFQDN is the fully qualified domain name of the CRI service, which depends on the containerd config version.
-func criFQDN(v int) string {
+func criFQDN(v int) (string, error) {
 	switch v {
-	case 3:
-		return "io.containerd.cri.v1.runtime"
+	case 3, 4:
+		return "io.containerd.cri.v1.runtime", nil
+	case 2:
+		return "io.containerd.grpc.v1.cri", nil
 	default:
-		return "io.containerd.grpc.v1.cri"
+		return "", fmt.Errorf("unsupported containerd config version: %d", v)
 	}
 }
 

--- a/nodeinstaller/internal/containerdconfig/config_test.go
+++ b/nodeinstaller/internal/containerdconfig/config_test.go
@@ -64,7 +64,7 @@ func TestPatchContainerdConfig(t *testing.T) {
 			conf.EnableDebug()
 			runtimeFragment, err := ContrastRuntime(runtimeBaseDir, tc.platform)
 			require.NoError(err)
-			conf.AddRuntime(runtimeHandler, runtimeFragment)
+			require.NoError(conf.AddRuntime(runtimeHandler, runtimeFragment))
 			require.NoError(conf.Write())
 
 			configData, err := os.ReadFile(configPath)
@@ -165,33 +165,103 @@ func TestConfig(t *testing.T) {
 		}
 	})
 	t.Run("AddRuntime", func(t *testing.T) {
-		assert := assert.New(t)
-
-		cfg := Config{
-			config: config{Version: 2},
-		}
-		runtimeName := "my-runtime"
+		const runtimeName = "my-runtime"
 		runtime := Runtime{
 			Type: "io.containerd.runc.v2",
 			Path: "/opt/my-runtime/bin/containerd-runtime",
 		}
-		cfg.AddRuntime(runtimeName, runtime)
 
-		expected := Config{
-			config: config{
-				Version: 2,
-				Plugins: map[string]any{
-					criFQDN(2): map[string]any{
-						"containerd": map[string]any{
-							"runtimes": map[string]any{
-								runtimeName: runtime,
+		for name, tc := range map[string]struct {
+			input     Config
+			expected  Config
+			expectErr bool
+		}{
+			"no version": {
+				input: Config{
+					config: config{},
+				},
+				expectErr: true,
+			},
+			"v1": {
+				input: Config{
+					config: config{Version: 1},
+				},
+				expectErr: true,
+			},
+			"v2": {
+				input: Config{
+					config: config{Version: 2},
+				},
+				expected: Config{
+					config: config{
+						Version: 2,
+						Plugins: map[string]any{
+							"io.containerd.grpc.v1.cri": map[string]any{
+								"containerd": map[string]any{
+									"runtimes": map[string]any{
+										runtimeName: runtime,
+									},
+								},
 							},
 						},
 					},
 				},
 			},
+			"v3": {
+				input: Config{
+					config: config{Version: 3},
+				},
+				expected: Config{
+					config: config{
+						Version: 3,
+						Plugins: map[string]any{
+							"io.containerd.cri.v1.runtime": map[string]any{
+								"containerd": map[string]any{
+									"runtimes": map[string]any{
+										runtimeName: runtime,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"v4": {
+				input: Config{
+					config: config{Version: 4},
+				},
+				expected: Config{
+					config: config{
+						Version: 4,
+						Plugins: map[string]any{
+							"io.containerd.cri.v1.runtime": map[string]any{
+								"containerd": map[string]any{
+									"runtimes": map[string]any{
+										runtimeName: runtime,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"v5": {
+				input: Config{
+					config: config{Version: 5},
+				},
+				expectErr: true,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				assert := assert.New(t)
+				err := tc.input.AddRuntime(runtimeName, runtime)
+				if tc.expectErr {
+					assert.Error(err)
+					return
+				}
+				assert.Equal(tc.expected, tc.input)
+			})
 		}
-		assert.Equal(expected.config, cfg.config)
 	})
 	t.Run("EnableDebug", func(t *testing.T) {
 		assert := assert.New(t)

--- a/nodeinstaller/node-installer.go
+++ b/nodeinstaller/node-installer.go
@@ -107,7 +107,9 @@ func run(ctx context.Context, fetcher assetFetcher, platform platforms.Platform)
 	if err != nil {
 		return fmt.Errorf("generating containerd runtime fragment: %w", err)
 	}
-	containerdConf.AddRuntime(runtimeHandler, containerdRuntime)
+	if err := containerdConf.AddRuntime(runtimeHandler, containerdRuntime); err != nil {
+		return fmt.Errorf("adding runtime to containerd config: %w", err)
+	}
 	if err := containerdConf.Write(); err != nil {
 		return fmt.Errorf("writing containerd config %q: %w", targetConf.ContainerdConfigPath(), err)
 	}


### PR DESCRIPTION
Config version 4 has been released with containerd v2.3.0. The changes are mostly deprecations, of which we are not affected. The only config item that we're using is the `io.containerd.cri.v1` plugin. This plugin is still supported, did not move, and all the fields we're setting are not deprecated as of containerd 2.3.

New containerd config versions will now fail hard and require a new Contrast release. We're picking the conservative path here to avoid unforeseen consequences of setting wrong paths in a new config layout.

Fixes CON-81.