### PR TITLE
scripts.select-e2e-tests: placate nix not wanting to eval a shallow repo

### DIFF
--- a/e2e/kds-pcs-downtime/kds-pcs-downtime_test.go
+++ b/e2e/kds-pcs-downtime/kds-pcs-downtime_test.go
@@ -1,7 +1,6 @@
 // Copyright 2025 Edgeless Systems GmbH
 // SPDX-License-Identifier: BUSL-1.1
 
-// test-if: nix:containers.collateral-proxy
 // test-if: path:internal/attestation/certcache
 
 //go:build e2e

--- a/packages/by-name/scripts/select-e2e-tests/select-e2e-tests.sh
+++ b/packages/by-name/scripts/select-e2e-tests/select-e2e-tests.sh
@@ -117,8 +117,8 @@ else
     done < <(directives_of "$name")
   done < <(list_test_names)
   for attr in "${!nix_attrs[@]}"; do
-    b=$(nix eval --raw "git+file://$root?rev=$base_sha#base.$attr.drvPath" 2>/dev/null || true)
-    h=$(nix eval --raw "git+file://$root?rev=$head_sha#base.$attr.drvPath" 2>/dev/null || true)
+    b=$(nix eval --raw "git+file://$root?shallow=1&rev=$base_sha#base.$attr.drvPath" 2>/dev/null || true)
+    h=$(nix eval --raw "git+file://$root?shallow=1&rev=$head_sha#base.$attr.drvPath" 2>/dev/null || true)
     if [[ -z $b || -z $h ]]; then
       printf 'select-e2e-tests: warning: cannot evaluate nix:%s, assuming changed\n' "$attr" >&2
       nix_changed[$attr]=1


### PR DESCRIPTION
Noticed way more tests than expected were running here: https://github.com/edgelesssys/contrast/actions/runs/30010354157/job/89216542581?pr=2543

Reason seems to be that nix refuses to evaluate on a shallow git clone by default, failing the evaluation, and we include failed ones by default on purpose.