### PR TITLE
execserver: add protocol and handler for running remote commands

### DIFF
--- a/internal/execserver/codec.go
+++ b/internal/execserver/codec.go
@@ -1,0 +1,59 @@
+package execserver
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// MaxMessageSize is the largest JSON message accepted by ReadMessage.
+const MaxMessageSize = 1 << 20 // 1 MiB
+
+const readBufSize = 32 * 1024
+
+// WriteMessage marshals v to JSON and writes it to w as a single frame, prefixed with its
+// length as a 4-byte big-endian integer.
+func WriteMessage(w io.Writer, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshaling message: %w", err)
+	}
+	if len(data) > MaxMessageSize {
+		return fmt.Errorf("%w: maximum %d bytes, encoded message is %d bytes", ErrMessageTooLarge, MaxMessageSize, len(data))
+	}
+
+	if err := binary.Write(w, binary.BigEndian, uint32(len(data))); err != nil {
+		return fmt.Errorf("writing header: %w", err)
+	}
+	if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("writing message: %w", err)
+	}
+	return nil
+}
+
+// ReadMessage reads a single length-prefixed frame from r, as written by WriteMessage, and
+// unmarshals its JSON payload into v.
+func ReadMessage(r io.Reader, v any) error {
+	var size uint32
+	if err := binary.Read(r, binary.BigEndian, &size); err != nil {
+		return fmt.Errorf("reading header: %w", err)
+	}
+	if size > MaxMessageSize {
+		return fmt.Errorf("%w: maximum %d bytes, incoming message is %d bytes", ErrMessageTooLarge, MaxMessageSize, size)
+	}
+
+	data := make([]byte, size)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return fmt.Errorf("reading message: %w", err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("unmarshaling message: %w", err)
+	}
+	return nil
+}
+
+// ErrMessageTooLarge is returned if the serialized message exceeds the maximum size.
+var ErrMessageTooLarge = errors.New("message to large")

--- a/internal/execserver/codec_test.go
+++ b/internal/execserver/codec_test.go
@@ -1,0 +1,32 @@
+package execserver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReadMessageRoundTrip(t *testing.T) {
+	require := require.New(t)
+	want := &Request{Cmd: []string{"echo", "hi"}}
+
+	var buf bytes.Buffer
+	require.NoError(WriteMessage(&buf, want))
+
+	var got Request
+	require.NoError(ReadMessage(&buf, &got))
+	require.Equal(want, &got)
+}
+
+func TestWriteMessageRejectsOversized(t *testing.T) {
+	var buf bytes.Buffer
+	require.ErrorIs(t, WriteMessage(&buf, &StreamEvent{Data: make([]byte, MaxMessageSize+1)}), ErrMessageTooLarge)
+}
+
+func TestReadMessageRejectsOversizedLengthPrefix(t *testing.T) {
+	// A length prefix claiming more than MaxMessageSize must be rejected before
+	// ReadMessage allocates a buffer for the (nonexistent) payload.
+	var got StreamEvent
+	require.ErrorIs(t, ReadMessage(bytes.NewReader([]byte{0xFF, 0xFF, 0xFF, 0xFF}), &got), ErrMessageTooLarge)
+}

--- a/internal/execserver/execserver_test.go
+++ b/internal/execserver/execserver_test.go
@@ -1,0 +1,82 @@
+package execserver
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestRun(t *testing.T) {
+	for name, tc := range map[string]struct {
+		stdin string
+		cmd   []string
+
+		wantCode   int
+		wantStdout string
+		wantStderr string
+	}{
+		"echo to stdout": {
+			cmd:        []string{"echo", "hello world"},
+			wantStdout: "hello world\n",
+		},
+		"echo to stderr": {
+			cmd:        []string{"sh", "-c", `echo "hello world" >&2`},
+			wantStderr: "hello world\n",
+		},
+		"mirror stdin": {
+			cmd:        []string{"cat"},
+			stdin:      "ping",
+			wantStdout: "ping",
+		},
+		"non-zero exit code": {
+			cmd:      []string{"sh", "-c", "exit 5"},
+			wantCode: 5,
+		},
+		"signaled": {
+			cmd:      []string{"sh", "-c", "kill $$"},
+			wantCode: int(128 + syscall.SIGTERM),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			log := slog.Default()
+
+			serverConn, clientConn := net.Pipe()
+			serverDone := make(chan struct{})
+
+			go func() {
+				defer close(serverDone)
+				NewHandler(log.With("subsystem", "handler")).Handle(t.Context(), serverConn)
+			}()
+
+			var stdoutBuf, stderrBuf bytes.Buffer
+			code, err := Run(t.Context(), log.With("subsystem", "runner"), clientConn, tc.cmd, strings.NewReader(tc.stdin), &closer{&stdoutBuf}, &closer{&stderrBuf})
+			require.NoError(err)
+			assert.Equal(tc.wantCode, code)
+			assert.Equal(tc.wantStdout, stdoutBuf.String())
+			assert.Equal(tc.wantStderr, stderrBuf.String())
+			<-serverDone
+		})
+	}
+}
+
+type closer struct {
+	io.Writer
+}
+
+func (c *closer) Close() error {
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/execserver/handler.go
+++ b/internal/execserver/handler.go
@@ -1,0 +1,171 @@
+package execserver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os/exec"
+	"sync"
+	"syscall"
+)
+
+type handler struct {
+	log *slog.Logger
+}
+
+// NewHandler creates the default handler for executing commands for a remote peer.
+func NewHandler(log *slog.Logger) Handler {
+	return &handler{log: log}
+}
+
+// Handle runs a single command over the given connection.
+func (h *handler) Handle(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	// connMu guards concurrent writes to conn
+	connMu := &sync.Mutex{}
+
+	var req Request
+	if err := ReadMessage(conn, &req); err != nil {
+		h.log.Warn("Could not read initial message", "error", err)
+		return
+	}
+	if len(req.Cmd) == 0 {
+		slog.Warn("First request did not contain a command")
+		return
+	}
+
+	cmd := exec.CommandContext(ctx, req.Cmd[0], req.Cmd[1:]...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		h.log.Warn("Could not get command's stdin", "error", err)
+		return
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		h.log.Warn("Could not get command's stdout", "error", err)
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		h.log.Warn("Could not get command's stderr", "error", err)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		h.log.Warn("Could not start command", "error", err)
+		msg := &Response{
+			ExitStatus: &ExitStatus{Error: err.Error()},
+		}
+		if err := h.writeResponse(conn, connMu, msg); err != nil {
+			h.log.Warn("Could not send error report", "error", err)
+		}
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		h.connToStdin(conn, stdin)
+	})
+	wg.Go(func() {
+		h.pipeOutput(conn, connMu, stdout, func(e *StreamEvent) *Response {
+			return &Response{Stdout: e}
+		})
+	})
+	wg.Go(func() {
+		h.pipeOutput(conn, connMu, stderr, func(e *StreamEvent) *Response {
+			return &Response{Stderr: e}
+		})
+	})
+
+	// If the command terminates, all streams will close and the pipe functions will complete.
+	// Until then, we want to keep forwarding stream data.
+	wg.Wait()
+
+	status := waitStatus(cmd.Wait())
+	if err := h.writeResponse(conn, connMu, &Response{ExitStatus: status}); err != nil {
+		h.log.Warn("Could not send exit status", "error", err)
+	}
+	h.log.Info("command finished", "status", status)
+}
+
+func (h *handler) connToStdin(conn net.Conn, stdin io.WriteCloser) {
+	defer h.log.Info("stdin done")
+	defer stdin.Close()
+	for {
+		var req Request
+		if err := ReadMessage(conn, &req); err != nil {
+			h.log.Warn("Could not read message", "error", err)
+			return
+		}
+		h.log.Info("received message", "message", req)
+		if req.Stdin == nil {
+			h.log.Warn("Protocol violation: a subsequent message did not have Stdin set", "message", req)
+			return
+		} else if req.Stdin.EOF {
+			return
+		} else if len(req.Stdin.Data) > 0 {
+			if _, err := stdin.Write(req.Stdin.Data); err != nil {
+				h.log.Warn("Could not write to process stdin", "error", err)
+				return
+			}
+		} else {
+			h.log.Warn("Encountered remote error receiving stdin", "error", req.Stdin.Error)
+			return
+		}
+	}
+}
+
+func (h *handler) pipeOutput(conn net.Conn, writeMu *sync.Mutex, r io.Reader, wrap func(*StreamEvent) *Response) {
+	buf := make([]byte, readBufSize)
+	keepGoing := true
+	for keepGoing {
+		evt := &StreamEvent{}
+		n, err := r.Read(buf)
+		if errors.Is(err, io.EOF) {
+			evt.EOF = true
+			keepGoing = false
+		} else if err != nil {
+			evt.Error = err.Error()
+			keepGoing = false
+		} else {
+			evt.Data = buf[:n]
+		}
+		if err := h.writeResponse(conn, writeMu, wrap(evt)); err != nil {
+			h.log.Warn("Could not send streaming event", "error", err)
+			keepGoing = false
+		}
+	}
+}
+
+func (h *handler) writeResponse(conn net.Conn, writeMu *sync.Mutex, resp *Response) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+	return WriteMessage(conn, resp)
+}
+
+// waitStatus translates the result of cmd.Wait into an ExitStatus.
+func waitStatus(waitErr error) *ExitStatus {
+	if waitErr == nil {
+		code := 0
+		return &ExitStatus{Terminated: &code}
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		return &ExitStatus{Error: waitErr.Error()}
+	}
+
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return &ExitStatus{Error: waitErr.Error()}
+	}
+	if status.Signaled() {
+		sig := int(status.Signal())
+		return &ExitStatus{Signaled: &sig}
+	}
+	code := status.ExitStatus()
+	return &ExitStatus{Terminated: &code}
+}

--- a/internal/execserver/protocol.go
+++ b/internal/execserver/protocol.go
@@ -1,0 +1,50 @@
+package execserver
+
+// Request messages are sent from client to server.
+//
+// The first request on a connection must set Cmd. Subsequent messages feed data to the command's
+// stdin. Don't set both Cmd and Stdin.
+type Request struct {
+	// Cmd is the command to execute, as it would be passed to exec* syscalls.
+	//
+	// It must have at least one element, the binary to run.
+	Cmd []string `json:"cmd,omitempty"`
+
+	// Stdin conveys events for the remote process' stdin.
+	Stdin *StreamEvent `json:"stdin,omitempty"`
+}
+
+// Response messages are sent from server to client.
+//
+// Each message has exactly one field set. Once the ExitStatus has been sent, no further messages
+// are expected on the channel.
+type Response struct {
+	// Stdout conveys events for the client's stdout.
+	Stdout *StreamEvent `json:"stdout,omitempty"`
+	// Stderr conveys events for the client's stderr.
+	Stderr *StreamEvent `json:"stderr,omitempty"`
+	// ExitStatus conveys the UNIX wait status to the client.
+	ExitStatus *ExitStatus `json:"exit_status,omitempty"`
+}
+
+// StreamEvent transfers stream events to the peer.
+//
+// Only one of the fields must be set per message.
+// If Data is set, it must be non-empty (at least 1 byte).
+// Once EOF or Error have been sent, no further messages are expected for this stream.
+type StreamEvent struct {
+	Data  []byte `json:"data,omitempty"`
+	EOF   bool   `json:"eof,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// ExitStatus models the server process' UNIX wait status.
+//
+// Exactly one of the fields is set. If the process was signaled, Signaled contains the causing
+// signal. If the process terminated normally, Terminated contains the exit code. If something else
+// happened, Error is set to a descriptive error message.
+type ExitStatus struct {
+	Terminated *int   `json:"terminated,omitempty"`
+	Signaled   *int   `json:"signaled,omitempty"`
+	Error      string `json:"unknown,omitempty"`
+}

--- a/internal/execserver/runner.go
+++ b/internal/execserver/runner.go
@@ -1,0 +1,99 @@
+package execserver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+)
+
+// Run runs a command at the remote end of conn.
+//
+// It forwards stdin to the remote command, and pipes the remote output to the local writers.
+// After the command completes, Run returns the exit code.
+func Run(_ context.Context, log *slog.Logger, conn net.Conn, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser) (int, error) {
+	defer conn.Close()
+
+	// Initiate the command execution by sending the argv to execute first.
+	if err := WriteMessage(conn, &Request{Cmd: cmd}); err != nil {
+		return 0, fmt.Errorf("sending command: %w", err)
+	}
+
+	// Forward stdin in a simple goroutine: it might be open, but not required by the remote
+	// command. In that case, we would block forever on the Read although the remote command
+	// completed.
+	go func() {
+		buf := make([]byte, readBufSize)
+		for {
+			n, err := stdin.Read(buf)
+			// According to io.Reader, we might encounter n>0 and EOF in the same read.
+			if n > 0 {
+				if sendErr := WriteMessage(conn, &Request{Stdin: &StreamEvent{Data: buf[:n]}}); sendErr != nil {
+					log.Error("Encountered error while forwarding stdin", "error", err)
+					return
+				}
+			}
+			if err == io.EOF {
+				if sendErr := WriteMessage(conn, &Request{Stdin: &StreamEvent{EOF: true}}); sendErr != nil {
+					log.Error("Encountered error while closing remote stdin", "error", err)
+				}
+				return
+			} else if err != nil {
+				if sendErr := WriteMessage(conn, &Request{Stdin: &StreamEvent{Error: err.Error()}}); sendErr != nil {
+					log.Error("Encountered error while reporting stdin read error", "error", err)
+				}
+				return
+			}
+		}
+	}()
+
+	for {
+		var resp Response
+		if err := ReadMessage(conn, &resp); err != nil {
+			return 0, fmt.Errorf("reading response: %w", err)
+		}
+
+		switch {
+		case resp.Stdout != nil:
+			if err := writeEvent(stdout, resp.Stdout); err != nil {
+				return 0, err
+			}
+		case resp.Stderr != nil:
+			if err := writeEvent(stderr, resp.Stderr); err != nil {
+				return 0, err
+			}
+		case resp.ExitStatus != nil:
+			return exitCode(resp.ExitStatus)
+		}
+	}
+}
+
+func writeEvent(dst io.WriteCloser, e *StreamEvent) error {
+	if len(e.Data) > 0 {
+		if _, err := dst.Write(e.Data); err != nil {
+			return fmt.Errorf("writing to local stream: %w", err)
+		}
+	} else if e.EOF {
+		return dst.Close()
+	} else {
+		return fmt.Errorf("remote stream error: %s", e.Error)
+	}
+	return nil
+}
+
+// exitCode translates a remote ExitStatus into a process exit code.
+func exitCode(status *ExitStatus) (int, error) {
+	var exitCode int
+	switch {
+	case status.Terminated != nil:
+		exitCode = *status.Terminated
+	case status.Signaled != nil:
+		// Convention originating in bash which users are accustomed to.
+		// https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+		exitCode = 128 + *status.Signaled
+	default:
+		return -1, fmt.Errorf("remote command ended with unknown status: %s", status.Error)
+	}
+	return exitCode, nil
+}

--- a/internal/execserver/server.go
+++ b/internal/execserver/server.go
@@ -1,0 +1,65 @@
+package execserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"github.com/mdlayher/vsock"
+)
+
+// Handler can handle a single command execution.
+type Handler interface {
+	// Handle receives a command over the net.Conn and executes it until it terminates or the context expires.
+	//
+	// The net.Conn is closed after this function returns.
+	Handle(context.Context, net.Conn)
+}
+
+// Server receives connections from a listener and runs the embedded Handler for every connection.
+type Server struct {
+	log *slog.Logger
+	h   Handler
+}
+
+// NewServer constructs a new server that dispatches to the given Handler.
+func NewServer(log *slog.Logger, h Handler) *Server {
+	return &Server{log: log, h: h}
+}
+
+// ListenAndServeVsock creates a VSOCK listener and serves connections until the context expires.
+func (s *Server) ListenAndServeVsock(ctx context.Context, port uint32) error {
+	l, err := vsock.Listen(port, nil)
+	if err != nil {
+		return fmt.Errorf("listening on vsock port %d: %w", port, err)
+	}
+	defer l.Close()
+	return s.Serve(ctx, l)
+}
+
+// Serve serves connections from the listener until the context expires.
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	conns := make(chan net.Conn)
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				s.log.Error("accept failed", "error", err)
+				return
+			}
+			conns <- conn
+		}
+	}()
+
+	for {
+		select {
+		case conn := <-conns:
+			s.log.Info("Accepted connection", "peer", conn.RemoteAddr())
+			go s.h.Handle(ctx, conn)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
Draft: just the protocol for now, before I wire nix and image. Recommended reading order:

- `protocol.go`
- `codec.go`
- `server.go` / `handler.go`
- `runner.go`
- tests