### PR TITLE
deps: bump `go-sev-guest` to ensure that received CRLs are within their validity windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.6
 // Upstream is poorly maintained, use edgelesssys fork instead.
 replace github.com/google/go-tdx-guest => github.com/edgelesssys/go-tdx-guest v0.0.0-20260625102850-ea481d3db249
 
-replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20260625102846-50db367a5686
+replace github.com/google/go-sev-guest => github.com/edgelesssys/go-sev-guest v0.0.0-20260729130516-c98bf131aac5
 
 require (
 	filippo.io/keygen v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/edgelesssys/go-sev-guest v0.0.0-20260625102846-50db367a5686 h1:otyw8ZDXu+rjayooly5LrgDru6PXjJQ8xzXe3x8reWA=
-github.com/edgelesssys/go-sev-guest v0.0.0-20260625102846-50db367a5686/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
+github.com/edgelesssys/go-sev-guest v0.0.0-20260729130516-c98bf131aac5 h1:X8Zl2fYL+GEFYwOVSqS//yeiGsApDDHsAkxcIAdy1hc=
+github.com/edgelesssys/go-sev-guest v0.0.0-20260729130516-c98bf131aac5/go.mod h1:SK9vW+uyfuzYdVN0m8BShL3OQCtXZe/JPF7ZkpD3760=
 github.com/edgelesssys/go-tdx-guest v0.0.0-20260625102850-ea481d3db249 h1:Tx0olMH9+rqQgXfX8dIzIDN8UadjSJeTev6t4Qcx+J8=
 github.com/edgelesssys/go-tdx-guest v0.0.0-20260625102850-ea481d3db249/go.mod h1:uHy3VaNXNXhl0fiPxKqTxieeouqQmW6A0EfLcaeCYBk=
 github.com/elazarl/goproxy v1.8.2 h1:keGt9KHFAnrXFEctQuOF9NRxKFCXtd5cQg5PrBdeVW4=

--- a/packages/by-name/contrast/contrast/package.nix
+++ b/packages/by-name/contrast/contrast/package.nix
@@ -54,7 +54,7 @@ buildGoModule (finalAttrs: {
     };
 
   proxyVendor = true;
-  vendorHash = "sha256-h0bMWs892CPwq1cxIAD5WUxGrI1LNebNwnB1nevc50E=";
+  vendorHash = "sha256-t40TIrv5SXUEwbLl9TzO8kKLWTQcqNes2avniNizAlQ=";
 
   subPackages = packageOutputs;
 


### PR DESCRIPTION
https://github.com/edgelesssys/go-sev-guest/pull/5