### PR TITLE
runtime: increase overhead for GPU workloads

### DIFF
--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -60,13 +60,9 @@ func ContrastRuntimeClass(platform platforms.Platform) (*RuntimeClassConfig, err
 
 	// Consists of the default VM memory, 70MiB for the Kata shim and 100MiB for qemu overhead.
 	memoryOverhead := platforms.DefaultMemoryInMebiBytes(platform) + 170
-	if platforms.IsInsecure(platform) && platforms.IsGPU(platform) {
-		// On insecure (non-CC) GPU platforms, iommufd VFIO passthrough pins guest
-		// memory and allocates IOMMU page tables that are charged to the pod's
-		// cgroup. On CC platforms, TDX manages this memory outside the cgroup.
-		// (in the kernel / TDX module memory)
-		// Add extra headroom to avoid OOM kills. 512MB should suffice for VMs up
-		// to ~256GB of memory, which is our current limit on TDX as well.
+	if platforms.IsGPU(platform) {
+		// GPU workloads consume more memory on the host with the cause yet to be found.
+		// Add extra headroom to avoid OOM kills from the host cgroup.
 		memoryOverhead += 512
 	}
 

--- a/internal/kuberesource/parts.go
+++ b/internal/kuberesource/parts.go
@@ -60,13 +60,16 @@ func ContrastRuntimeClass(platform platforms.Platform) (*RuntimeClassConfig, err
 
 	// Consists of the default VM memory, 70MiB for the Kata shim and 100MiB for qemu overhead.
 	memoryOverhead := platforms.DefaultMemoryInMebiBytes(platform) + 170
-	if platforms.IsInsecure(platform) && platforms.IsGPU(platform) {
+	if platforms.IsGPU(platform) {
 		// On insecure (non-CC) GPU platforms, iommufd VFIO passthrough pins guest
 		// memory and allocates IOMMU page tables that are charged to the pod's
 		// cgroup. On CC platforms, TDX manages this memory outside the cgroup.
 		// (in the kernel / TDX module memory)
 		// Add extra headroom to avoid OOM kills. 512MB should suffice for VMs up
 		// to ~256GB of memory, which is our current limit on TDX as well.
+		//
+		// Running a CC workload with GPU will however also consume more memory on the host,
+		// on SNP as well as TDX, so we increase the overhead here as well.
 		memoryOverhead += 512
 	}
 


### PR DESCRIPTION
The runtime overhead on the host is not enough for running large GPU workloads. Allocating a lot of GPU memory only leaves very little memory in the host cgroup, sometimes leading to an OOM. Increasing the runtime overhead fixes this.

This was discovered because normally the cgroup memory max is not actually set. Only now when using pod memory, the memory max is set, which can then lead to an OOM.

Fixes CON-218

The issue includes a reproducer. Without the additional runtime overhead, the model load will fail halfway.