### PR TITLE
imagepuller: retry dial timeouts

### DIFF
--- a/imagepuller/internal/service/verify.go
+++ b/imagepuller/internal/service/verify.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
@@ -24,6 +26,43 @@ var (
 	errMissingPlatform     = errors.New("obtaining image digest for linux/amd64: platform missing from image index")
 )
 
+// retryBackoff is chosen such that the pull can succeed even if dialing times out for up to a minute.
+// TODO(burgerdev): figure out why the network is slow to begin with.
+var retryBackoff = transport.Backoff{
+	Duration: 5 * time.Second,
+	Jitter:   0.1,
+	Steps:    12,
+}
+
+// retryPredicate fixes the default retry predicate of the transport package for dial timeouts.
+//
+// It returns true if an error looks transient and could be retried, such as dial timeouts. It
+// never returns true for the proper context.DeadlineExceeded error, since it comes from the
+// caller and should be respected.
+func (s *ImagePullerService) retryPredicate(err error) (ret bool) {
+	if err == nil {
+		return false
+	}
+	defer func() {
+		s.Logger.Warn("Failed remote call", "error", err, "retriable", ret)
+	}()
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		// There are at least two errors that enter this block, context.DeadlineExceeded and
+		// net.errTimeout. The latter is returned when net.Dial-like functions time out, for
+		// historical reasons. To make it compatible with the context package, errTimeout
+		// implements Is(DeadlineExceeded), which forces us to look closer into this error and
+		// decide whether it's an external deadline, or the internal dial deadline.
+		return strings.Contains(err.Error(), "i/o timeout")
+	}
+
+	if te, ok := err.(interface{ Temporary() bool }); ok && te.Temporary() {
+		return true
+	}
+
+	return false
+}
+
 func (s *ImagePullerService) getAndVerifyImage(ctx context.Context, log *slog.Logger, imageURL string) (gcr.Image, error) {
 	ref, err := name.NewDigest(imageURL)
 	if err != nil {
@@ -35,7 +74,7 @@ func (s *ImagePullerService) getAndVerifyImage(ctx context.Context, log *slog.Lo
 		return nil, fmt.Errorf("obtaining authenticator and transport for %s: %w", imageURL, err)
 	}
 
-	tr := transport.NewRetry(transportConfig)
+	tr := transport.NewRetry(transportConfig, transport.WithRetryBackoff(retryBackoff), transport.WithRetryPredicate(s.retryPredicate))
 
 	desc, err := s.Remote.Head(ref, remote.WithContext(ctx), remote.WithTransport(tr), remote.WithAuth(*authenticator))
 	if err != nil {

--- a/imagepuller/internal/service/verify_test.go
+++ b/imagepuller/internal/service/verify_test.go
@@ -9,12 +9,19 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/edgelesssys/contrast/imagepuller/internal/auth"
 	"github.com/edgelesssys/contrast/imagepuller/internal/remote"
 	"github.com/edgelesssys/contrast/imagepuller/internal/test/registry"
+	"github.com/google/go-containerregistry/pkg/name"
 	gcr "github.com/google/go-containerregistry/pkg/v1"
+	gcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
@@ -310,4 +317,92 @@ func (s *fakeStore) DeleteLayer(id string) error {
 	}
 	delete(s.layers, id)
 	return nil
+}
+
+// TestRetry ensures that dial timeouts are retried.
+func TestRetry(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	log := slog.New(slog.DiscardHandler)
+
+	// 192.0.2.1 is not routable, packets should be dropped.
+	// https://datatracker.ietf.org/doc/html/rfc5737
+	img := "192.0.2.1/foo:latest"
+	ref, err := name.NewTag(img)
+	require.NoError(err)
+
+	// Now configure the gcr method as close to the ImagePullerService as possible.
+	// First, the HTTP transport, but with a dialer that returns a timeout on first try.
+	authConfig := &auth.Config{
+		Registries: map[string]auth.Registry{
+			".": {InsecureSkipVerify: true},
+		},
+	}
+	_, rt, err := authConfig.AuthTransportFor(img, log)
+	require.NoError(err)
+
+	tr, ok := rt.(*http.Transport)
+	require.True(ok)
+	originalDialer := tr.DialContext
+	var failed bool
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if failed {
+			// Marker error to check whether dialing was retried.
+			return nil, assert.AnError
+		}
+		failed = true
+		// Simulate dial timeout by setting a deadline in the past.
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Hour))
+		defer cancel()
+		return originalDialer(ctx, network, addr)
+	}
+
+	// Second, the backoff strategy. We don't want to wait forever in the unit test, so just use a
+	// short non-exponential backoff with two attempts.
+	backOff := transport.Backoff{
+		Duration: time.Microsecond,
+		Steps:    2,
+	}
+
+	// Third, the retry predicate without any modifications.
+	s := &ImagePullerService{
+		Logger: log,
+	}
+	retryTransport := transport.NewRetry(tr, transport.WithRetryBackoff(backOff), transport.WithRetryPredicate(s.retryPredicate))
+
+	_, err = gcrremote.Head(ref, gcrremote.WithContext(ctx), gcrremote.WithTransport(retryTransport))
+	require.ErrorIs(err, assert.AnError)
+}
+
+func TestPredicate(t *testing.T) {
+	for name, tc := range map[string]struct {
+		err       error
+		wantRetry bool
+	}{
+		"no error":          {},
+		"deadline exceeded": {err: context.DeadlineExceeded},
+		"i/o timeout":       {err: &timeoutError{}, wantRetry: true},
+		"unrelated":         {err: assert.AnError},
+		"temporary":         {err: &net.DNSError{IsTemporary: true}, wantRetry: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := &ImagePullerService{
+				Logger: slog.New(slog.DiscardHandler),
+			}
+
+			got := s.retryPredicate(tc.err)
+			require.Equal(t, tc.wantRetry, got)
+		})
+	}
+}
+
+// From Go src/net/net.go, since not exported.
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+func (e *timeoutError) Is(err error) bool {
+	return err == context.DeadlineExceeded
 }


### PR DESCRIPTION
The default retry configuration of the `go-containerregistry` module does not retry dial timeouts. Kata VMs sometimes lag in the networking setup, for reasons not yet understood, resulting in TCP SYN packets disappearing in the void. Setting a backoff strategy and a custom retry predicate fixes the issue, and image pulls should be retried until the network stack is ready. 

Fixes CON-287.