### PR TITLE
ci: exclude upgrade-gpu-operator on Metal-QEMU-TDX-GPU

### DIFF
--- a/.github/workflows/bm_maintenance_platform.yml
+++ b/.github/workflows/bm_maintenance_platform.yml
@@ -66,10 +66,9 @@ jobs:
         run: |
           GPU_OPERATOR_VERSION=$(jq -r '."gpu-operator".currentValue' ./tools/bm-maintenance/versions.json)
           OPTS=(--version "$GPU_OPERATOR_VERSION")
-          if [[ "${PLATFORM_NAME}" == "Metal-QEMU-TDX-GPU" ]]; then
-            OPTS+=(--blackwell)
+          if [[ "${PLATFORM_NAME}" != "Metal-QEMU-TDX-GPU" ]]; then
+            nix run ".#${SET}.scripts.upgrade-gpu-operator" -- "${OPTS[@]}"
           fi
-          nix run ".#${SET}.scripts.upgrade-gpu-operator" -- "${OPTS[@]}"
       - name: Report success
         id: report
         run: echo "result=success" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
gpu-operator on this cluster is managed manually. It runs with another config than what upgrade-gpu-operator.sh applies. Until now, the gpu-operator version was the same, so the script exited early and did not do anything. Now, a later version is installed in the cluster.