### PR TITLE
kuberesource: adjust `TDXEnabledNodeLabel`

### DIFF
--- a/internal/kuberesource/constants.go
+++ b/internal/kuberesource/constants.go
@@ -55,7 +55,7 @@ const (
 
 const (
 	// TDXEnabledNodeLabel is the node-feature-discovery label that marks a node as TDX-capable.
-	TDXEnabledNodeLabel = "feature.node.kubernetes.io/tdx.enabled"
+	TDXEnabledNodeLabel = "feature.node.kubernetes.io/cpu-security.tdx.enabled"
 
 	// MainRunnerNodeLabel restricts pods to the bare-metal nodes of our CI runner.
 	MainRunnerNodeLabel = "ci.contrast.edgeless.systems/main-runner"


### PR DESCRIPTION
The old label was removed in latest gpu-operator: https://github.com/NVIDIA/gpu-operator/commit/bd954f7ce25707d33519862f3a22b7d15b942078