### PR TITLE
resourcegen: replace versions

### DIFF
--- a/packages/by-name/contrast/resourcegen/package.nix
+++ b/packages/by-name/contrast/resourcegen/package.nix
@@ -8,7 +8,7 @@
   reference-values,
 }:
 
-buildGoModule (_finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "${contrast.pname}-resourcegen";
   inherit (contrast)
     version
@@ -63,6 +63,7 @@ buildGoModule (_finalAttrs: {
 
   ldflags = [
     "-s"
+    "-X github.com/edgelesssys/contrast/internal/constants.Version=v${finalAttrs.version}"
   ];
 
   tags = [ "contrast_unstable_api" ];


### PR DESCRIPTION
#2514 added the labels in question, but without setting the required flag to override the version in the nix build.