### PR TITLE
scripts: fix cleanup-bare-metal RuntimeClass extraction

### DIFF
--- a/packages/cleanup-bare-metal.sh
+++ b/packages/cleanup-bare-metal.sh
@@ -47,8 +47,8 @@ done
 # Extract runtime class names from running node installers
 {
   # TODO(burgerdev): checking the annotation is a fallback for older runtimes, can be removed in Q4 2026.
-  kubectl get pods --all-namespaces -o jsonpath='{.items[?(@.metadata.annotations.contrast\.edgeless\.systems/pod-role=="contrast-node-installer")].metadata.name}'
-  kubectl get pods --all-namespaces --selector contrast.edgeless.systems/pod-role=contrast-node-installer -o jsonpath='{.items[*].metadata.name}'
+  kubectl get pods --all-namespaces -o jsonpath='{.items[?(@.metadata.annotations.contrast\.edgeless\.systems/pod-role=="contrast-node-installer")].metadata.name}{"\n"}'
+  kubectl get pods --all-namespaces --selector contrast.edgeless.systems/pod-role=contrast-node-installer -o jsonpath='{.items[*].metadata.name}{"\n"}'
 } |
   tr ' ' '\n' |
   grep -o "contrast-cc-.\+" |


### PR DESCRIPTION
The first result from the second command was appended without whitespace and thus not recognized as used RuntimeClass.