### PR TITLE
genpolicy: support insecure registries

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -93,6 +93,7 @@ subcommands.`,
 	cmd.Flags().Bool("insecure-enable-debug-shell-access", false, "enable the debug shell service in the pod CVM to get access from container to guest VM")
 	cmd.Flags().Bool("calculate-pod-memory", false, "calculate pod memory based on image layer sizes and container resource limits")
 	cmd.Flags().StringP("output", "o", "", "output file for generated YAML")
+	cmd.Flags().StringArray("insecure-registry", []string{}, "registries to access via plain HTTP instead of HTTPS (can be passed more than once)")
 	must(cmd.MarkFlagFilename("policy", "rego"))
 	must(cmd.MarkFlagFilename("settings", "json"))
 	must(cmd.MarkFlagFilename("manifest", "json"))
@@ -205,6 +206,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("patch targets: %w", err)
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "✔️ Patched targets")
+
+	if len(flags.insecureRegistries) > 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "⚠️ Using insecure registries for policy generation!")
+	}
 
 	if err := generatePolicies(cmd.Context(), flags, fileMap, extraFile.Name(), log); err != nil {
 		return fmt.Errorf("generate policies: %w", err)
@@ -450,7 +455,7 @@ func generatePolicies(ctx context.Context, flags *generateFlags, fileMap map[str
 		return fmt.Errorf("creating default policy.rego file: %w", err)
 	}
 
-	runner, err := genpolicy.New(flags.policyPath, flags.settingsPath, flags.genpolicyCachePath, cfg.Bin)
+	runner, err := genpolicy.New(flags.policyPath, flags.settingsPath, flags.genpolicyCachePath, flags.insecureRegistries, cfg.Bin)
 	if err != nil {
 		return fmt.Errorf("preparing genpolicy: %w", err)
 	}
@@ -960,6 +965,7 @@ type generateFlags struct {
 	injectImageStore         bool
 	insecureEnableDebugShell bool
 	calculatePodMemory       bool
+	insecureRegistries       []string
 	outputFile               string
 }
 
@@ -1065,6 +1071,10 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 	if err != nil {
 		return nil, err
 	}
+	insecureRegistries, err := cmd.Flags().GetStringArray("insecure-registry")
+	if err != nil {
+		return nil, err
+	}
 	outputFile, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return nil, err
@@ -1092,6 +1102,7 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 		injectImageStore:         injectImageStore,
 		insecureEnableDebugShell: insecureEnableDebugShell,
 		calculatePodMemory:       calculatePodMemory,
+		insecureRegistries:       insecureRegistries,
 		outputFile:               outputFile,
 	}, nil
 }

--- a/cli/genpolicy/genpolicy.go
+++ b/cli/genpolicy/genpolicy.go
@@ -24,13 +24,14 @@ import (
 type Runner struct {
 	genpolicy embedbin.Installed
 
-	rulesPath    string
-	settingsPath string
-	cachePath    string
+	rulesPath          string
+	settingsPath       string
+	cachePath          string
+	insecureRegistries []string
 }
 
 // New creates a new Runner for the given configuration.
-func New(rulesPath, settingsPath, cachePath string, bin []byte) (*Runner, error) {
+func New(rulesPath, settingsPath, cachePath string, insecureRegistries []string, bin []byte) (*Runner, error) {
 	e := embedbin.New()
 	genpolicy, err := e.Install("", bin)
 	if err != nil {
@@ -41,10 +42,11 @@ func New(rulesPath, settingsPath, cachePath string, bin []byte) (*Runner, error)
 	}
 
 	runner := &Runner{
-		genpolicy:    genpolicy,
-		rulesPath:    rulesPath,
-		settingsPath: settingsPath,
-		cachePath:    cachePath,
+		genpolicy:          genpolicy,
+		rulesPath:          rulesPath,
+		settingsPath:       settingsPath,
+		cachePath:          cachePath,
+		insecureRegistries: insecureRegistries,
 	}
 
 	return runner, nil
@@ -61,6 +63,9 @@ func (r *Runner) Run(ctx context.Context, res any, extraPath string, needLayersC
 		"--layers-cache-file-path=" + r.cachePath,
 		"--config-file=" + extraPath,
 		"--base64-out",
+	}
+	for _, registry := range r.insecureRegistries {
+		args = append(args, "--insecure-registry="+registry)
 	}
 	genpolicy := exec.CommandContext(ctx, r.genpolicy.Path(), args...)
 	genpolicy.Cancel = func() error {

--- a/cli/genpolicy/genpolicy_test.go
+++ b/cli/genpolicy/genpolicy_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/edgelesssys/contrast/internal/kuberesource"
@@ -38,6 +39,9 @@ while [ $# -gt 0 ]; do
 	;;
 	--layers-cache-file-path=*)
 	  printf "%%s" "[]" >${1#--layers-cache-file-path=}
+	;;
+	--insecure-registry=*)
+	  printf "%%s" "${1#--insecure-registry=}" >>insecure_registries
 	;;
     --runtime-class-names*|--yaml-file*|--base64-out*)
 	;;
@@ -74,10 +78,12 @@ func TestRunner(t *testing.T) {
 	settingsPathFile := filepath.Join(d, "settings_path")
 	expectedExtraPath := "/extra.yml"
 	extraPathFile := filepath.Join(d, "extra_path")
+	expectedInsecureRegistries := []string{"registry1", "registry2"}
+	insecureRegistriesFile := filepath.Join(d, "insecure_registries")
 	cachePath := filepath.Join(d, "cache", "cache.json")
 	envFile := filepath.Join(d, "env_path")
 
-	r, err := New(expectedRulesPath, expectedSettingsPath, cachePath, genpolicyBin)
+	r, err := New(expectedRulesPath, expectedSettingsPath, cachePath, expectedInsecureRegistries, genpolicyBin)
 	require.NoError(err)
 
 	applyConfig, err := kuberesource.UnmarshalApplyConfigurations([]byte(podYAML))
@@ -97,6 +103,10 @@ func TestRunner(t *testing.T) {
 	extraPath, err := os.ReadFile(extraPathFile)
 	require.NoError(err)
 	assert.Equal(expectedExtraPath, string(extraPath))
+
+	insecureRegistries, err := os.ReadFile(insecureRegistriesFile)
+	require.NoError(err)
+	assert.Equal(strings.Join(expectedInsecureRegistries, ""), string(insecureRegistries))
 
 	yamlString, err := os.ReadFile(filepath.Join(d, "stdout.yaml"))
 	require.NoError(err)


### PR DESCRIPTION
This allows specifying insecure registries for `contrast generate`, e.g., running a local registry and then calling:
```
contrast generate --insecure-registry localhost:5000 ...
```
We need this for the policy test suite to speed up policy generation with a local registry.

Fixes CON-163