### PR TITLE
ci: update bm-tcb-specs for dgx-007

### DIFF
--- a/dev-docs/e2e/dgx-007/manifest.json
+++ b/dev-docs/e2e/dgx-007/manifest.json
@@ -8,7 +8,7 @@
     {
       "op": "replace",
       "path": "/MrSeam",
-      "value": "346bc77a1846cac214dd2e8edeb9ee4349449d6c3f9ff2c52149a634c27b7fd1bd314c2ef6b973eeebd55742952531a1"
+      "value": "ab62561a173acbd18ee50ff37750db44184c6cf5e886df74247cc575e163b04c34b9e18374757c235affa614d4127f6b"
     },
     {
       "op": "replace",
@@ -27,7 +27,7 @@
     {
       "op": "replace",
       "path": "/MrSeam",
-      "value": "346bc77a1846cac214dd2e8edeb9ee4349449d6c3f9ff2c52149a634c27b7fd1bd314c2ef6b973eeebd55742952531a1"
+      "value": "ab62561a173acbd18ee50ff37750db44184c6cf5e886df74247cc575e163b04c34b9e18374757c235affa614d4127f6b"
     },
     {
       "op": "replace",


### PR DESCRIPTION
I deployed the latest module from https://github.com/intel/confidential-computing.tdx.tdx-module on this machine.