### PR TITLE
ci: update olimar PIID after firmware update

### DIFF
--- a/dev-docs/e2e/olimar/manifest.json
+++ b/dev-docs/e2e/olimar/manifest.json
@@ -14,7 +14,7 @@
       "op": "replace",
       "path": "/AllowedPIIDs",
       "value": [
-        "59028de46725be119ee89a10002b191c"
+        "508018b6d843328c0d4b98cfaf0b42aa"
       ]
     }
   ]


### PR DESCRIPTION
Updating olimar's BIOS regenerated the platform's SGX provisioning keys, which changed its PPID, QE ID and Platform Instance ID. The platform had to be registered with Intel again before it could produce quotes at all, and the new PIID no longer matches what we pin.

Extracted from the post-update pckid_retrieval.csv as described in dev-docs/e2e/bare-metal-runner.md.