### PR TITLE
[release/v1.23] .github: hot-fixes for patch release

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -2,3 +2,11 @@ self-hosted-runner:
   labels:
     - SNP
     - TDX
+
+paths:
+  .github/workflows/e2e_nightly.yml:
+    ignore:
+      # TODO(charludo): TEMPORARY, revert together with the disabled TDX-GPU jobs.
+      # `if: false` is deliberate there: it keeps the job definitions and the
+      # `needs:` graph intact while the runner is unhealthy.
+      - 'constant expression "false" in condition'

--- a/.github/actions/prepare_post_release_pr/action.yml
+++ b/.github/actions/prepare_post_release_pr/action.yml
@@ -32,6 +32,11 @@ inputs:
     description: Whether to bump the flake version post-release
     required: false
     default: 'true'
+  verify_main_version:
+    description: >
+      Whether checkout_main_ref's version.txt must match the release version. On a patch, main is already a minor ahead and no ref carries the patch version.
+    required: false
+    default: 'true'
   github_token:
     description: GitHub token
     required: true
@@ -56,6 +61,7 @@ runs:
         path: contrast-main
         persist-credentials: false
     - name: Verify main version matches release
+      if: inputs.verify_main_version == 'true'
       shell: bash
       working-directory: contrast-main
       env:

--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -76,6 +76,9 @@ jobs:
 
   tdx-gpu-maintenance:
     name: maintenance Metal-QEMU-TDX-GPU
+    # TODO(charludo): TEMPORARY, revert. TDX-GPU runner is unhealthy (nix-gc
+    # maintenance job times out), blocking the v1.23.1 release. Disabled 2026-08-20.
+    if: false
     needs: build-image
     uses: ./.github/workflows/bm_maintenance_platform.yml
     with:
@@ -145,6 +148,9 @@ jobs:
 
   tdx-gpu:
     name: Metal-QEMU-TDX-GPU
+    # TODO(charludo): TEMPORARY, revert. TDX-GPU runner is unhealthy (nix-gc
+    # maintenance job times out), blocking the v1.23.1 release. Disabled 2026-08-20.
+    if: false
     needs: tdx-gpu-maintenance
     uses: ./.github/workflows/e2e_nightly_platform.yml
     with:
@@ -259,9 +265,12 @@ jobs:
             entries+=("{\"title\": \"Metal-QEMU-SNP-DEV\", \"value\": \"$(str="${snp_dev[*]}"; echo "${str// /, }")\"}")
           fi
 
-          if [[ "${#tdx_gpu[@]}" -gt 0 ]]; then
-            entries+=("{\"title\": \"Metal-QEMU-TDX-GPU\", \"value\": \"$(str="${tdx_gpu[*]}"; echo "${str// /, }")\"}")
-          fi
+          # TODO(charludo): TEMPORARY, revert together with the disabled tdx-gpu jobs.
+          # Their outputs are empty while disabled, which would report every TDX-GPU
+          # maintenance step as failed on every nightly.
+          # if [[ "${#tdx_gpu[@]}" -gt 0 ]]; then
+          #   entries+=("{\"title\": \"Metal-QEMU-TDX-GPU\", \"value\": \"$(str="${tdx_gpu[*]}"; echo "${str// /, }")\"}")
+          # fi
 
           if [[ "${#entries[@]}" -eq 0 ]]; then
             echo "No failures detected, nothing to notify."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
           pr_branch_suffix: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
           create_docs_release: ${{ inputs.kind == 'minor' }}
           bump_version: ${{ inputs.kind == 'minor' }}
+          verify_main_version: ${{ inputs.kind == 'minor' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           nunki_ci_token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
           cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,12 @@ jobs:
             node-installer-target-conf: k3s
             linux-runner: TDX
             is-public: false
-          - name: Metal-QEMU-TDX-GPU
-            node-installer-target-conf: none
-            linux-runner: TDX-GPU
-            is-public: true
+            # TODO(charludo): TEMPORARY, revert. TDX-GPU runner is unhealthy (nix-gc
+            # maintenance job times out), blocking the v1.23.1 release. Disabled 2026-08-20.
+            # - name: Metal-QEMU-TDX-GPU
+            #   node-installer-target-conf: none
+            #   linux-runner: TDX-GPU
+            #   is-public: true
         cli-arch:
           - x86_64-linux
           - aarch64-darwin

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -159,10 +159,12 @@ jobs:
             node-installer-target-conf: k3s
             linux-runner: TDX
             is-public: false
-          - name: Metal-QEMU-TDX-GPU
-            node-installer-target-conf: none
-            linux-runner: TDX-GPU
-            is-public: true
+            # TODO(charludo): TEMPORARY, revert. TDX-GPU runner is unhealthy (nix-gc
+            # maintenance job times out), blocking the v1.23.1 release. Disabled 2026-08-20.
+            # - name: Metal-QEMU-TDX-GPU
+            #   node-installer-target-conf: none
+            #   linux-runner: TDX-GPU
+            #   is-public: true
         cli-arch:
           - x86_64-linux
           - aarch64-darwin

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -87,7 +87,10 @@ jobs:
             "release-requirement: e2e nightly / Metal-QEMU-SNP "
             "release-requirement: e2e nightly / Metal-QEMU-TDX "
             "release-requirement: e2e nightly / Metal-QEMU-SNP-GPU "
-            "release-requirement: e2e nightly / Metal-QEMU-TDX-GPU "
+            # TODO(charludo): TEMPORARY, revert. TDX-GPU runner is unhealthy (nix-gc
+            # maintenance job times out). Disabled 2026-08-20, so the job no longer
+            # appears in the nightly run and would be reported as missing here.
+            # "release-requirement: e2e nightly / Metal-QEMU-TDX-GPU "
             "release-requirement: e2e release on "
           )
           missing=()

--- a/packages/by-name/kata/source/0003-genpolicy-allow-image_guest_pull.patch
+++ b/packages/by-name/kata/source/0003-genpolicy-allow-image_guest_pull.patch
@@ -174,7 +174,7 @@ index cc47c2f40d94d0a18720e861b7053d8b0a577903..61c078a6c64656b215e8d46c8312a687
  			return nil, err
  		}
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index 76c5aadafbfeccf01bd1f13fdb4a1108383f2740..c7ad38dc68f91cf41153e8a86653ebd52b603255 100644
+index 76c5aadafbfeccf01bd1f13fdb4a1108383f2740..040d60b6c801f0a197d60c48e345390266736f64 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -1230,10 +1230,9 @@ allow_storages(p_storages, i_storages, bundle_id, sandbox_id) if {
@@ -190,7 +190,7 @@ index 76c5aadafbfeccf01bd1f13fdb4a1108383f2740..c7ad38dc68f91cf41153e8a86653ebd5
  
      every i_storage in i_storages {
          allow_storage(p_storages, i_storage, bundle_id, sandbox_id)
-@@ -1247,16 +1246,6 @@ allow_storage(p_storages, i_storage, bundle_id, sandbox_id) if {
+@@ -1255,16 +1254,6 @@ allow_storage(p_storages, i_storage, bundle_id, sandbox_id) if {
  
      print("allow_storage: true")
  }
@@ -207,7 +207,7 @@ index 76c5aadafbfeccf01bd1f13fdb4a1108383f2740..c7ad38dc68f91cf41153e8a86653ebd5
  allow_storage(p_storages, i_storage, bundle_id, sandbox_id) if {
      print("allow_storage with scsi: start")
  
-@@ -1329,6 +1318,23 @@ allow_storage_source(p_storage, i_storage, bundle_id) if {
+@@ -1337,6 +1326,23 @@ allow_storage_source(p_storage, i_storage, bundle_id) if {
  
      print("allow_storage_source 3: true")
  }
@@ -231,7 +231,7 @@ index 76c5aadafbfeccf01bd1f13fdb4a1108383f2740..c7ad38dc68f91cf41153e8a86653ebd5
  
  allow_storage_options(p_storage, i_storage) if {
      print("allow_storage_options 1: start")
-@@ -1404,6 +1410,25 @@ allow_mount_point(p_storage, i_storage, bundle_id, sandbox_id) if {
+@@ -1412,6 +1418,25 @@ allow_mount_point(p_storage, i_storage, bundle_id, sandbox_id) if {
  
      print("allow_mount_point 5: true")
  }

--- a/packages/by-name/kata/source/0005-genpolicy-support-mount-propagation-and-ro-mounts.patch
+++ b/packages/by-name/kata/source/0005-genpolicy-support-mount-propagation-and-ro-mounts.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] genpolicy: support mount propagation and ro-mounts
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/src/tools/genpolicy/rules.rego b/src/tools/genpolicy/rules.rego
-index c7ad38dc68f91cf41153e8a86653ebd52b603255..b7bafe29ccb82a45f6eb8af6dfc00561c8710143 100644
+index 040d60b6c801f0a197d60c48e345390266736f64..e311420e30c35b3a10ac6813b58a2caf3968e393 100644
 --- a/src/tools/genpolicy/rules.rego
 +++ b/src/tools/genpolicy/rules.rego
 @@ -143,7 +143,8 @@ allow_create_container_input if {

--- a/packages/by-name/kata/source/package.nix
+++ b/packages/by-name/kata/source/package.nix
@@ -6,9 +6,11 @@
   applyPatches,
   rustPlatform,
   callPackage,
+  lib,
+  stdenv,
+  open-policy-agent,
   protobuf,
   pkg-config,
-  pkgs,
   openssl,
   libseccomp,
   lvm2,
@@ -184,11 +186,10 @@ rec {
       ./0026-genpolicy-unconditionally-skip-guest-pull-security-c.patch
     ];
 
-    nativeBuildInputs = with pkgs; [
-      open-policy-agent
-    ];
+    # The rules.rego unit tests only run on linux, since open-policy-agent fails to build on darwin.
+    nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ open-policy-agent ];
 
-    postPatch = ''
+    postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
       echo "running unit tests for rules.rego" >&2
       testdir=$(mktemp -d)
       cp src/tools/genpolicy/rules.rego ${./rules_test.rego} "$testdir"


### PR DESCRIPTION
Backport of #2594 to `release/v1.23`.

Original description:

---

First commit: would have failed the prepare post release PR step. Not blocking the release itself, but the post-PR.
Second commit: temporarily disable TDX-GPU tests