### PR TITLE
.github: make the post-release action kind-aware

### DIFF
--- a/.github/actions/prepare_post_release_pr/action.yml
+++ b/.github/actions/prepare_post_release_pr/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: true
   kind:
     description: >
-      Release kind, minor or patch. A patch skips the versioned docs snapshot, the post-release version bump, and the check that checkout_main_ref carries the released version.
+      Release kind, minor or patch. A patch skips the versioned docs snapshot and the post-release version bump, and only requires checkout_main_ref to be at or ahead of the released version.
     required: false
     default: minor
   github_token:
@@ -52,18 +52,35 @@ runs:
         ref: ${{ inputs.checkout_main_ref }}
         path: contrast-main
         persist-credentials: false
-    - name: Verify main version matches release
-      if: inputs.kind == 'minor'
+    - name: Verify main version
       shell: bash
       working-directory: contrast-main
       env:
         EXPECTED_VERSION: ${{ inputs.without_v }}
+        KIND: ${{ inputs.kind }}
       run: |
         actual=$(sed 's/-.*$//' version.txt)
-        if [[ "${actual}" != "${EXPECTED_VERSION}" ]]; then
-          echo "::error::checkout_main_ref version.txt base version is ${actual}, expected ${EXPECTED_VERSION}."
-          exit 1
-        fi
+        case "${KIND}" in
+          minor)
+            if [[ "${actual}" != "${EXPECTED_VERSION}" ]]; then
+              echo "::error::checkout_main_ref version.txt base version is ${actual}, expected ${EXPECTED_VERSION}."
+              exit 1
+            fi
+            ;;
+          patch)
+            # A patch is cut from release/*, while main has already moved on to the
+            # next minor, so only the ordering can be checked here.
+            oldest=$(printf '%s\n%s\n' "${actual}" "${EXPECTED_VERSION}" | sort -V | head -1)
+            if [[ "${oldest}" != "${EXPECTED_VERSION}" ]]; then
+              echo "::error::checkout_main_ref version.txt base version is ${actual}, expected at least ${EXPECTED_VERSION}."
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::Unknown release kind ${KIND}, expected minor or patch."
+            exit 1
+            ;;
+        esac
     - uses: ./.github/actions/setup_nix
       with:
         githubToken: ${{ inputs.github_token }}

--- a/.github/actions/prepare_post_release_pr/action.yml
+++ b/.github/actions/prepare_post_release_pr/action.yml
@@ -24,19 +24,11 @@ inputs:
   pr_branch_suffix:
     description: Suffix for the automated PR branch (automated/update-main-after-<suffix>)
     required: true
-  create_docs_release:
-    description: Whether to create a versioned docs snapshot
-    required: false
-    default: 'true'
-  bump_version:
-    description: Whether to bump the flake version post-release
-    required: false
-    default: 'true'
-  verify_main_version:
+  kind:
     description: >
-      Whether checkout_main_ref's version.txt must match the release version. On a patch, main is already a minor ahead and no ref carries the patch version.
+      Release kind, minor or patch. A patch skips the versioned docs snapshot, the post-release version bump, and the check that checkout_main_ref carries the released version.
     required: false
-    default: 'true'
+    default: minor
   github_token:
     description: GitHub token
     required: true
@@ -61,7 +53,7 @@ runs:
         path: contrast-main
         persist-credentials: false
     - name: Verify main version matches release
-      if: inputs.verify_main_version == 'true'
+      if: inputs.kind == 'minor'
       shell: bash
       working-directory: contrast-main
       env:
@@ -82,7 +74,7 @@ runs:
         git config --global user.name "edgelessci"
         git config --global user.email "edgelessci@users.noreply.github.com"
     - name: Create docs release
-      if: inputs.create_docs_release == 'true'
+      if: inputs.kind == 'minor'
       shell: bash
       working-directory: contrast-main/docs
       env:
@@ -149,7 +141,7 @@ runs:
         git clean -fx :/
         git reset --hard HEAD
     - name: Bump flake version to post release pre-version
-      if: inputs.bump_version == 'true'
+      if: inputs.kind == 'minor'
       id: bump
       uses: ./.github/actions/bump_version
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,9 +250,7 @@ jobs:
           without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
           next_minor_pre_without_v: ${{ needs.process-inputs.outputs.NEXT_MINOR_PRE_WITHOUT_V }}
           pr_branch_suffix: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-          create_docs_release: ${{ inputs.kind == 'minor' }}
-          bump_version: ${{ inputs.kind == 'minor' }}
-          verify_main_version: ${{ inputs.kind == 'minor' }}
+          kind: ${{ inputs.kind }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           nunki_ci_token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
           cachix_token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
Follow-up to #2594.

That PR added a third boolean to `prepare_post_release_pr`, alongside `create_docs_release` and `bump_version`, all three wired to the same `inputs.kind == 'minor'` at the call site.
The action was asking its caller three questions that have only ever had one answer between them, so it takes `kind` once and decides internally.
Across roughly 30 post-release PRs since 1.5.2 those booleans have only ever been all-on or all-off (the 4-commit and 2-commit PRs), never mixed.
No behaviour change for minors, and `release_promote.yml` still relies on the default.

The second commit restores the guard the hot-fix had to drop.
Skipping the version check on a patch left `checkout_main_ref` unvalidated on that path, which is the mistake the check exists to catch.
Main can never carry a patch version but is always ahead of one, so a patch asserts that ordering instead of an exact match.
By construction this is weaker than the minor check: it catches a ref that is behind the release, not one that is ahead and still wrong.

Should land after #2594.
Main-only, no backport needed.