### PR TITLE
ci: run bare metal maintenance on the right nodes

### DIFF
--- a/.github/workflows/bm_maintenance_platform.yml
+++ b/.github/workflows/bm_maintenance_platform.yml
@@ -103,7 +103,13 @@ jobs:
             kubectl delete job -n maintenance-cleanup cleanup-maintenance --ignore-not-found
             sed -e "s#@@REPLACE_IMAGE@@#${IMAGE}#g" -e "s#@@REPLACE_K3S_VERSION@@#${K3S_VERSION}#g" -e "s#@@REPLACE_NODE@@#${node}#g" \
               ./tools/bm-maintenance/cleanup.yml | kubectl apply -f -
-            kubectl wait -n maintenance-cleanup --for=condition=complete --timeout=600s job/cleanup-maintenance || failed=1
+            if ! kubectl wait -n maintenance-cleanup --for=condition=complete --timeout=600s job/cleanup-maintenance; then
+              failed=1
+              echo "::error::cleanup failed on ${node}"
+              kubectl get pods -n maintenance-cleanup -o wide || true
+              kubectl describe job -n maintenance-cleanup cleanup-maintenance || true
+              kubectl events -n maintenance-cleanup || true
+            fi
             kubectl logs -n maintenance-cleanup job/cleanup-maintenance || true
           done
           [[ ${failed} -eq 0 ]]
@@ -142,7 +148,13 @@ jobs:
             kubectl delete job -n maintenance-containerd-cleanup containerd-cleanup-maintenance --ignore-not-found
             sed -e "s#@@REPLACE_IMAGE@@#${IMAGE}#g" -e "s#@@REPLACE_NODE@@#${node}#g" \
               ./tools/bm-maintenance/cleanup-containerd.yml | kubectl apply -f -
-            kubectl wait -n maintenance-containerd-cleanup --for=condition=complete --timeout=600s job/containerd-cleanup-maintenance || failed=1
+            if ! kubectl wait -n maintenance-containerd-cleanup --for=condition=complete --timeout=600s job/containerd-cleanup-maintenance; then
+              failed=1
+              echo "::error::containerd cleanup failed on ${node}"
+              kubectl get pods -n maintenance-containerd-cleanup -o wide || true
+              kubectl describe job -n maintenance-containerd-cleanup containerd-cleanup-maintenance || true
+              kubectl events -n maintenance-containerd-cleanup || true
+            fi
             kubectl logs -n maintenance-containerd-cleanup job/containerd-cleanup-maintenance || true
           done
           [[ ${failed} -eq 0 ]]
@@ -184,6 +196,12 @@ jobs:
         run: |
           kubectl wait -n maintenance-nix-gc --for=condition=complete --timeout=600s job/nix-garbage-collection
           echo "result=success" >> "$GITHUB_OUTPUT"
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          kubectl get pods -n maintenance-nix-gc -o wide || true
+          kubectl describe jobs -n maintenance-nix-gc || true
+          kubectl events -n maintenance-nix-gc || true
       - name: Collect logs and cleanup
         if: always()
         run: |

--- a/.github/workflows/bm_maintenance_platform.yml
+++ b/.github/workflows/bm_maintenance_platform.yml
@@ -77,7 +77,7 @@ jobs:
   cleanup:
     name: "Cleanup ${{ inputs.platform-name }}"
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     outputs:
       result: ${{ steps.update.outputs.result }}
     permissions:
@@ -87,18 +87,26 @@ jobs:
         with:
           persist-credentials: false
       - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
-      - name: Apply resources
+      - name: Clean up each node
+        id: update
         env:
           IMAGE: ${{ inputs.image }}
         run: |
           K3S_VERSION=$(jq -r '.k3s.currentValue' ./tools/bm-maintenance/versions.json)
-          sed -i "s#@@REPLACE_IMAGE@@#${IMAGE}#g" ./tools/bm-maintenance/cleanup.yml
-          sed -i "s#@@REPLACE_K3S_VERSION@@#${K3S_VERSION}#g" ./tools/bm-maintenance/cleanup.yml
-          kubectl apply -f ./tools/bm-maintenance/cleanup.yml
-      - name: Wait for cleanup job
-        id: update
-        run: |
-          kubectl wait -n maintenance-cleanup --for=condition=complete --timeout=600s job/cleanup-maintenance
+          nodes=$(kubectl get nodes -l ci.contrast.edgeless.systems/main-runner=true --field-selector spec.unschedulable=false -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+          if [[ -z "${nodes}" ]]; then
+            echo "::error::no node labeled ci.contrast.edgeless.systems/main-runner=true, or all of them are cordoned"
+            exit 1
+          fi
+          failed=0
+          for node in $nodes; do
+            kubectl delete job -n maintenance-cleanup cleanup-maintenance --ignore-not-found
+            sed -e "s#@@REPLACE_IMAGE@@#${IMAGE}#g" -e "s#@@REPLACE_K3S_VERSION@@#${K3S_VERSION}#g" -e "s#@@REPLACE_NODE@@#${node}#g" \
+              ./tools/bm-maintenance/cleanup.yml | kubectl apply -f -
+            kubectl wait -n maintenance-cleanup --for=condition=complete --timeout=600s job/cleanup-maintenance || failed=1
+            kubectl logs -n maintenance-cleanup job/cleanup-maintenance || true
+          done
+          [[ ${failed} -eq 0 ]]
           echo "result=success" >> "$GITHUB_OUTPUT"
       - name: Collect logs and cleanup
         if: always()
@@ -109,7 +117,7 @@ jobs:
   cleanup-containerd:
     name: "Cleanup Containerd ${{ inputs.platform-name }}"
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     outputs:
       result: ${{ steps.update.outputs.result }}
     permissions:
@@ -119,16 +127,25 @@ jobs:
         with:
           persist-credentials: false
       - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
-      - name: Apply resources
+      - name: Clean containerd on each node
+        id: update
         env:
           IMAGE: ${{ inputs.image }}
         run: |
-          sed -i "s#@@REPLACE_IMAGE@@#${IMAGE}#g" ./tools/bm-maintenance/cleanup-containerd.yml
-          kubectl apply -f ./tools/bm-maintenance/cleanup-containerd.yml
-      - name: Wait for cleanup job
-        id: update
-        run: |
-          kubectl wait -n maintenance-containerd-cleanup --for=condition=complete --timeout=600s job/containerd-cleanup-maintenance
+          nodes=$(kubectl get nodes -l ci.contrast.edgeless.systems/main-runner=true --field-selector spec.unschedulable=false -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+          if [[ -z "${nodes}" ]]; then
+            echo "::error::no node labeled ci.contrast.edgeless.systems/main-runner=true, or all of them are cordoned"
+            exit 1
+          fi
+          failed=0
+          for node in $nodes; do
+            kubectl delete job -n maintenance-containerd-cleanup containerd-cleanup-maintenance --ignore-not-found
+            sed -e "s#@@REPLACE_IMAGE@@#${IMAGE}#g" -e "s#@@REPLACE_NODE@@#${node}#g" \
+              ./tools/bm-maintenance/cleanup-containerd.yml | kubectl apply -f -
+            kubectl wait -n maintenance-containerd-cleanup --for=condition=complete --timeout=600s job/containerd-cleanup-maintenance || failed=1
+            kubectl logs -n maintenance-containerd-cleanup job/containerd-cleanup-maintenance || true
+          done
+          [[ ${failed} -eq 0 ]]
           echo "result=success" >> "$GITHUB_OUTPUT"
       - name: Collect logs and cleanup
         if: always()

--- a/.github/workflows/bm_maintenance_platform.yml
+++ b/.github/workflows/bm_maintenance_platform.yml
@@ -153,7 +153,14 @@ jobs:
         env:
           IMAGE: ${{ inputs.image }}
         run: |
+          machineID=$(cat /etc/machine-id)
+          node=$(kubectl get nodes -o jsonpath="{.items[?(@.status.nodeInfo.machineID=='${machineID:?}')].metadata.name}")
+          if [[ $(wc -w <<< "${node}") -ne 1 ]]; then
+            echo "::error::expected exactly one node with this runner's machine ID, got: ${node:-<none>}"
+            exit 1
+          fi
           sed -i "s#@@REPLACE_IMAGE@@#${IMAGE}#g" ./tools/bm-maintenance/nix-gc.yml
+          sed -i "s#@@REPLACE_NODE@@#${node}#g" ./tools/bm-maintenance/nix-gc.yml
           kubectl apply -f ./tools/bm-maintenance/nix-gc.yml
       - name: Wait for nix garbage collection job
         id: update

--- a/tools/bm-maintenance/cleanup-containerd.yml
+++ b/tools/bm-maintenance/cleanup-containerd.yml
@@ -14,7 +14,7 @@ spec:
       name: containerd-cleanup-maintenance
     spec:
       nodeSelector:
-        ci.contrast.edgeless.systems/main-runner: "true"
+        kubernetes.io/hostname: "@@REPLACE_NODE@@"
       containers:
         - name: cleanup
           image: "@@REPLACE_IMAGE@@"

--- a/tools/bm-maintenance/cleanup.yml
+++ b/tools/bm-maintenance/cleanup.yml
@@ -51,7 +51,7 @@ spec:
       name: cleanup-maintenance
     spec:
       nodeSelector:
-        ci.contrast.edgeless.systems/main-runner: "true"
+        kubernetes.io/hostname: "@@REPLACE_NODE@@"
       serviceAccountName: cleanup-sa
       hostPID: true
       containers:

--- a/tools/bm-maintenance/nix-gc.yml
+++ b/tools/bm-maintenance/nix-gc.yml
@@ -14,7 +14,7 @@ spec:
       name: nix-garbage-collection
     spec:
       nodeSelector:
-        ci.contrast.edgeless.systems/main-runner: "true"
+        kubernetes.io/hostname: "@@REPLACE_NODE@@"
       hostPID: true
       containers:
         - name: nix-garbage-collection


### PR DESCRIPTION
Two nodes have carried `ci.contrast.edgeless.systems/main-runner=true` since a second bare-metal machine joined the TDX-GPU cluster on 2026-08-14, so the maintenance jobs pick one at random.

`nix-gc` collects the runner's nix store and dies on the other machine (timed out 08-18 and twice on 08-20, blocking v1.23.1, hence b0753f7d07).
It now resolves the runner's own node by matching `/etc/machine-id` against the node's `machineID`, so no labeling is needed.
`cleanup` and `cleanup-containerd` pass but only clean the node they land on, so they now run once per `main-runner` node, and a failure on one no longer skips the rest.

Revert b0753f7d07 once the `bare metal maintenance` run this merge triggers is green on TDX-GPU.
Why nix-gc dies on that node is still unknown, but the last commit dumps job and pod state on failure, so the next occurrence will say.