### PR TITLE
upgrade-gpu-operator: upgrade in place instead of reinstalling

### DIFF
--- a/.github/workflows/bm_maintenance_platform.yml
+++ b/.github/workflows/bm_maintenance_platform.yml
@@ -33,6 +33,7 @@ jobs:
   update-resources:
     name: "Update resources ${{ inputs.platform-name }}"
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
     outputs:
       result: ${{ steps.report.outputs.result }}
     env:

--- a/docs/docs/howto/cluster-setup/bare-metal.md
+++ b/docs/docs/howto/cluster-setup/bare-metal.md
@@ -218,7 +218,8 @@ For a GPU-enabled Contrast cluster, you can then deploy the operator with the fo
 <!-- > sh $
 sed -n '/^# Add the NVIDIA Helm repository$/,/^$/p' ../../../../packages/by-name/scripts/upgrade-gpu-operator/upgrade-gpu-operator.sh
 sed -n '/^# Install the GPU Operator$/,/^$/p' ../../../../packages/by-name/scripts/upgrade-gpu-operator/upgrade-gpu-operator.sh |
-  sed '$d' | sed "s/\"\$GPU_OPERATOR_VERSION\"/$GPU_OPERATOR_VERSION/g"
+  sed '$d' | sed "s/\"\$GPU_OPERATOR_VERSION\"/$GPU_OPERATOR_VERSION/g" |
+  sed 's/"\$RELEASE"/gpu-operator/g'
 -->
 
 <!-- BEGIN mdsh -->
@@ -229,7 +230,7 @@ helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
 # Install the GPU Operator
 # The Kata sandbox plugin defaults to the pgpu alias when P_GPU_ALIAS is unset.
 # An explicitly empty value disables the alias and exposes model-specific resources.
-helm install --wait --generate-name \
+helm upgrade --install gpu-operator --wait \
   -n gpu-operator --create-namespace \
   nvidia/gpu-operator \
   --version=v26.3.3 \

--- a/overlays/runtimepkgs.nix
+++ b/overlays/runtimepkgs.nix
@@ -102,7 +102,6 @@ else
               cleanup-images
               cleanup-containerd
               nix-gc
-              upgrade-gpu-operator
               sev-snp-measure-consistency
               ;
           }

--- a/packages/by-name/scripts/upgrade-gpu-operator/package.nix
+++ b/packages/by-name/scripts/upgrade-gpu-operator/package.nix
@@ -8,6 +8,7 @@
   jq,
   kubectl,
   kubernetes-helm,
+  yq-go,
 }:
 
 # Usage: upgrade-gpu-operator --version <version>
@@ -19,6 +20,7 @@ writeShellApplication {
     jq
     kubectl
     kubernetes-helm
+    yq-go
   ];
   text = builtins.readFile ./upgrade-gpu-operator.sh;
 }

--- a/packages/by-name/scripts/upgrade-gpu-operator/package.nix
+++ b/packages/by-name/scripts/upgrade-gpu-operator/package.nix
@@ -3,7 +3,8 @@
 
 {
   writeShellApplication,
-  busybox,
+  coreutils,
+  gnugrep,
   jq,
   kubectl,
   kubernetes-helm,
@@ -13,7 +14,8 @@
 writeShellApplication {
   name = "upgrade-gpu-operator";
   runtimeInputs = [
-    busybox
+    coreutils
+    gnugrep
     jq
     kubectl
     kubernetes-helm

--- a/packages/by-name/scripts/upgrade-gpu-operator/upgrade-gpu-operator.sh
+++ b/packages/by-name/scripts/upgrade-gpu-operator/upgrade-gpu-operator.sh
@@ -71,18 +71,38 @@ helm upgrade --install "$RELEASE" --wait \
 
 # The API server drops any ClusterPolicy field the installed CRD doesn't declare,
 # without erroring, and the operator then reports itself ready having deployed no
-# device plugin. Assert the settings above actually survived, so a stale CRD fails
-# here instead of silently producing a GPU-less node.
-if ! kubectl get clusterpolicy -o json |
-  jq -e '.items[0].spec
-         | .sandboxWorkloads.mode == "kata"
-           and ([.kataSandboxDevicePlugin.env[]? | select(.name == "P_GPU_ALIAS")] | length == 1)' >/dev/null; then
-  echo "ERROR: the ClusterPolicy did not retain the kata sandbox device plugin settings." >&2
-  echo "This usually means clusterpolicies.nvidia.com is older than the chart being installed." >&2
-  echo -n "  CRD created: " >&2
-  kubectl get crd clusterpolicies.nvidia.com -o jsonpath='{.metadata.creationTimestamp}{"\n"}' >&2
-  kubectl get clusterpolicy -o json | jq '.items[0].spec | {sandboxWorkloads, kataSandboxDevicePlugin}' >&2
-  exit 1
+# device plugin. Check that the settings above actually reached the live object.
+clusterpolicy_matches_chart() {
+  kubectl get clusterpolicy -o json |
+    jq -e '.items[0].spec
+           | .sandboxWorkloads.mode == "kata"
+             and ([.kataSandboxDevicePlugin.env[]? | select(.name == "P_GPU_ALIAS")] | length == 1)' >/dev/null
+}
+
+if ! clusterpolicy_matches_chart; then
+  # Helm's three-way merge only patches fields that differ between the previously
+  # rendered manifest and the new one, so a ClusterPolicy that was pruned when it
+  # was first written matches neither revision and helm leaves it untouched. The
+  # CRD is current by this point, so re-applying what helm rendered converges it.
+  # Helm owns .metadata and .spec here and the operator only owns .status, so this
+  # doesn't contend with the operator.
+  echo "WARNING: the live ClusterPolicy doesn't match the chart, reconciling it." >&2
+  helm get manifest "$RELEASE" -n gpu-operator |
+    yq 'select(.kind == "ClusterPolicy")' |
+    kubectl apply -f -
+
+  if ! clusterpolicy_matches_chart; then
+    echo "ERROR: the ClusterPolicy still doesn't carry the kata sandbox device plugin settings." >&2
+    echo "The clusterpolicies.nvidia.com CRD is probably older than the chart being installed" >&2
+    echo "and is pruning them. Note that a CRD updated in place keeps its original" >&2
+    echo "creationTimestamp, so check the schema rather than the age:" >&2
+    kubectl get crd clusterpolicies.nvidia.com -o json |
+      jq '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties
+          | {has_kataSandboxDevicePlugin: has("kataSandboxDevicePlugin"),
+             has_sandboxWorkloads_mode: (.sandboxWorkloads.properties | has("mode"))}' >&2
+    kubectl get clusterpolicy -o json | jq '.items[0].spec | {sandboxWorkloads, kataSandboxDevicePlugin}' >&2
+    exit 1
+  fi
 fi
 
 # Bounded: an operator that never deploys a device plugin would otherwise spin here

--- a/packages/by-name/scripts/upgrade-gpu-operator/upgrade-gpu-operator.sh
+++ b/packages/by-name/scripts/upgrade-gpu-operator/upgrade-gpu-operator.sh
@@ -29,18 +29,27 @@ if [[ -z $GPU_OPERATOR_VERSION ]]; then
   exit 1
 fi
 
-# Uninstall existing GPU operator, if exists
-helm_release=$(helm list -n gpu-operator 2>/dev/null | (grep gpu-operator || true) | awk '{print $1}')
-if [[ -n $helm_release ]]; then
-  # Skip installation if the installed version matches the desired version.
-  current_version=$(helm list -n gpu-operator 2>/dev/null | grep gpu-operator | awk '{print $10}')
-  if [[ $current_version == "$GPU_OPERATOR_VERSION" ]]; then
-    echo "GPU Operator version $GPU_OPERATOR_VERSION is already installed. Skipping installation."
-    exit 0
+# Reuse the existing release name if the operator is already installed. Clusters
+# set up before this script used --generate-name, so their release is called
+# something like gpu-operator-1787258651. Upgrading that release in place keeps
+# them on one release instead of stranding the old one next to a new one.
+# Deliberately not guarded with `|| true` or `2>/dev/null`: if helm itself fails,
+# stop. Swallowing the error would leave $existing empty, fall through to the
+# default name, and install a second release beside the one already there.
+existing=$(helm list -n gpu-operator -o json | jq -r '.[].name | select(startswith("gpu-operator"))')
+
+RELEASE=gpu-operator
+if [[ -n $existing ]]; then
+  if [[ $(wc -l <<<"$existing") -gt 1 ]]; then
+    # Two releases means someone installed a second one by hand. Picking either
+    # silently would upgrade one and leave the other shadowing it on the same node.
+    echo "ERROR: more than one gpu-operator helm release in the gpu-operator namespace:" >&2
+    echo "$existing" >&2
+    echo "Remove the stale one before running this." >&2
+    exit 1
   fi
-  helm delete -n gpu-operator "$helm_release"
+  RELEASE="$existing"
 fi
-kubectl delete crd nvidiadrivers.nvidia.com --ignore-not-found
 
 # Add the NVIDIA Helm repository
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
@@ -48,7 +57,7 @@ helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
 # Install the GPU Operator
 # The Kata sandbox plugin defaults to the pgpu alias when P_GPU_ALIAS is unset.
 # An explicitly empty value disables the alias and exposes model-specific resources.
-helm install --wait --generate-name \
+helm upgrade --install "$RELEASE" --wait \
   -n gpu-operator --create-namespace \
   nvidia/gpu-operator \
   --version="$GPU_OPERATOR_VERSION" \
@@ -60,12 +69,37 @@ helm install --wait --generate-name \
   --set nfd.enabled=true \
   --set nfd.nodefeaturerules=true
 
+# The API server drops any ClusterPolicy field the installed CRD doesn't declare,
+# without erroring, and the operator then reports itself ready having deployed no
+# device plugin. Assert the settings above actually survived, so a stale CRD fails
+# here instead of silently producing a GPU-less node.
+if ! kubectl get clusterpolicy -o json |
+  jq -e '.items[0].spec
+         | .sandboxWorkloads.mode == "kata"
+           and ([.kataSandboxDevicePlugin.env[]? | select(.name == "P_GPU_ALIAS")] | length == 1)' >/dev/null; then
+  echo "ERROR: the ClusterPolicy did not retain the kata sandbox device plugin settings." >&2
+  echo "This usually means clusterpolicies.nvidia.com is older than the chart being installed." >&2
+  echo -n "  CRD created: " >&2
+  kubectl get crd clusterpolicies.nvidia.com -o jsonpath='{.metadata.creationTimestamp}{"\n"}' >&2
+  kubectl get clusterpolicy -o json | jq '.items[0].spec | {sandboxWorkloads, kataSandboxDevicePlugin}' >&2
+  exit 1
+fi
+
+# Bounded: an operator that never deploys a device plugin would otherwise spin here
+# until the CI runner's 6h job timeout, reporting only "cancelled".
+deadline=$((SECONDS + 600))
 until [[ "$(
   kubectl get nodes -l nvidia.com/gpu.present -o json |
     jq '[.items[] | .status.allocatable
         | to_entries[] | select(.key | startswith("nvidia.com/"))
         | select(.value != "0")] | length'
 )" -gt 0 ]]; do
+  if ((SECONDS > deadline)); then
+    echo "ERROR: no node advertised a non-zero nvidia.com/* resource within 10m." >&2
+    kubectl get ds,po -n gpu-operator >&2
+    kubectl get clusterpolicy -o yaml >&2
+    exit 1
+  fi
   echo 'Waiting for GPU to become available...'
   sleep 5
 done


### PR DESCRIPTION
Fixes CON-311.

helm uninstall + helm install never refreshes a CRD, so discovery validated v26.3.3's ClusterPolicy against a schema from 2025-07-21. The API server silently pruned the two new fields, the operator deployed no device plugin and still reported itself ready, and every GPU test since failed to schedule.

Use helm upgrade --install so the chart's pre-upgrade CRD hook runs. Drop the version-equality skip that made the broken state permanent, bound the wait loop that held a runner for 6h, verify the settings actually landed, and build the package natively instead of pinning it to x86_64-linux.

Do not merge before the v1.23.1 patch release is cut. Merging fires bare metal maintenance, which with the skip gone resets discovery to P_GPU_ALIAS="". It's currently pinned to the pgpu alias, cluster-side only, because tmp/v1.23.1 hardcodes that name. main accepts either.