### PR TITLE
dev-shells: add helm

### DIFF
--- a/dev-shells/by-name/development.nix
+++ b/dev-shells/by-name/development.nix
@@ -12,6 +12,7 @@
   gotools,
   just,
   kubectl,
+  kubernetes-helm,
   yq-go,
   # keep-sorted end
   mkShell,
@@ -35,6 +36,7 @@ mkShell {
     gotools
     just
     kubectl
+    kubernetes-helm
     yq-go
     # keep-sorted end
   ]


### PR DESCRIPTION
The repo ships upgrade-gpu-operator, whose whole job is driving helm, but helm isn't on PATH in the dev shell, so debugging it means reaching outside with nix shell. kubectl and yq-go are already here for the same kind of cluster poking.

This pulls helm from the flake's nixpkgs pin, so it's the same 3.20.2 the script's own package uses rather than whatever nixpkgs-unstable has.