### PR TITLE
.github: publish the release before deleting the working branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,10 +284,6 @@ jobs:
           RELEASE_BRANCH: ${{ needs.process-inputs.outputs.RELEASE_BRANCH }}
         # release/* requires linear history so this push must be a fast-forward.
         run: git push origin "refs/tags/${VERSION}^{commit}:refs/heads/${RELEASE_BRANCH}"
-      - name: Delete temporary working branch
-        env:
-          WORKING_BRANCH: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
-        run: git push origin --delete "${WORKING_BRANCH}" || true
       - uses: ./.github/actions/regenerate_release_notes
         with:
           version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
@@ -299,6 +295,13 @@ jobs:
           VERSION: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
         run: |
           gh release edit "${VERSION}" --draft=false --repo "${{ github.repository }}"
+      # Must run after the release is published: while the release is a draft,
+      # this branch is its target_commitish, and GitHub rejects every edit to
+      # the release (including --draft=false) once the branch is gone.
+      - name: Delete temporary working branch
+        env:
+          WORKING_BRANCH: ${{ needs.process-inputs.outputs.WORKING_BRANCH }}
+        run: git push origin --delete "${WORKING_BRANCH}" || true
 
   prepare-github-release:
     name: Create backport label and milestone


### PR DESCRIPTION
The working branch is the draft release's target_commitish, so deleting it first makes every later edit to the release fail with "HTTP 422: Release.target_commitish is invalid". That includes the --draft=false publish itself, so v1.23.1 was left as a draft after the tag and the release branch had already been pushed.

Latent since dfcdfa4070, which folded this cleanup in from release_publish.yml. There it ran on the release:published trigger, so it could not run before the release left draft state.