### PR TITLE
ci/release: test the version that was built, not the branch's

### DIFF
--- a/.github/actions/release_e2e_test/action.yml
+++ b/.github/actions/release_e2e_test/action.yml
@@ -5,6 +5,10 @@ inputs:
   version:
     description: Release tag to test against, e.g. v1.2.3
     required: true
+  without_v:
+    description: >
+      Base version without the v prefix and without any pre-release suffix, e.g. 1.2.3. Must be the same value the build job was given, since it decides which derivations are in cachix.
+    required: true
   s3_base_url:
     description: If set, fetch release artifacts from this base HTTPS URL in S3 instead of from the Github release.
     required: false
@@ -60,6 +64,18 @@ inputs:
 runs:
   using: composite
   steps:
+    # The checked-out tree's version isn't the one the build job built and cached, so without
+    # this nix rebuilds the whole x86_64-linux closure, which darwin runners can't do at all.
+    - name: Verify the release version was reported
+      shell: bash
+      env:
+        WITHOUT_V: ${{ inputs.without_v }}
+      run: test -n "${WITHOUT_V}" || { echo "without_v is empty, refusing to test an unknown version"; exit 1; }
+    - name: Align version.txt with the version that was built
+      uses: ./.github/actions/bump_version
+      with:
+        version: ${{ inputs.without_v }}
+        commit: false
     - uses: ./.github/actions/setup_nix
       if: inputs.self_hosted != 'true'
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,7 @@ jobs:
       - uses: ./.github/actions/release_e2e_test
         with:
           version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
           s3_base_url: ${{ needs.release-x86_64-linux.outputs.ARTIFACTS_URL }}
           container_registry: ${{ env.container_registry }}
           platform_name: ${{ matrix.platform.name }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -178,6 +178,7 @@ jobs:
       - uses: ./.github/actions/release_e2e_test
         with:
           version: ${{ needs.process-inputs.outputs.EFFECTIVE_VERSION }}
+          without_v: ${{ needs.process-inputs.outputs.WITHOUT_V }}
           s3_base_url: ${{ needs.release-x86_64-linux.outputs.ARTIFACTS_URL }}
           container_registry: ${{ env.container_registry }}
           platform_name: ${{ matrix.platform.name }}


### PR DESCRIPTION
The build job bumps version.txt to the release version before building and caching, but the e2e jobs evaluate whatever the branch says. On a release that's a pre-version nothing ever built, so nothing is cached: Linux runners quietly rebuild and pass, Mac runners can't build Linux artifacts and fail.

Apply the same bump before evaluating.

That's the last fix that I had to workaround with the manual uploading to cachix of the assets needed by the darwin runners.