### PR TITLE
  tdx-measure: derive RTMR[0] ACPI digests from QEMU blobs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -205,3 +205,22 @@ jobs:
       - name: Run sev-snp-measure-consistency
         run: |
           nix run ".#${SET}.scripts.sev-snp-measure-consistency"
+
+  qemu-acpi-blobs-test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      SET: base
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup_nix
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Test QEMU ACPI blobs
+        run: |
+          nix build -L ".#${SET}.kata.qemu-acpi-blobs-test"

--- a/packages/by-name/kata/calculateTdxLaunchDigests/package.nix
+++ b/packages/by-name/kata/calculateTdxLaunchDigests/package.nix
@@ -23,12 +23,17 @@ let
   # Hardcode this to the B200 for now, since the calculator only
   # distinguishes between GPU and non-GPU.
   gpuFlag = lib.optionalString withGPU "-g b200";
-  # The nodeinstaller sets use_legacy_serial=true when withDebug is enabled so
-  # OVMF's DEBUG_ON_SERIAL_PORT output reaches the host. That drops
-  # virtio-serial-pci from the QEMU command line and changes the ACPI tables
-  # the firmware measures into RTMR[0]. Tell tdx-measure so it picks the
-  # matching set of hardcoded ACPI hashes.
-  legacySerialFlag = lib.optionalString withDebug "--legacy-serial";
+  # withDebug enables Kata's legacy serial topology, which changes ACPI.
+  # TODO(sespiros): Plumb the vCPU count; reference values assume one.
+  # GPU VMs currently measure no ACPI tables.
+  acpiBlobsFlag =
+    lib.optionalString (!withGPU)
+      "--acpi-blobs ${
+        kata.qemuACPIBlobs {
+          legacySerial = withDebug;
+          vcpus = 1;
+        }
+      }";
 in
 
 stdenvNoCC.mkDerivation {
@@ -41,7 +46,7 @@ stdenvNoCC.mkDerivation {
     mkdir $out
 
     ${lib.getExe tdx-measure} mrtd -f ${ovmf-tdx} --eventlog-dir eventlogs > $out/mrtd.hex
-    ${lib.getExe tdx-measure} rtmr ${gpuFlag} ${legacySerialFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 0 > $out/rtmr0.hex
+    ${lib.getExe tdx-measure} rtmr ${gpuFlag} ${acpiBlobsFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 0 > $out/rtmr0.hex
     ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 1 > $out/rtmr1.hex
     ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 2 > $out/rtmr2.hex
     ${lib.getExe tdx-measure} rtmr ${gpuFlag} -f ${ovmf-tdx} -k ${kernel} -i ${initrd} -c '${cmdline}' 3 > $out/rtmr3.hex

--- a/packages/by-name/kata/qemu-acpi-blobs-test/package.nix
+++ b/packages/by-name/kata/qemu-acpi-blobs-test/package.nix
@@ -1,0 +1,19 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{
+  qemuACPIBlobs,
+  tdx-measure,
+}:
+
+tdx-measure.overrideAttrs (_old: {
+  pname = "qemu-acpi-blobs-test";
+  ACPI_BLOBS_DEFAULT_DIR = qemuACPIBlobs {
+    vcpus = 1;
+  };
+  ACPI_BLOBS_LEGACY_SERIAL_DIR = qemuACPIBlobs {
+    vcpus = 1;
+    legacySerial = true;
+  };
+  doCheck = true;
+})

--- a/packages/by-name/kata/qemuACPIBlobs/package.nix
+++ b/packages/by-name/kata/qemuACPIBlobs/package.nix
@@ -6,6 +6,7 @@
   stdenvNoCC,
   qemu-cc,
   source,
+  tdx-measure,
 }:
 
 {

--- a/packages/by-name/kata/qemuACPIBlobs/package.nix
+++ b/packages/by-name/kata/qemuACPIBlobs/package.nix
@@ -1,0 +1,152 @@
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+{
+  lib,
+  stdenvNoCC,
+  qemu-cc,
+  source,
+}:
+
+{
+  # MADT depends on the vCPU count.
+  vcpus,
+  legacySerial ? false,
+  # qemu-cc omits memory-dependent ACPI data; 130 MiB is the DMA minimum.
+  memoryMiB ? 1024,
+}:
+
+# Generates OVMF-measured ACPI blobs for Kata's q35 topology with qtest.
+let
+  # Force review of the mirrored topology on Kata upgrades.
+  mirroredKataVersion = "4.1.0";
+
+  qemuAcpiDump = tdx-measure.overrideAttrs (oldAttrs: {
+    pname = "qemu-acpi-dump";
+    subPackages = [ "internal/cmd/qemu-acpi-dump" ];
+    ldflags = [ "-s" ];
+    doCheck = false;
+    meta = oldAttrs.meta // {
+      mainProgram = "qemu-acpi-dump";
+    };
+  });
+
+  mkBlob =
+    {
+      vcpus,
+      legacySerial,
+      memoryMiB,
+    }:
+    let
+      mem = "${toString memoryMiB}M";
+
+      # Legacy serial replaces virtio-serial-pci and shifts later PCI slots.
+      serialDevices =
+        if legacySerial then
+          [
+            "-chardev"
+            "null,id=charconsole0"
+            "-serial"
+            "chardev:charconsole0"
+          ]
+        else
+          [
+            "-device"
+            "virtio-serial-pci,disable-modern=false,id=serial0"
+          ];
+
+      # Device order mirrors Kata and determines ACPI PCI slots.
+      qemuArgs = [
+        # TDX disables SMM and PIC; both affect ACPI.
+        "-machine"
+        "q35,accel=qtest,smm=off,pic=off"
+        # qtest cannot use -cpu host; ACPI uses the -smp count.
+        "-cpu"
+        "qemu64"
+        "-m"
+        mem
+        # Match Kata's OVMF hot-plug bridge.
+        "-device"
+        "pcie-root-port,id=rp-pci-bridge-0,bus=pcie.0,chassis=16,slot=0,addr=2,multifunction=off,bus-reserve=0x1,pref64-reserve=1m,mem-reserve=1m,io-reserve=4k"
+        "-device"
+        "pcie-pci-bridge,bus=rp-pci-bridge-0,id=pci-bridge-0"
+      ]
+      ++ serialDevices
+      ++ [
+        # Storage devices preserve Kata's PCI topology; null-co provides their backends.
+        "-blockdev"
+        "driver=null-co,node-name=drv-image,size=1073741824"
+        "-device"
+        "virtio-blk-pci,disable-modern=false,drive=drv-image"
+        "-device"
+        "virtio-scsi-pci,id=scsi0,disable-modern=false"
+        "-blockdev"
+        "driver=null-co,node-name=drv-initdata,size=1073741824"
+        "-device"
+        "virtio-blk-pci,disable-modern=false,drive=drv-initdata"
+        "-blockdev"
+        "driver=null-co,node-name=drv-imagepuller,size=1073741824"
+        "-device"
+        "virtio-blk-pci,disable-modern=false,drive=drv-imagepuller"
+        # Balloon preserves vhost-vsock's PCI slot without a host backend.
+        "-device"
+        "virtio-balloon-pci"
+        # hubport replaces tap; virtio-net-pci remains ACPI-visible.
+        "-netdev"
+        "hubport,id=network-0,hubid=0"
+        "-device"
+        "virtio-net-pci,netdev=network-0,disable-modern=false"
+        "-rtc"
+        "base=utc,driftfix=slew,clock=host"
+        "-vga"
+        "none"
+        "-no-user-config"
+        "-nodefaults"
+        "-nographic"
+        "--no-reboot"
+        "-object"
+        "memory-backend-ram,id=dimm1,size=${mem}"
+        "-numa"
+        "node,memdev=dimm1"
+        "-smp"
+        "${toString vcpus},cores=${toString vcpus},threads=1,sockets=1,maxcpus=${toString vcpus}"
+      ];
+
+      manifest = builtins.toJSON {
+        inherit vcpus legacySerial memoryMiB;
+        kataVersion = source.version;
+      };
+    in
+    assert lib.assertMsg (source.version == mirroredKataVersion)
+      "qemu-acpi-blobs mirrors Kata ${mirroredKataVersion}; review qemuArgs before updating to ${source.version}";
+    assert lib.assertMsg (vcpus > 0) "qemu-acpi-blobs requires vcpus > 0";
+    assert lib.assertMsg (
+      memoryMiB >= 130
+    ) "qemu-acpi-blobs requires memoryMiB >= 130 for fw_cfg DMA scratch space";
+    stdenvNoCC.mkDerivation {
+      name = "qemu-acpi-blobs${lib.optionalString legacySerial "-legacy-serial"}-${toString vcpus}vcpu";
+
+      dontUnpack = true;
+
+      nativeBuildInputs = [
+        qemu-cc
+        qemuAcpiDump
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        mkdir -p "$out"
+        qemu-acpi-dump \
+          --output "$out" \
+          --qemu ${qemu-cc}/bin/qemu-system-x86_64 \
+          --metadata-json ${lib.escapeShellArg manifest} \
+          -- ${lib.escapeShellArgs qemuArgs}
+
+        runHook postBuild
+      '';
+
+      dontInstall = true;
+    };
+in
+mkBlob { inherit vcpus legacySerial memoryMiB; }

--- a/tools/tdx-measure/internal/acpi/blobs.go
+++ b/tools/tdx-measure/internal/acpi/blobs.go
@@ -24,3 +24,15 @@ func WriteBlob(outputDir, name string, data []byte) error {
 	}
 	return nil
 }
+
+// readBlob reads data from its validated fw_cfg path below blobsDir.
+func readBlob(blobsDir, name string) ([]byte, error) {
+	if !fs.ValidPath(name) {
+		return nil, fmt.Errorf("invalid fw_cfg blob name %q", name)
+	}
+	data, err := os.ReadFile(filepath.Join(blobsDir, filepath.FromSlash(name)))
+	if err != nil {
+		return nil, fmt.Errorf("reading ACPI blob %q: %w", name, err)
+	}
+	return data, nil
+}

--- a/tools/tdx-measure/internal/acpi/blobs.go
+++ b/tools/tdx-measure/internal/acpi/blobs.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package acpi
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// WriteBlob writes data at its validated fw_cfg path below outputDir.
+func WriteBlob(outputDir, name string, data []byte) error {
+	if !fs.ValidPath(name) {
+		return fmt.Errorf("invalid fw_cfg blob name %q", name)
+	}
+	destination := filepath.Join(outputDir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return fmt.Errorf("creating directory for %q: %w", name, err)
+	}
+	if err := os.WriteFile(destination, data, 0o644); err != nil {
+		return fmt.Errorf("writing ACPI blob %q: %w", name, err)
+	}
+	return nil
+}

--- a/tools/tdx-measure/internal/acpi/digests.go
+++ b/tools/tdx-measure/internal/acpi/digests.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package acpi
+
+import "crypto/sha512"
+
+// OVMFDataDigests hashes OVMF's fixed ACPI DATA sequence.
+// Digests cover raw fw_cfg blobs before relocation and checksum patches.
+func OVMFDataDigests(blobsDir string) ([][48]byte, error) {
+	files := OVMFMeasuredFiles()
+	digests := make([][48]byte, 0, len(files))
+	for _, name := range files {
+		blob, err := readBlob(blobsDir, name)
+		if err != nil {
+			return nil, err
+		}
+		digests = append(digests, sha512.Sum384(blob))
+	}
+	return digests, nil
+}

--- a/tools/tdx-measure/internal/acpi/digests_test.go
+++ b/tools/tdx-measure/internal/acpi/digests_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package acpi
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"os"
+	"testing"
+)
+
+// Known Kata 4.0 digests in OVMFMeasuredFiles order.
+var referenceDataDigests = map[string][]string{
+	"default": {
+		"a98ebc08f45482c21c329b93a51b926a299c4c366d4e79d6ba586e4a8c92a66e9d593b176ffdf32476f0dd81bb68f95b",
+		"6cd5eb8fa5c659b3ac4172a1c678aa1bba3118e107dcc5cdea0deec83b50e152703822396ef3422fd020bbf0ffdc3491",
+		"764a603f33825a43eff061cf6154516d8304eb420a08c06b7e3d7a956932b82efa591701b1854a1fb75a8deb54b2aefc",
+	},
+	"legacy-serial": {
+		"1714c92f524640a6763417944c2c0e59b81b8560c94e8f8cb3e0b30c895c2eb90b6fd380dce3e4b89b8356766c7eacee",
+		"0d00216b9fcdff6a6dfb7bb92b8ccf35b6804d5d195f2b9dd34fbecd0585433cf567a520f3cefb45a792469f859430b2",
+		"05e27a7651b031e69216a487d39aba403766b546bba04b2bebfdc5bc160275a75249cfe147a753b799b5023a17124da4",
+	},
+}
+
+// Nix sets these paths for the real-blob regression.
+var blobsDirEnv = map[string]string{
+	"default":       "ACPI_BLOBS_DEFAULT_DIR",
+	"legacy-serial": "ACPI_BLOBS_LEGACY_SERIAL_DIR",
+}
+
+func writeTestBlob(t *testing.T, blobsDir, name string, data []byte) {
+	t.Helper()
+	if err := WriteBlob(blobsDir, name, data); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+// TestOVMFDataDigestsSynthetic checks ordering and raw SHA-384 hashing.
+func TestOVMFDataDigestsSynthetic(t *testing.T) {
+	dir := t.TempDir()
+
+	loader := []byte("dummy-table-loader-blob")
+	rsdp := []byte("dummy-rsdp-blob")
+	tables := []byte("dummy-tables-blob-contents")
+	writeTestBlob(t, dir, "etc/table-loader", loader)
+	writeTestBlob(t, dir, "etc/acpi/rsdp", rsdp)
+	writeTestBlob(t, dir, "etc/acpi/tables", tables)
+
+	digests, err := OVMFDataDigests(dir)
+	if err != nil {
+		t.Fatalf("OVMFDataDigests: %v", err)
+	}
+
+	want := [][48]byte{
+		sha512.Sum384(loader),
+		sha512.Sum384(rsdp),
+		sha512.Sum384(tables),
+	}
+	if len(digests) != len(want) {
+		t.Fatalf("got %d digests, want %d", len(digests), len(want))
+	}
+	for i := range want {
+		if digests[i] != want[i] {
+			t.Errorf("digest %d: got %s, want %s", i,
+				hex.EncodeToString(digests[i][:]), hex.EncodeToString(want[i][:]))
+		}
+	}
+}
+
+// TestOVMFDataDigestsRealBlobs checks generated blobs against known digests.
+func TestOVMFDataDigestsRealBlobs(t *testing.T) {
+	for topology, want := range referenceDataDigests {
+		t.Run(topology, func(t *testing.T) {
+			dir := os.Getenv(blobsDirEnv[topology])
+			if dir == "" {
+				t.Skipf("%s unset; skipping real-blob regression", blobsDirEnv[topology])
+			}
+			digests, err := OVMFDataDigests(dir)
+			if err != nil {
+				t.Fatalf("OVMFDataDigests: %v", err)
+			}
+			if len(digests) != len(want) {
+				t.Fatalf("got %d digests, want %d", len(digests), len(want))
+			}
+			for i, w := range want {
+				if got := hex.EncodeToString(digests[i][:]); got != w {
+					t.Errorf("digest %d: got %s, want %s", i, got, w)
+				}
+			}
+		})
+	}
+}

--- a/tools/tdx-measure/internal/acpi/files.go
+++ b/tools/tdx-measure/internal/acpi/files.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package acpi handles QEMU ACPI fw_cfg blobs measured by OVMF.
+package acpi
+
+// OVMFMeasuredFiles returns OVMF's fixed measurement order.
+func OVMFMeasuredFiles() []string {
+	return []string{
+		"etc/table-loader",
+		"etc/acpi/rsdp",
+		"etc/acpi/tables",
+	}
+}

--- a/tools/tdx-measure/internal/cmd/qemu-acpi-dump/dump.go
+++ b/tools/tdx-measure/internal/cmd/qemu-acpi-dump/dump.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/edgelesssys/contrast/tdx-measure/internal/acpi"
+	"github.com/edgelesssys/contrast/tdx-measure/internal/qtest"
+)
+
+const (
+	pciexbarOffset      = 0x60
+	ecamBase            = 0xe0000000
+	ecamEnable          = 0x1
+	ich9LPCDevice       = 0x1f
+	ich9LPCPMBaseOffset = 0x40
+	ich9LPCPMBaseValue  = 0x0600
+	ich9LPCACPIOffset   = 0x44
+	ich9LPCACPIEnable   = 0x80
+)
+
+type dumpConfig struct {
+	OutputDir  string
+	QEMUBinary string
+	QEMUArgs   []string
+}
+
+// dump extracts OVMF-measured ACPI blobs without running guest code.
+func dump(ctx context.Context, config dumpConfig) (returnErr error) {
+	if config.OutputDir == "" {
+		return fmt.Errorf("output directory is required")
+	}
+	if config.QEMUBinary == "" {
+		return fmt.Errorf("QEMU binary is required")
+	}
+	if err := os.MkdirAll(config.OutputDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	session, err := qtest.Start(ctx, config.QEMUBinary, config.QEMUArgs)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := session.Close(); err != nil && returnErr == nil {
+			returnErr = err
+		}
+	}()
+
+	client := session.Client()
+	if err := programACPIChipsetRegisters(ctx, client); err != nil {
+		return fmt.Errorf("programming ACPI chipset registers: %w", err)
+	}
+
+	fwConfig, err := qtest.OpenFWConfig(ctx, client)
+	if err != nil {
+		return err
+	}
+	for _, name := range acpi.OVMFMeasuredFiles() {
+		blob, err := fwConfig.ReadFile(ctx, name)
+		if err != nil {
+			return err
+		}
+		if err := acpi.WriteBlob(config.OutputDir, name, blob); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// programACPIChipsetRegisters reproduces OVMF's q35 ACPI register setup.
+func programACPIChipsetRegisters(ctx context.Context, client *qtest.Client) error {
+	if err := client.PCIConfigWrite32(ctx, 0, 0, 0, pciexbarOffset+4, ecamBase>>32); err != nil {
+		return err
+	}
+	if err := client.PCIConfigWrite32(ctx, 0, 0, 0, pciexbarOffset, ecamBase|ecamEnable); err != nil {
+		return err
+	}
+	if err := client.PCIConfigWrite32(ctx, 0, ich9LPCDevice, 0, ich9LPCPMBaseOffset, ich9LPCPMBaseValue); err != nil {
+		return err
+	}
+	return client.PCIConfigWrite8(ctx, 0, ich9LPCDevice, 0, ich9LPCACPIOffset, ich9LPCACPIEnable)
+}
+
+func qemuVersion(ctx context.Context, binary string) (string, error) {
+	output, err := exec.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("reading QEMU version: %w", err)
+	}
+	version, _, _ := strings.Cut(string(output), "\n")
+	if version == "" {
+		return "", fmt.Errorf("QEMU returned an empty version")
+	}
+	return strings.TrimSuffix(version, "\r"), nil
+}

--- a/tools/tdx-measure/internal/cmd/qemu-acpi-dump/main.go
+++ b/tools/tdx-measure/internal/cmd/qemu-acpi-dump/main.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string) error {
+	flags := flag.NewFlagSet("qemu-acpi-dump", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	outputDir := flags.String("output", "", "directory to write the ACPI blobs into")
+	qemuBinary := flags.String("qemu", "", "QEMU system binary")
+	metadataJSON := flags.String("metadata-json", "{}", "JSON object to merge into manifest.json")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if *outputDir == "" {
+		return errors.New("--output is required")
+	}
+	if *qemuBinary == "" {
+		return errors.New("--qemu is required")
+	}
+
+	metadata := map[string]any{}
+	if err := json.Unmarshal([]byte(*metadataJSON), &metadata); err != nil {
+		return fmt.Errorf("parsing --metadata-json: %w", err)
+	}
+	if metadata == nil {
+		return errors.New("--metadata-json must be a JSON object")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if err := dump(ctx, dumpConfig{
+		OutputDir:  *outputDir,
+		QEMUBinary: *qemuBinary,
+		QEMUArgs:   flags.Args(),
+	}); err != nil {
+		return err
+	}
+	version, err := qemuVersion(ctx, *qemuBinary)
+	if err != nil {
+		return err
+	}
+
+	metadata["qemuVersion"] = version
+	manifest, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding manifest: %w", err)
+	}
+	manifest = append(manifest, '\n')
+	if err := os.WriteFile(filepath.Join(*outputDir, "manifest.json"), manifest, 0o644); err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+	return nil
+}

--- a/tools/tdx-measure/internal/qtest/client.go
+++ b/tools/tdx-measure/internal/qtest/client.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package qtest accesses QEMU's emulated devices through the qtest protocol.
+package qtest
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+// Client is a qtest protocol client.
+type Client struct {
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+// NewClient creates a qtest client over conn.
+func NewClient(conn net.Conn) *Client {
+	return &Client{
+		conn:   conn,
+		reader: bufio.NewReader(conn),
+	}
+}
+
+func (c *Client) command(ctx context.Context, command string) (string, error) {
+	deadline := time.Now().Add(time.Minute)
+	if contextDeadline, ok := ctx.Deadline(); ok {
+		deadline = contextDeadline
+	}
+	if err := c.conn.SetDeadline(deadline); err != nil {
+		return "", fmt.Errorf("setting qtest deadline: %w", err)
+	}
+	if _, err := io.WriteString(c.conn, command+"\n"); err != nil {
+		return "", fmt.Errorf("sending qtest command %q: %w", command, err)
+	}
+
+	response, err := c.reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("reading response to qtest command %q: %w", command, err)
+	}
+	response = strings.TrimSuffix(response, "\n")
+	if response != "OK" && !strings.HasPrefix(response, "OK ") {
+		return "", fmt.Errorf("qtest command %q failed: %q", command, response)
+	}
+	return response, nil
+}
+
+func (c *Client) outB(ctx context.Context, port uint16, value byte) error {
+	_, err := c.command(ctx, fmt.Sprintf("outb 0x%x 0x%x", port, value))
+	return err
+}
+
+func (c *Client) outL(ctx context.Context, port uint16, value uint32) error {
+	_, err := c.command(ctx, fmt.Sprintf("outl 0x%x 0x%x", port, value))
+	return err
+}
+
+func (c *Client) writeMemory(ctx context.Context, address uint64, data []byte) error {
+	_, err := c.command(ctx, fmt.Sprintf("write 0x%x 0x%x 0x%x", address, len(data), data))
+	return err
+}
+
+func (c *Client) readMemory(ctx context.Context, address uint64, size uint32) ([]byte, error) {
+	response, err := c.command(ctx, fmt.Sprintf("b64read 0x%x 0x%x", address, size))
+	if err != nil {
+		return nil, err
+	}
+	fields := strings.Fields(response)
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("malformed b64read response %q", response)
+	}
+	data, err := base64.StdEncoding.DecodeString(fields[1])
+	if err != nil {
+		return nil, fmt.Errorf("decoding b64read response: %w", err)
+	}
+	if len(data) != int(size) {
+		return nil, fmt.Errorf("qtest b64read returned %d bytes, want %d", len(data), size)
+	}
+	return data, nil
+}

--- a/tools/tdx-measure/internal/qtest/client_test.go
+++ b/tools/tdx-measure/internal/qtest/client_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestReadMemory(t *testing.T) {
+	const testAddress = 0x08000000
+
+	clientConnection, serverConnection := net.Pipe()
+	defer clientConnection.Close()
+	defer serverConnection.Close()
+
+	want := []byte{0, 1, 2, 0xfe, 0xff}
+	serverError := make(chan error, 1)
+	go func() {
+		request, err := bufio.NewReader(serverConnection).ReadString('\n')
+		if err != nil {
+			serverError <- err
+			return
+		}
+		if request != "b64read 0x8000000 0x5\n" {
+			serverError <- fmt.Errorf("request = %q", request)
+			return
+		}
+		_, err = fmt.Fprintf(serverConnection, "OK %s\n", base64.StdEncoding.EncodeToString(want))
+		serverError <- err
+	}()
+
+	got, err := NewClient(clientConnection).readMemory(t.Context(), testAddress, uint32(len(want)))
+	if err != nil {
+		t.Fatalf("readMemory: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("readMemory() = %x, want %x", got, want)
+	}
+	if err := <-serverError; err != nil {
+		t.Fatalf("fake qtest server: %v", err)
+	}
+}
+
+func TestRejectsErrorResponse(t *testing.T) {
+	clientConnection, serverConnection := net.Pipe()
+	defer clientConnection.Close()
+	defer serverConnection.Close()
+
+	go func() {
+		_, _ = bufio.NewReader(serverConnection).ReadString('\n')
+		_, _ = fmt.Fprintln(serverConnection, "FAIL unsupported command")
+	}()
+	if _, err := NewClient(clientConnection).command(t.Context(), "bad-command"); err == nil {
+		t.Fatal("command returned nil error")
+	}
+}

--- a/tools/tdx-measure/internal/qtest/fwcfg.go
+++ b/tools/tdx-measure/internal/qtest/fwcfg.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+	"strings"
+)
+
+const (
+	dmaAddressHighPort = 0x514
+	dmaAddressLowPort  = 0x518
+	fileDirectory      = 0x19
+	dmaControlRead     = 0x02
+	dmaControlSelect   = 0x08
+
+	dataAddress   = 0x08000000
+	accessAddress = 0x08100000
+	maxBlobSize   = accessAddress - dataAddress
+
+	fileDirectoryEntrySize  = 64
+	maxFileDirectoryEntries = 4095
+)
+
+// FWConfig provides access to QEMU fw_cfg files through qtest DMA.
+type FWConfig struct {
+	client    *Client
+	directory map[string]fwConfigFile
+}
+
+type fwConfigFile struct {
+	selector uint16
+	size     uint32
+}
+
+// OpenFWConfig reads the fw_cfg file directory.
+func OpenFWConfig(ctx context.Context, client *Client) (*FWConfig, error) {
+	directory, err := readDirectory(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("reading fw_cfg directory: %w", err)
+	}
+	return &FWConfig{client: client, directory: directory}, nil
+}
+
+// ReadFile returns the contents of the named fw_cfg file.
+func (f *FWConfig) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	entry, exists := f.directory[name]
+	if !exists {
+		return nil, fmt.Errorf("fw_cfg entry %q not found", name)
+	}
+	if entry.size > maxBlobSize {
+		return nil, fmt.Errorf("fw_cfg entry %q is %d bytes, exceeding DMA scratch space %d", name, entry.size, maxBlobSize)
+	}
+	data, err := dmaRead(ctx, f.client, entry.selector, entry.size)
+	if err != nil {
+		return nil, fmt.Errorf("reading fw_cfg entry %q: %w", name, err)
+	}
+	return data, nil
+}
+
+func dmaRead(ctx context.Context, client *Client, selector uint16, size uint32) ([]byte, error) {
+	if size > maxBlobSize {
+		return nil, fmt.Errorf("fw_cfg entry size %d exceeds DMA scratch space %d", size, maxBlobSize)
+	}
+	access := make([]byte, 16)
+	control := uint32(selector)<<16 | dmaControlSelect | dmaControlRead
+	binary.BigEndian.PutUint32(access[0:4], control)
+	binary.BigEndian.PutUint32(access[4:8], size)
+	binary.BigEndian.PutUint64(access[8:16], dataAddress)
+	if err := client.writeMemory(ctx, accessAddress, access); err != nil {
+		return nil, err
+	}
+
+	// The fw_cfg DMA address register is big-endian.
+	high := bits.ReverseBytes32(uint32(accessAddress >> 32))
+	low := bits.ReverseBytes32(uint32(accessAddress))
+	if err := client.outL(ctx, dmaAddressHighPort, high); err != nil {
+		return nil, err
+	}
+	if err := client.outL(ctx, dmaAddressLowPort, low); err != nil {
+		return nil, err
+	}
+	return client.readMemory(ctx, dataAddress, size)
+}
+
+func readDirectory(ctx context.Context, client *Client) (map[string]fwConfigFile, error) {
+	countData, err := dmaRead(ctx, client, fileDirectory, 4)
+	if err != nil {
+		return nil, err
+	}
+	count := binary.BigEndian.Uint32(countData)
+	if count == 0 || count > maxFileDirectoryEntries {
+		return nil, fmt.Errorf("invalid fw_cfg file count %d", count)
+	}
+	raw, err := dmaRead(ctx, client, fileDirectory, 4+count*fileDirectoryEntrySize)
+	if err != nil {
+		return nil, err
+	}
+	return parseDirectory(raw)
+}
+
+func parseDirectory(raw []byte) (map[string]fwConfigFile, error) {
+	if len(raw) < 4 {
+		return nil, fmt.Errorf("fw_cfg directory is only %d bytes", len(raw))
+	}
+	count := binary.BigEndian.Uint32(raw[:4])
+	if count == 0 || count > maxFileDirectoryEntries {
+		return nil, fmt.Errorf("invalid fw_cfg file count %d", count)
+	}
+	expectedSize := 4 + int(count)*fileDirectoryEntrySize
+	if len(raw) != expectedSize {
+		return nil, fmt.Errorf("fw_cfg directory has %d bytes, want %d", len(raw), expectedSize)
+	}
+
+	directory := make(map[string]fwConfigFile, count)
+	for index := range count {
+		offset := 4 + int(index)*fileDirectoryEntrySize
+		entry := raw[offset : offset+fileDirectoryEntrySize]
+		name := cString(entry[8:64])
+		if name == "" {
+			return nil, fmt.Errorf("fw_cfg directory entry %d has an empty name", index)
+		}
+		if _, exists := directory[name]; exists {
+			return nil, fmt.Errorf("fw_cfg directory contains duplicate entry %q", name)
+		}
+		directory[name] = fwConfigFile{
+			selector: binary.BigEndian.Uint16(entry[4:6]),
+			size:     binary.BigEndian.Uint32(entry[0:4]),
+		}
+	}
+	return directory, nil
+}
+
+func cString(data []byte) string {
+	if index := strings.IndexByte(string(data), 0); index >= 0 {
+		return string(data[:index])
+	}
+	return string(data)
+}

--- a/tools/tdx-measure/internal/qtest/fwcfg_test.go
+++ b/tools/tdx-measure/internal/qtest/fwcfg_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseDirectory(t *testing.T) {
+	raw := make([]byte, 4+2*fileDirectoryEntrySize)
+	binary.BigEndian.PutUint32(raw[:4], 2)
+	writeDirectoryEntry(raw[4:4+fileDirectoryEntrySize], "etc/table-loader", 0x20, 384)
+	writeDirectoryEntry(raw[4+fileDirectoryEntrySize:], "etc/acpi/tables", 0x21, 131072)
+
+	directory, err := parseDirectory(raw)
+	if err != nil {
+		t.Fatalf("parseDirectory: %v", err)
+	}
+	if got := directory["etc/table-loader"]; got != (fwConfigFile{selector: 0x20, size: 384}) {
+		t.Fatalf("table-loader entry = %#v", got)
+	}
+	if got := directory["etc/acpi/tables"]; got != (fwConfigFile{selector: 0x21, size: 131072}) {
+		t.Fatalf("tables entry = %#v", got)
+	}
+}
+
+func TestParseDirectoryRejectsMalformedInput(t *testing.T) {
+	tests := map[string][]byte{
+		"short header": {0, 0, 0},
+		"zero entries": {0, 0, 0, 0},
+		"short entry":  {0, 0, 0, 1},
+	}
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseDirectory(raw); err == nil {
+				t.Fatal("parseDirectory returned nil error")
+			}
+		})
+	}
+}
+
+func TestParseDirectoryRejectsDuplicateName(t *testing.T) {
+	raw := make([]byte, 4+2*fileDirectoryEntrySize)
+	binary.BigEndian.PutUint32(raw[:4], 2)
+	writeDirectoryEntry(raw[4:4+fileDirectoryEntrySize], "duplicate", 1, 1)
+	writeDirectoryEntry(raw[4+fileDirectoryEntrySize:], "duplicate", 2, 2)
+	if _, err := parseDirectory(raw); err == nil {
+		t.Fatal("parseDirectory returned nil error")
+	}
+}
+
+func writeDirectoryEntry(entry []byte, name string, selector uint16, size uint32) {
+	binary.BigEndian.PutUint32(entry[0:4], size)
+	binary.BigEndian.PutUint16(entry[4:6], selector)
+	copy(entry[8:64], name)
+}

--- a/tools/tdx-measure/internal/qtest/pci.go
+++ b/tools/tdx-measure/internal/qtest/pci.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import "context"
+
+const (
+	pciConfigAddressPort = 0xcf8
+	pciConfigDataPort    = 0xcfc
+)
+
+// PCIConfigWrite32 writes a 32-bit value to a PCI configuration register.
+func (c *Client) PCIConfigWrite32(ctx context.Context, bus, device, function, offset, value uint32) error {
+	if err := c.outL(ctx, pciConfigAddressPort, pciConfigAddress(bus, device, function, offset)); err != nil {
+		return err
+	}
+	return c.outL(ctx, pciConfigDataPort, value)
+}
+
+// PCIConfigWrite8 writes an 8-bit value to a PCI configuration register.
+func (c *Client) PCIConfigWrite8(ctx context.Context, bus, device, function, offset uint32, value byte) error {
+	if err := c.outL(ctx, pciConfigAddressPort, pciConfigAddress(bus, device, function, offset)); err != nil {
+		return err
+	}
+	return c.outB(ctx, pciConfigDataPort+uint16(offset&3), value)
+}
+
+func pciConfigAddress(bus, device, function, offset uint32) uint32 {
+	return 0x80000000 | bus<<16 | device<<11 | function<<8 | offset&0xfc
+}

--- a/tools/tdx-measure/internal/qtest/pci_test.go
+++ b/tools/tdx-measure/internal/qtest/pci_test.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import "testing"
+
+func TestPCIConfigAddress(t *testing.T) {
+	if got, want := pciConfigAddress(2, 3, 1, 0x65), uint32(0x80021964); got != want {
+		t.Fatalf("pciConfigAddress() = %#x, want %#x", got, want)
+	}
+}

--- a/tools/tdx-measure/internal/qtest/session.go
+++ b/tools/tdx-measure/internal/qtest/session.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// Session owns a QEMU process and its qtest connection.
+type Session struct {
+	client       *Client
+	connection   net.Conn
+	listener     net.Listener
+	process      *os.Process
+	processDone  <-chan error
+	temporaryDir string
+}
+
+// Start launches QEMU with a qtest control socket and waits for QEMU to connect.
+func Start(ctx context.Context, binary string, arguments []string) (*Session, error) {
+	if binary == "" {
+		return nil, fmt.Errorf("QEMU binary is required")
+	}
+	temporaryDir, err := os.MkdirTemp("", "qtest-")
+	if err != nil {
+		return nil, fmt.Errorf("creating qtest temporary directory: %w", err)
+	}
+
+	socketPath := filepath.Join(temporaryDir, "qtest.sock")
+	// QEMU's qtest chardev connects as a client unless server=on is set.
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "unix", socketPath)
+	if err != nil {
+		_ = os.RemoveAll(temporaryDir)
+		return nil, fmt.Errorf("listening on qtest socket: %w", err)
+	}
+
+	qemuArguments := append([]string{}, arguments...)
+	qemuArguments = append(
+		qemuArguments,
+		"-qtest", "unix:path="+socketPath,
+		"-qtest-log", "none",
+		"-display", "none",
+	)
+	command := exec.CommandContext(ctx, binary, qemuArguments...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Start(); err != nil {
+		_ = listener.Close()
+		_ = os.RemoveAll(temporaryDir)
+		return nil, fmt.Errorf("starting QEMU: %w", err)
+	}
+
+	processDone := make(chan error, 1)
+	go func() {
+		processDone <- command.Wait()
+		close(processDone)
+	}()
+
+	connection, err := acceptConnection(ctx, listener, processDone)
+	if err != nil {
+		_ = listener.Close()
+		stopErr := stopProcess(command.Process, processDone)
+		_ = os.RemoveAll(temporaryDir)
+		return nil, errors.Join(err, stopErr)
+	}
+
+	return &Session{
+		client:       NewClient(connection),
+		connection:   connection,
+		listener:     listener,
+		process:      command.Process,
+		processDone:  processDone,
+		temporaryDir: temporaryDir,
+	}, nil
+}
+
+// Client returns the qtest protocol client for the session.
+func (s *Session) Client() *Client {
+	return s.client
+}
+
+// Close terminates QEMU and releases the qtest socket and temporary directory.
+func (s *Session) Close() error {
+	_ = s.connection.Close()
+	stopErr := stopProcess(s.process, s.processDone)
+	_ = s.listener.Close()
+	_ = os.RemoveAll(s.temporaryDir)
+	return stopErr
+}
+
+func acceptConnection(ctx context.Context, listener net.Listener, processDone <-chan error) (net.Conn, error) {
+	type acceptResult struct {
+		connection net.Conn
+		err        error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		connection, err := listener.Accept()
+		accepted <- acceptResult{connection: connection, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for QEMU qtest connection: %w", ctx.Err())
+	case err := <-processDone:
+		if err == nil {
+			return nil, errors.New("QEMU exited before connecting to qtest")
+		}
+		return nil, fmt.Errorf("QEMU exited before connecting to qtest: %w", err)
+	case result := <-accepted:
+		if result.err != nil {
+			return nil, fmt.Errorf("accepting QEMU qtest connection: %w", result.err)
+		}
+		return result.connection, nil
+	}
+}
+
+func stopProcess(process *os.Process, processDone <-chan error) error {
+	if err := process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("terminating QEMU: %w", err)
+	}
+	select {
+	case <-processDone:
+		return nil
+	case <-time.After(10 * time.Second):
+		if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return fmt.Errorf("killing QEMU after timeout: %w", err)
+		}
+		<-processDone
+		return nil
+	}
+}

--- a/tools/tdx-measure/internal/qtest/session_test.go
+++ b/tools/tdx-measure/internal/qtest/session_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package qtest
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestAcceptConnection(t *testing.T) {
+	clientConnection, serverConnection := net.Pipe()
+	defer clientConnection.Close()
+	listener := newTestListener()
+	listener.results <- testAcceptResult{connection: serverConnection}
+
+	connection, err := acceptConnection(context.Background(), listener, make(chan error))
+	if err != nil {
+		t.Fatalf("acceptConnection: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("closing accepted connection: %v", err)
+	}
+}
+
+func TestAcceptConnectionReportsProcessExit(t *testing.T) {
+	listener := newTestListener()
+	defer listener.Close()
+	want := errors.New("QEMU failed")
+	processDone := make(chan error, 1)
+	processDone <- want
+	close(processDone)
+	if _, err := acceptConnection(context.Background(), listener, processDone); !errors.Is(err, want) {
+		t.Fatalf("acceptConnection error = %v, want wrapped %v", err, want)
+	}
+}
+
+type testAcceptResult struct {
+	connection net.Conn
+	err        error
+}
+
+type testListener struct {
+	results chan testAcceptResult
+}
+
+func newTestListener() *testListener {
+	return &testListener{results: make(chan testAcceptResult, 1)}
+}
+
+func (l *testListener) Accept() (net.Conn, error) {
+	result := <-l.results
+	return result.connection, result.err
+}
+
+func (l *testListener) Close() error {
+	select {
+	case l.results <- testAcceptResult{err: net.ErrClosed}:
+	default:
+	}
+	return nil
+}
+
+func (l *testListener) Addr() net.Addr {
+	return testAddr("qtest")
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return string(a) }
+func (a testAddr) String() string  { return string(a) }

--- a/tools/tdx-measure/main.go
+++ b/tools/tdx-measure/main.go
@@ -128,7 +128,10 @@ func newRtMrCmd() *cobra.Command {
 	}
 	cmd.Flags().StringP("cmdline", "c", "", "kernel command line")
 	cmd.Flags().StringP("gpu-model", "g", "none", "GPU model used in the VM (none, h100, b200, b300)")
-	cmd.Flags().Bool("legacy-serial", false, "VM uses -serial chardev:... instead of virtio-serial-pci (changes ACPI topology)")
+	cmd.Flags().String("acpi-blobs", "", "path to the directory of dumped QEMU ACPI fw_cfg blobs (etc/table-loader, etc/acpi/*) for the VM topology; required for RTMR 0 of non-GPU VMs")
+	if err := cmd.MarkFlagDirname("acpi-blobs"); err != nil {
+		panic(err)
+	}
 	return cmd
 }
 
@@ -153,11 +156,11 @@ func runRtMr(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("invalid gpu model: %w", err)
 		}
-		legacySerial, err := cmd.Flags().GetBool("legacy-serial")
+		acpiBlobsDir, err := cmd.Flags().GetString("acpi-blobs")
 		if err != nil {
 			return err
 		}
-		digest, err = rtmr.CalcRtmr0(firmware, gpuModel, legacySerial)
+		digest, err = rtmr.CalcRtmr0(firmware, gpuModel, acpiBlobsDir)
 		if err != nil {
 			return fmt.Errorf("can't calculate RTMR 0: %w", err)
 		}

--- a/tools/tdx-measure/rtmr/rtmr.go
+++ b/tools/tdx-measure/rtmr/rtmr.go
@@ -11,10 +11,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 	"unicode/utf16"
 
+	"github.com/edgelesssys/contrast/tdx-measure/internal/acpi"
 	"github.com/edgelesssys/contrast/tdx-measure/tdvf"
 	"github.com/foxboron/go-uefi/authenticode"
 )
@@ -116,11 +116,10 @@ var (
 	}
 )
 
-// CalcRtmr0 calculates RTMR[0] for the given firmware. If legacySerial is true,
-// the hardcoded ACPI hashes for a VM launched with -serial chardev:... are
-// used instead of the ones for a VM with virtio-serial-pci; the two topologies
-// produce different ACPI tables.
-func CalcRtmr0(firmware []byte, gpu GPUModel, legacySerial bool) ([48]byte, error) {
+// CalcRtmr0 calculates RTMR[0] for the given firmware.
+//
+// acpiBlobsDir must match the non-GPU VM topology. GPU VMs ignore it.
+func CalcRtmr0(firmware []byte, gpu GPUModel, acpiBlobsDir string) ([48]byte, error) {
 	var rtmr Rtmr
 
 	// We don't measure the Hobs, the firmware verifies them instead.
@@ -148,55 +147,17 @@ func CalcRtmr0(firmware []byte, gpu GPUModel, legacySerial bool) ([48]byte, erro
 
 	rtmr.extendSeparator()
 
-	// TODO(freax13): Don't hard-code these, calculate them instead.
-	//
-	// TODO(sespiros): the obvious approach of invoking qemu in the Nix
-	// build and hashing etc/acpi/* via fw_cfg does not work in a pure
-	// build sandbox (tdx-guest needs KVM, vhost-vsock-pci needs
-	// /dev/vhost-vsock). Refresh the digests by hand from inside any
-	// pod running on the set you want to capture. OVMF writes a TCG
-	// CC event log as it extends the RTMRs, and Linux exposes the
-	// raw log at /sys/firmware/acpi/tables/data/CCEL. Each ACPI DATA
-	// event's 48-byte SHA-384 digest sits 52 bytes before the marker
-	// (TCG_PCR_EVENT2: digest[48] + eventSize[4]):
-	//
-	//   kubectl exec -i -n <ns> <pod> -c contrast-debug-shell -- \
-	//       debugshell '
-	//     F=/sys/firmware/acpi/tables/data/CCEL
-	//     for off in $(grep -aob "ACPI DATA" "$F" | cut -d: -f1); do
-	//       dd if="$F" bs=1 skip=$((off-52)) count=48 status=none \
-	//         | od -An -v -tx1 | tr -d ' \n'; echo
-	//     done'
-	//
-	// Prints three digests in OVMF's measurement order; paste them
-	// into the matching hash set below.
-	acpiHashes := []string{
-		// Default (virtio-serial-pci + virtconsole) topology.
-		"a98ebc08f45482c21c329b93a51b926a299c4c366d4e79d6ba586e4a8c92a66e9d593b176ffdf32476f0dd81bb68f95b",
-		"6cd5eb8fa5c659b3ac4172a1c678aa1bba3118e107dcc5cdea0deec83b50e152703822396ef3422fd020bbf0ffdc3491",
-		"764a603f33825a43eff061cf6154516d8304eb420a08c06b7e3d7a956932b82efa591701b1854a1fb75a8deb54b2aefc",
-	}
-	legacySerialAcpiHashes := []string{
-		// Legacy-serial topology, used when kata sets use_legacy_serial=true
-		// (debug set) so OVMF's DEBUG_ON_SERIAL_PORT output reaches the host.
-		"1714c92f524640a6763417944c2c0e59b81b8560c94e8f8cb3e0b30c895c2eb90b6fd380dce3e4b89b8356766c7eacee",
-		"0d00216b9fcdff6a6dfb7bb92b8ccf35b6804d5d195f2b9dd34fbecd0585433cf567a520f3cefb45a792469f859430b2",
-		"05e27a7651b031e69216a487d39aba403766b546bba04b2bebfdc5bc160275a75249cfe147a753b799b5023a17124da4",
-	}
-	var configHashes []string
 	if gpu == GPUModelNone {
-		if legacySerial {
-			configHashes = slices.Concat(legacySerialAcpiHashes)
-		} else {
-			configHashes = slices.Concat(acpiHashes)
+		if acpiBlobsDir == "" {
+			return [48]byte{}, fmt.Errorf("no ACPI blobs directory given; --acpi-blobs is required to measure the ACPI tables")
 		}
-	}
-	for _, hash := range configHashes {
-		var buffer [48]byte
-		if _, err := hex.Decode(buffer[:], []byte(hash)); err != nil {
-			return [48]byte{}, fmt.Errorf("can't decode config hash %s: %w", hash, err)
+		digests, err := acpi.OVMFDataDigests(acpiBlobsDir)
+		if err != nil {
+			return [48]byte{}, fmt.Errorf("can't derive ACPI data digests: %w", err)
 		}
-		rtmr.Extend(buffer)
+		for _, digest := range digests {
+			rtmr.Extend(digest)
+		}
 	}
 
 	return rtmr.Get(), nil


### PR DESCRIPTION
  ## Summary

  Replace the hard-coded RTMR[0] ACPI digests with digests derived from QEMU's measured `fw_cfg` blobs.

  - add qtest and `fw_cfg` access to `tdx-measure`
  - dump QEMU's measured ACPI blobs during the Nix build
  - mirror Kata's normal and legacy-serial device topologies
  - calculate the ACPI extensions from the dumped blobs
  - verify both topologies against the existing reference digests

  The vCPU count remains fixed at one. Parameterization will be handled separately.

  ## Testing

  - `just lint`
  - `go test ./tools/tdx-measure/...`
  - `nix build -L --system x86_64-linux .#base.kata.qemu-acpi-blobs.tests.regression --no-link`
  - two-vCPU TDX `TestMultipleCPUs` E2E on the follow-up spike
  
  CON-131