### PR TITLE
cli: don't add wildcard SAN

### DIFF
--- a/cli/cmd/policies.go
+++ b/cli/cmd/policies.go
@@ -157,7 +157,7 @@ type deployment struct {
 }
 
 func (d deployment) DNSNames() []string {
-	return []string{d.name, "*"}
+	return []string{d.name}
 }
 
 func orDefault(s, d string) string {

--- a/docs/docs/architecture/components/manifest.md
+++ b/docs/docs/architecture/components/manifest.md
@@ -56,9 +56,7 @@ Allowed values are:
 - URIs
 - DNS names
 
-By default, the Contrast CLI will add two SANs for each workload on generate: The pod name as DNS name under which the pod can be reached inside the cluster,
-and a wildcard DNS name `*` to allow the certificate to be used with any other hostname (for example an external load balancer).
-As DNS is untrusted in the context of Contrast, issuing a wildcard certificate won't weaken the security of your workload.
+The Contrast CLI adds the workload resource name (for example, the `Deployment` name) to the manifest as a DNS SAN.
 In addition, the Coordinator will add the pod IP address to the certificate.
 
 If the pod is exposed via a different IP than the pod IP, for example a load balancer, and you want to include that IP in the certificate for verification,
@@ -70,9 +68,8 @@ The change could look like this:
      ...
      "99dd77cbd7fe2c4e1f29511014c14054a21a376f7d58a48d50e9e036f4522f6b": {
        "SANs": [
-         "web",
--        "*"
-+        "*",
+-        "web"
++        "web",
 +        "203.0.113.34"
        ],
      },
@@ -87,9 +84,8 @@ The change to add such an URI SAN to the manifest could look like this:
      ...
      "99dd77cbd7fe2c4e1f29511014c14054a21a376f7d58a48d50e9e036f4522f6b": {
        "SANs": [
-         "web",
--        "*"
-+        "*",
+-        "web"
++        "web",
 +        "spiffe://acme.com/billing/payments"
        ],
      },

--- a/docs/docs/getting-started/deployment.md
+++ b/docs/docs/getting-started/deployment.md
@@ -558,9 +558,8 @@ Add the `frontendIP` to the list of SANs:
      ...
      "99dd77cbd7fe2c4e1f29511014c14054a21a376f7d58a48d50e9e036f4522f6b": {
        "SANs": [
-         "web",
--        "*"
-+        "*",
+-        "web"
++        "web",
 +        "203.0.113.34"
        ],
      },

--- a/docs/docs/howto/workload-deployment/workload-communication.md
+++ b/docs/docs/howto/workload-deployment/workload-communication.md
@@ -34,7 +34,7 @@ openssl s_client -CAfile verify/mesh-ca.pem -verify_return_error -connect ${fron
 
 :::info[Subject alternative names and LoadBalancer IP]
 
-By default, mesh certificates are issued with a wildcard DNS entry.
+By default, mesh certificates are issued with a SAN for their workload resource name.
 Here, the service is accessed via its LoadBalancer IP address.
 Tools like curl check the certificate for IP entries in the subject alternative name (SAN) field, which aren't present.
 For example, attempting to connect with curl and the mesh CA certificate will throw the following error:

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -21,7 +21,7 @@ func newTestManifestSNP() *Manifest {
 		Policies: map[HexString]PolicyEntry{
 			HexString("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"): {
 				Role:             "coordinator",
-				SANs:             []string{"example.com", "*"},
+				SANs:             []string{"example.com"},
 				WorkloadSecretID: "foo",
 			},
 		},


### PR DESCRIPTION
The plain wildcard SAN `*` can't be used with the majority of TLS implementations, which makes it ineffective for use outside the cluster where standard implementations (in particular, browsers) are usually used. Inside the cluster, where more permissive TLS libraries may be in use, its presence does more harm than good, considering that workloads may impersonate each other. Thus, don't add a plain `*` as SAN anymore.

Fixes CON-222.