### PR TITLE
apitypes: move the v1 wire types into a subpackage

### DIFF
--- a/apitypes/apitypes.go
+++ b/apitypes/apitypes.go
@@ -3,7 +3,9 @@
 
 // Package apitypes contains the wire-format types of the Contrast HTTP API.
 //
-// The types here define the request/response bodies exchanged with the Coordinator.
+// This package holds only what is independent of the API version.
+// Everything that belongs to a specific version lives in a subpackage named after it, e.g.
+// [github.com/edgelesssys/contrast/apitypes/apiv1] for the /v1/ endpoints.
 package apitypes
 
 // Port is the listening port of the HTTP API server.

--- a/apitypes/apitypes_test.go
+++ b/apitypes/apitypes_test.go
@@ -4,22 +4,41 @@
 package apitypes
 
 import (
+	"errors"
 	"go/build"
+	"io/fs"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestNoExternalImports asserts that apitypes depends on the standard library only.
-func TestNoExternalImports(t *testing.T) {
-	// Mode 0 only scans the directory for import statements, it does not resolve them.
-	pkg, err := build.ImportDir(".", 0)
-	require.NoError(t, err)
+// selfImportPath is the import path prefix shared by apitypes and its subpackages.
+const selfImportPath = "github.com/edgelesssys/contrast/apitypes"
 
-	for _, imp := range pkg.Imports {
-		// Standard library import paths have no dot in their first segment, because that segment cannot be a domain name.
-		first, _, _ := strings.Cut(imp, "/")
-		require.NotContains(t, first, ".", "apitypes must not import %q", imp)
-	}
+// TestNoExternalImports asserts that apitypes and its subpackages depend on the standard library and each other only.
+func TestNoExternalImports(t *testing.T) {
+	require.NoError(t, filepath.WalkDir(".", func(dir string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return err
+		}
+		// Mode 0 only scans the directory for import statements, it does not resolve them.
+		pkg, err := build.ImportDir(dir, 0)
+		var noGo *build.NoGoError
+		if errors.As(err, &noGo) {
+			return nil
+		}
+		require.NoError(t, err)
+
+		for _, imp := range pkg.Imports {
+			if imp == selfImportPath || strings.HasPrefix(imp, selfImportPath+"/") {
+				continue
+			}
+			// Standard library import paths have no dot in their first segment, because that segment cannot be a domain name.
+			first, _, _ := strings.Cut(imp, "/")
+			require.NotContains(t, first, ".", "package %q must not import %q", dir, imp)
+		}
+		return nil
+	}))
 }

--- a/apitypes/apiv1/apiv1.go
+++ b/apitypes/apiv1/apiv1.go
@@ -1,0 +1,7 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package apiv1 contains the wire-format types of version 1 of the Contrast HTTP API.
+//
+// The client for this version lives in [github.com/edgelesssys/contrast/sdk/apiv1].
+package apiv1

--- a/apitypes/apiv1/attest.go
+++ b/apitypes/apiv1/attest.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Edgeless Systems GmbH
 // SPDX-License-Identifier: BUSL-1.1
 
-package apitypes
+package apiv1
 
 import (
 	"bytes"
@@ -9,6 +9,8 @@ import (
 	"encoding/asn1"
 	"encoding/json"
 	"fmt"
+
+	"github.com/edgelesssys/contrast/apitypes"
 )
 
 // ReportDataSize is the size of the SNP/TDX REPORTDATA fields.
@@ -22,8 +24,8 @@ type AttestationRequest struct {
 
 // AttestationError is returned by the /attest endpoint if the request was not successful.
 //
-// It is an alias of [APIError], which all Contrast HTTP API endpoints return on error.
-type AttestationError = APIError
+// It is an alias of [apitypes.APIError], which all Contrast HTTP API endpoints return on error.
+type AttestationError = apitypes.APIError
 
 // AttestationResponse contains all fields required for application-level verification.
 type AttestationResponse struct {

--- a/apitypes/apiv1/attest_test.go
+++ b/apitypes/apiv1/attest_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Edgeless Systems GmbH
 // SPDX-License-Identifier: BUSL-1.1
 
-package apitypes
+package apiv1
 
 import (
 	"encoding/json"

--- a/apitypes/apiv1/reportdata_test.go
+++ b/apitypes/apiv1/reportdata_test.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Edgeless Systems GmbH
 // SPDX-License-Identifier: BUSL-1.1
 
-package apitypes
+package apiv1
 
 import (
 	"encoding/hex"

--- a/coordinator/internal/httpapi/attest.go
+++ b/coordinator/internal/httpapi/attest.go
@@ -13,7 +13,7 @@ import (
 	"mime"
 	"net/http"
 
-	"github.com/edgelesssys/contrast/apitypes"
+	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 	"github.com/edgelesssys/contrast/coordinator/internal/userapi"
 	"github.com/edgelesssys/contrast/internal/atls"
@@ -41,7 +41,7 @@ type AttestationHandler struct {
 	StateGuard StateGuard
 }
 
-func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*apitypes.AttestationResponse, int, error) {
+func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*apitypesv1.AttestationResponse, int, error) {
 	// state knows the latest transition
 	state, err := h.StateGuard.GetState(ctx)
 	switch {
@@ -59,7 +59,7 @@ func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*ap
 	}
 
 	ca := state.CA()
-	coordinatorState := &apitypes.CoordinatorState{
+	coordinatorState := &apitypesv1.CoordinatorState{
 		Manifests: manifests,
 		RootCA:    ca.GetRootCACert(),
 		MeshCA:    ca.GetMeshCACert(),
@@ -69,13 +69,13 @@ func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*ap
 	}
 
 	transitionHash := state.LatestTransition().TransitionHash
-	reportData := apitypes.ConstructReportData(nonce, transitionHash[:], coordinatorState)
+	reportData := apitypesv1.ConstructReportData(nonce, transitionHash[:], coordinatorState)
 	attestation, err := h.Issuer.Issue(ctx, reportData)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("%w: %w", errGettingAttestation, err)
 	}
 
-	resp := &apitypes.AttestationResponse{
+	resp := &apitypesv1.AttestationResponse{
 		Version:           constants.Version,
 		AttestationType:   h.Issuer.OID(),
 		RawAttestationDoc: attestation,
@@ -116,7 +116,7 @@ func (h *AttestationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req apitypes.AttestationRequest
+	var req apitypesv1.AttestationRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, err)
 		return
@@ -148,7 +148,7 @@ func writeJSONError(w http.ResponseWriter, status int, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
-	apiErr := &apitypes.AttestationError{
+	apiErr := &apitypesv1.AttestationError{
 		Version:    constants.Version,
 		StatusCode: status,
 		Code:       errorCode(err, status),

--- a/coordinator/internal/httpapi/attest_test.go
+++ b/coordinator/internal/httpapi/attest_test.go
@@ -14,7 +14,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/edgelesssys/contrast/apitypes"
+	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
 	"github.com/edgelesssys/contrast/coordinator/internal/userapi"
 	"github.com/edgelesssys/contrast/internal/atls"
@@ -30,7 +30,7 @@ var nonce = make([]byte, 32)
 
 func TestAttestationHandler(t *testing.T) {
 	testCases := map[string]struct {
-		request *apitypes.AttestationRequest
+		request *apitypesv1.AttestationRequest
 		method  string
 
 		malformedBody   bool
@@ -44,7 +44,7 @@ func TestAttestationHandler(t *testing.T) {
 		expErr    error
 	}{
 		"invalid nonce length": {
-			request:   &apitypes.AttestationRequest{Nonce: []byte{1, 2, 3}},
+			request:   &apitypesv1.AttestationRequest{Nonce: []byte{1, 2, 3}},
 			expStatus: http.StatusBadRequest,
 			expErr:    errNonceLength,
 		},
@@ -53,7 +53,7 @@ func TestAttestationHandler(t *testing.T) {
 			expStatus: http.StatusMethodNotAllowed,
 		},
 		"no body": {
-			request:   &apitypes.AttestationRequest{},
+			request:   &apitypesv1.AttestationRequest{},
 			expStatus: http.StatusBadRequest,
 			expErr:    errNonceLength,
 		},
@@ -67,48 +67,48 @@ func TestAttestationHandler(t *testing.T) {
 			expErr:        errNonceLength,
 		},
 		"no Content-Type": {
-			request:         &apitypes.AttestationRequest{Nonce: nonce},
+			request:         &apitypesv1.AttestationRequest{Nonce: nonce},
 			skipContentType: true,
 			expStatus:       http.StatusBadRequest,
 		},
 		"wrong Content-Type": {
-			request:     &apitypes.AttestationRequest{Nonce: nonce},
+			request:     &apitypesv1.AttestationRequest{Nonce: nonce},
 			contentType: "text/html",
 			expStatus:   http.StatusUnsupportedMediaType,
 			expErr:      errContentType,
 		},
 		"no state": {
-			request:   &apitypes.AttestationRequest{Nonce: nonce},
+			request:   &apitypesv1.AttestationRequest{Nonce: nonce},
 			guard:     &stubGuard{getStateErr: stateguard.ErrNoState},
 			expStatus: http.StatusPreconditionFailed,
 			expErr:    userapi.ErrNoManifest,
 		},
 		"stale state": {
-			request:   &apitypes.AttestationRequest{Nonce: nonce},
+			request:   &apitypesv1.AttestationRequest{Nonce: nonce},
 			guard:     &stubGuard{getStateErr: stateguard.ErrStaleState},
 			expStatus: http.StatusPreconditionFailed,
 			expErr:    userapi.ErrNeedsRecovery,
 		},
 		"unknown error during GetState": {
-			request:   &apitypes.AttestationRequest{Nonce: nonce},
+			request:   &apitypesv1.AttestationRequest{Nonce: nonce},
 			guard:     &stubGuard{getStateErr: assert.AnError},
 			expStatus: http.StatusInternalServerError,
 			expErr:    errGettingState,
 		},
 		"unknown error during GetHistory": {
-			request:   &apitypes.AttestationRequest{Nonce: nonce},
+			request:   &apitypesv1.AttestationRequest{Nonce: nonce},
 			guard:     &stubGuard{getHistoryErr: assert.AnError},
 			expStatus: http.StatusInternalServerError,
 			expErr:    errGettingHistory,
 		},
 		"unable to get attestation": {
-			request:   &apitypes.AttestationRequest{Nonce: nonce},
+			request:   &apitypesv1.AttestationRequest{Nonce: nonce},
 			issuer:    &stubIssuer{issueErr: assert.AnError},
 			expStatus: http.StatusInternalServerError,
 			expErr:    errGettingAttestation,
 		},
 		"success": {
-			request:   &apitypes.AttestationRequest{Nonce: nonce},
+			request:   &apitypesv1.AttestationRequest{Nonce: nonce},
 			expStatus: http.StatusOK,
 		},
 	}
@@ -166,12 +166,12 @@ func TestAttestationHandler(t *testing.T) {
 			require.Equal(tc.expStatus, res.StatusCode)
 
 			if tc.expErr != nil {
-				var apiErr apitypes.AttestationError
+				var apiErr apitypesv1.AttestationError
 				require.NoError(json.NewDecoder(res.Body).Decode(&apiErr))
 				require.Contains(apiErr.Err, tc.expErr.Error())
 				require.Equal(tc.expStatus, apiErr.StatusCode)
 			} else if res.StatusCode == http.StatusOK {
-				var resp apitypes.AttestationResponse
+				var resp apitypesv1.AttestationResponse
 				require.NoError(json.NewDecoder(res.Body).Decode(&resp))
 				require.Equal(constants.Version, resp.Version)
 				require.Equal(expectedOID, resp.AttestationType)

--- a/e2e/coordinator/coordinator_test.go
+++ b/e2e/coordinator/coordinator_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/edgelesssys/contrast/apitypes"
+	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/edgelesssys/contrast/e2e/internal/contrasttest"
 	"github.com/edgelesssys/contrast/e2e/internal/kubeclient"
 	"github.com/edgelesssys/contrast/internal/kuberesource"
@@ -217,7 +218,7 @@ func TestCoordinator(t *testing.T) {
 		require.Equal(manifestBytesExpected, state.Manifests[0])
 
 		// Test backwards compatibility of AttestationType.
-		var resp apitypes.AttestationResponse
+		var resp apitypesv1.AttestationResponse
 		require.NoError(json.NewDecoder(bytes.NewReader(report)).Decode(&resp))
 		resp.AttestationType = nil
 		reportWithoutType, err := json.Marshal(resp)

--- a/sdk/internal/httpapi/httpapi_test.go
+++ b/sdk/internal/httpapi/httpapi_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/contrast/apitypes"
+	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -167,11 +168,11 @@ func TestDoJSONSendsBody(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	c := &Client{HTTPClient: srv.Client(), BaseURL: srv.URL, Log: slog.New(slog.DiscardHandler)}
-	resp, err := c.DoJSON(t.Context(), http.MethodPost, "/attest", &apitypes.AttestationRequest{Nonce: []byte("nonce")})
+	resp, err := c.DoJSON(t.Context(), http.MethodPost, "/attest", &apitypesv1.AttestationRequest{Nonce: []byte("nonce")})
 	require.NoError(err)
 
 	assert.Equal("application/json", gotContentType)
-	var req apitypes.AttestationRequest
+	var req apitypesv1.AttestationRequest
 	require.NoError(json.Unmarshal(gotBody, &req))
 	assert.Equal([]byte("nonce"), req.Nonce)
 	assert.JSONEq(`{"api_versions":["v1"]}`, string(resp))

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -12,7 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/edgelesssys/contrast/apitypes"
+	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
@@ -33,7 +33,7 @@ func (c *Client) GetAttestation(ctx context.Context, nonce []byte) ([]byte, erro
 	if len(nonce) != cryptohelpers.RNGLengthDefault {
 		return nil, fmt.Errorf("bad nonce length: got %d, want %d", len(nonce), cryptohelpers.RNGLengthDefault)
 	}
-	return c.httpapi.DoJSON(ctx, http.MethodPost, attestPath, &apitypes.AttestationRequest{Nonce: nonce})
+	return c.httpapi.DoJSON(ctx, http.MethodPost, attestPath, &apitypesv1.AttestationRequest{Nonce: nonce})
 }
 
 // ValidateAttestation validates the Coordinator state returned by the http://coordinator:1314/attest endpoint.
@@ -52,7 +52,7 @@ func (c *Client) ValidateAttestation(ctx context.Context, nonce []byte, attestat
 		return nil, fmt.Errorf("wrong nonce length: got %d, want %d", len(nonce), cryptohelpers.RNGLengthDefault)
 	}
 
-	resp, err := apitypes.UnmarshalAttestationResponse(attestation)
+	resp, err := apitypesv1.UnmarshalAttestationResponse(attestation)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling attestation document: %w", err)
 	}
@@ -82,7 +82,7 @@ func (c *Client) ValidateAttestation(ctx context.Context, nonce []byte, attestat
 
 	transitions := history.BuildTransitionChain(resp.Manifests)
 	transitionDigest := transitions[len(transitions)-1].Digest()
-	reportData := apitypes.ConstructReportData(nonce, transitionDigest[:], &resp.CoordinatorState)
+	reportData := apitypesv1.ConstructReportData(nonce, transitionDigest[:], &resp.CoordinatorState)
 
 	if err := validator.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -14,7 +14,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/edgelesssys/contrast/apitypes"
+	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
@@ -30,12 +30,12 @@ func attestationHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	var req apitypes.AttestationRequest
+	var req apitypesv1.AttestationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	resp := &apitypes.AttestationResponse{
+	resp := &apitypesv1.AttestationResponse{
 		Version: constants.Version,
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -110,26 +110,26 @@ func TestValidateAttestation(t *testing.T) {
 	testOID := asn1.ObjectIdentifier{1, 2, 3}
 	for name, tc := range map[string]struct {
 		nonce       []byte
-		resp        *apitypes.AttestationResponse
+		resp        *apitypesv1.AttestationResponse
 		validateErr error
 		wantErr     string
 	}{
 		"success": {
 			nonce: testNonce,
-			resp: &apitypes.AttestationResponse{
+			resp: &apitypesv1.AttestationResponse{
 				AttestationType:   testOID,
 				RawAttestationDoc: testNonce,
-				CoordinatorState: apitypes.CoordinatorState{
+				CoordinatorState: apitypesv1.CoordinatorState{
 					Manifests: [][]byte{testManifest},
 				},
 			},
 		},
 		"no manifests": {
 			nonce: testNonce,
-			resp: &apitypes.AttestationResponse{
+			resp: &apitypesv1.AttestationResponse{
 				AttestationType:   testOID,
 				RawAttestationDoc: testNonce,
-				CoordinatorState:  apitypes.CoordinatorState{},
+				CoordinatorState:  apitypesv1.CoordinatorState{},
 			},
 			wantErr: "coordinator state does not include manifests",
 		},
@@ -138,10 +138,10 @@ func TestValidateAttestation(t *testing.T) {
 		},
 		"failed validation": {
 			nonce: testNonce,
-			resp: &apitypes.AttestationResponse{
+			resp: &apitypesv1.AttestationResponse{
 				AttestationType:   testOID,
 				RawAttestationDoc: testNonce,
-				CoordinatorState: apitypes.CoordinatorState{
+				CoordinatorState: apitypesv1.CoordinatorState{
 					Manifests: [][]byte{testManifest},
 				},
 			},


### PR DESCRIPTION
previous discussion: #2603

...and this is the last one of the loop doc PRs. 
