### PR TITLE
httpapi: prevent downgrade attacks

### DIFF
--- a/apitypes/apiv1/attest.go
+++ b/apitypes/apiv1/attest.go
@@ -95,8 +95,11 @@ type CoordinatorState struct {
 
 // ConstructReportData constructs an extended report data digest,
 // intended for use with application-level verification.
-func ConstructReportData(nonce []byte, transitionDigest []byte, state *CoordinatorState) [ReportDataSize]byte {
-	// reportdata = sha256(nonce || sha256(transition) || sha256(root-ca) || sha256(mesh-ca))
+//
+// capabilitiesDigest is the SHA-256 digest of the raw /capabilities response body.
+// Binding it into the report data lets clients detect tampering with the unauthenticated capabilities endpoint.
+func ConstructReportData(nonce []byte, transitionDigest []byte, capabilitiesDigest []byte, state *CoordinatorState) [ReportDataSize]byte {
+	// reportdata = sha256(nonce || sha256(transition) || sha256(root-ca) || sha256(mesh-ca) || sha256(capabilities))
 	rootCADigest := sha256.Sum256(state.RootCA)
 	meshCADigest := sha256.Sum256(state.MeshCA)
 
@@ -104,6 +107,7 @@ func ConstructReportData(nonce []byte, transitionDigest []byte, state *Coordinat
 	reportdata = append(reportdata, transitionDigest...)
 	reportdata = append(reportdata, rootCADigest[:]...)
 	reportdata = append(reportdata, meshCADigest[:]...)
+	reportdata = append(reportdata, capabilitiesDigest...)
 	hash32 := sha256.Sum256(reportdata)
 
 	var hash64 [64]byte

--- a/apitypes/apiv1/reportdata_test.go
+++ b/apitypes/apiv1/reportdata_test.go
@@ -15,6 +15,9 @@ import (
 // The digest is baked into attestation reports and reproduced independently by every client,
 // so any change here silently breaks verification against already-deployed Coordinators.
 // If this test fails, the change needs a new API version, not a new test value.
+//
+// The nil capabilitiesDigest case pins the layout of the legacy unversioned /attest endpoint,
+// which predates the capabilities binding and must never change.
 func TestConstructReportDataGolden(t *testing.T) {
 	nonce := make([]byte, 32)
 	for i := range nonce {
@@ -24,14 +27,32 @@ func TestConstructReportDataGolden(t *testing.T) {
 	for i := range transitionDigest {
 		transitionDigest[i] = byte(0xa0 + i)
 	}
+	capabilitiesDigest := make([]byte, 32)
+	for i := range capabilitiesDigest {
+		capabilitiesDigest[i] = byte(0xc0 + i)
+	}
 	state := &CoordinatorState{
 		RootCA: []byte("root-ca"),
 		MeshCA: []byte("mesh-ca"),
 	}
 
-	got := ConstructReportData(nonce, transitionDigest, state)
-
-	want := "ec25193fbfa21fb46964de80adca8e7d70222ad41e67c77a696e2f188c02a0f2" +
-		"0000000000000000000000000000000000000000000000000000000000000000"
-	assert.Equal(t, want, hex.EncodeToString(got[:]))
+	for name, tc := range map[string]struct {
+		capabilitiesDigest []byte
+		want               string
+	}{
+		"legacy, without capabilities digest": {
+			want: "ec25193fbfa21fb46964de80adca8e7d70222ad41e67c77a696e2f188c02a0f2" +
+				"0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		"v1, with capabilities digest": {
+			capabilitiesDigest: capabilitiesDigest,
+			want: "8e8d9ec21a9617767c4adb715f712fe246f121211fc76338f0c30824050bbb8e" +
+				"0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := ConstructReportData(nonce, transitionDigest, tc.capabilitiesDigest, state)
+			assert.Equal(t, tc.want, hex.EncodeToString(got[:]))
+		})
+	}
 }

--- a/apitypes/error.go
+++ b/apitypes/error.go
@@ -83,6 +83,12 @@ const (
 	// HTTP 412.
 	ErrorCodeManifestConflict ErrorCode = "manifest_conflict"
 
+	// ErrorCodeAPIVersionTooOld means the deployment's manifest pins a minimum API version,
+	// and the request used an older version or an unversioned legacy endpoint.
+	// Retrying the identical request will fail again. Retry against a newer API version.
+	// HTTP 403.
+	ErrorCodeAPIVersionTooOld ErrorCode = "api_version_too_old"
+
 	// ErrorCodeInternal means the Coordinator failed for a reason that is not the caller's fault.
 	// Retrying is reasonable.
 	// HTTP 5xx.

--- a/apitypes/version.go
+++ b/apitypes/version.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package apitypes
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseAPIVersion parses an API version identifier like "v1" into its numeric version.
+func ParseAPIVersion(version string) (int, error) {
+	digits, ok := strings.CutPrefix(version, "v")
+	if !ok || digits == "" || digits[0] == '0' || strings.TrimLeft(digits, "0123456789") != "" {
+		return 0, fmt.Errorf("API version %q: expected \"v\" followed by a positive integer", version)
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, fmt.Errorf("API version %q: %w", version, err)
+	}
+	return n, nil
+}

--- a/apitypes/version_test.go
+++ b/apitypes/version_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package apitypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPIVersion(t *testing.T) {
+	for version, want := range map[string]int{
+		"v1":  1,
+		"v2":  2,
+		"v10": 10,
+	} {
+		t.Run(version, func(t *testing.T) {
+			got, err := ParseAPIVersion(version)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+
+	for _, version := range []string{"", "1", "v", "v0", "v01", "V1", "v-1", "v+1", "v1.2", "v1x", "vv1"} {
+		t.Run("invalid_"+version, func(t *testing.T) {
+			_, err := ParseAPIVersion(version)
+			require.Error(t, err)
+		})
+	}
+}

--- a/coordinator/internal/httpapi/attest.go
+++ b/coordinator/internal/httpapi/attest.go
@@ -37,8 +37,9 @@ type StateGuard interface {
 
 // AttestationHandler handles POST requests to /attest.
 type AttestationHandler struct {
-	Issuer     atls.Issuer
-	StateGuard StateGuard
+	Issuer             atls.Issuer
+	StateGuard         StateGuard
+	CapabilitiesDigest []byte
 }
 
 func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*apitypesv1.AttestationResponse, int, error) {
@@ -69,7 +70,7 @@ func (h *AttestationHandler) getResponse(ctx context.Context, nonce []byte) (*ap
 	}
 
 	transitionHash := state.LatestTransition().TransitionHash
-	reportData := apitypesv1.ConstructReportData(nonce, transitionHash[:], coordinatorState)
+	reportData := apitypesv1.ConstructReportData(nonce, transitionHash[:], h.CapabilitiesDigest, coordinatorState)
 	attestation, err := h.Issuer.Issue(ctx, reportData)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("%w: %w", errGettingAttestation, err)

--- a/coordinator/internal/httpapi/attest_test.go
+++ b/coordinator/internal/httpapi/attest_test.go
@@ -227,9 +227,10 @@ func (s *stubIssuer) Issue(_ context.Context, reportData [64]byte) (quote []byte
 }
 
 type stubGuard struct {
-	ca            *ca.CA
-	getStateErr   error
-	getHistoryErr error
+	ca                *ca.CA
+	minimumAPIVersion string
+	getStateErr       error
+	getHistoryErr     error
 	stateguard.Guard
 }
 
@@ -237,7 +238,7 @@ func (s *stubGuard) GetState(context.Context) (*stateguard.State, error) {
 	if s.getStateErr != nil {
 		return nil, s.getStateErr
 	}
-	m := &manifest.Manifest{}
+	m := &manifest.Manifest{MinimumAPIVersion: s.minimumAPIVersion}
 	policyHash := sha256.Sum256(nil)
 	policyHashHex := manifest.NewHexString(policyHash[:])
 	m.Policies = map[manifest.HexString]manifest.PolicyEntry{

--- a/coordinator/internal/httpapi/attest_test.go
+++ b/coordinator/internal/httpapi/attest_test.go
@@ -181,9 +181,36 @@ func TestAttestationHandler(t *testing.T) {
 	}
 }
 
+func TestAttestationReportDataBindsCapabilities(t *testing.T) {
+	require := require.New(t)
+
+	meshKey := testkeys.New[ecdsa.PrivateKey](t, testkeys.ECDSAP384Keys[1])
+	rootKey := testkeys.New[ecdsa.PrivateKey](t, testkeys.ECDSAP384Keys[2])
+	ca, err := ca.New(rootKey, meshKey)
+	require.NoError(err)
+
+	capabilitiesDigest := NewCapabilitiesHandler().Digest()
+
+	reportDataFor := func(capabilitiesDigest []byte) [64]byte {
+		issuer := &stubIssuer{oid: asn1.ObjectIdentifier{1, 2, 3}}
+		handler := &AttestationHandler{
+			StateGuard:         &stubGuard{ca: ca},
+			Issuer:             issuer,
+			CapabilitiesDigest: capabilitiesDigest,
+		}
+		_, status, err := handler.getResponse(t.Context(), nonce)
+		require.NoError(err)
+		require.Equal(http.StatusOK, status)
+		return issuer.gotReportData
+	}
+
+	require.NotEqual(reportDataFor(nil), reportDataFor(capabilitiesDigest[:]))
+}
+
 type stubIssuer struct {
-	oid      asn1.ObjectIdentifier
-	issueErr error
+	oid           asn1.ObjectIdentifier
+	issueErr      error
+	gotReportData [64]byte
 	atls.Issuer
 }
 
@@ -191,10 +218,11 @@ func (s *stubIssuer) OID() asn1.ObjectIdentifier {
 	return s.oid
 }
 
-func (s *stubIssuer) Issue(_ context.Context, _ [64]byte) (quote []byte, err error) {
+func (s *stubIssuer) Issue(_ context.Context, reportData [64]byte) (quote []byte, err error) {
 	if s.issueErr != nil {
 		return nil, s.issueErr
 	}
+	s.gotReportData = reportData
 	return []byte("fake-attestation"), nil
 }
 

--- a/coordinator/internal/httpapi/capabilities.go
+++ b/coordinator/internal/httpapi/capabilities.go
@@ -4,8 +4,9 @@
 package httpapi
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
-	"log"
 	"net/http"
 
 	"github.com/edgelesssys/contrast/apitypes"
@@ -22,7 +23,26 @@ var supportedAPIVersions = []string{apitypes.APIVersionV1}
 //
 // This endpoint is deliberately NOT versioned, since it is used by clients to discover which versions exist.
 // The response body must only ever be extended.
-type CapabilitiesHandler struct{}
+type CapabilitiesHandler struct {
+	body []byte
+}
+
+// NewCapabilitiesHandler returns a [CapabilitiesHandler] advertising the supported API versions.
+func NewCapabilitiesHandler() *CapabilitiesHandler {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(apitypes.CapabilitiesResponse{APIVersions: supportedAPIVersions}); err != nil {
+		// The response is a fixed struct of strings; failing to encode it is a programming error.
+		panic(err)
+	}
+	return &CapabilitiesHandler{body: buf.Bytes()}
+}
+
+// Digest returns the SHA-256 digest of the exact response body this handler serves.
+func (h *CapabilitiesHandler) Digest() [32]byte {
+	return sha256.Sum256(h.body)
+}
 
 // ServeHTTP implements [http.Handler].
 func (h *CapabilitiesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -31,14 +51,6 @@ func (h *CapabilitiesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	resp := apitypes.CapabilitiesResponse{
-		APIVersions: supportedAPIVersions,
-	}
-
 	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(resp); err != nil {
-		log.Printf("encoding capabilities response: %v", err)
-	}
+	_, _ = w.Write(h.body)
 }

--- a/coordinator/internal/httpapi/capabilities_test.go
+++ b/coordinator/internal/httpapi/capabilities_test.go
@@ -4,7 +4,9 @@
 package httpapi
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +34,7 @@ func TestCapabilitiesHandler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			handler := &CapabilitiesHandler{}
+			handler := NewCapabilitiesHandler()
 
 			req := httptest.NewRequestWithContext(t.Context(), tc.method, "/capabilities", nil)
 			rec := httptest.NewRecorder()
@@ -51,4 +53,21 @@ func TestCapabilitiesHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCapabilitiesDigest ensures the digest bound into report data matches the served body.
+func TestCapabilitiesDigest(t *testing.T) {
+	require := require.New(t)
+
+	handler := NewCapabilitiesHandler()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/capabilities", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	res := rec.Result()
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(err)
+	require.Equal(sha256.Sum256(body), handler.Digest())
 }

--- a/coordinator/internal/httpapi/error.go
+++ b/coordinator/internal/httpapi/error.go
@@ -27,6 +27,8 @@ func errorCode(err error, statusCode int) apitypes.ErrorCode {
 		return apitypes.ErrorCodeManifestConflict
 	case errors.Is(err, userapi.ErrInvalidSignature):
 		return apitypes.ErrorCodeInvalidSignature
+	case errors.Is(err, errAPIVersionTooOld):
+		return apitypes.ErrorCodeAPIVersionTooOld
 	}
 
 	switch {

--- a/coordinator/internal/httpapi/versiongate.go
+++ b/coordinator/internal/httpapi/versiongate.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package httpapi
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/edgelesssys/contrast/apitypes"
+	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
+)
+
+// errAPIVersionTooOld rejects requests below the manifest's pinned minimum API version.
+var errAPIVersionTooOld = errors.New("API version rejected by the manifest")
+
+// APIVersionGate wraps an HTTP API endpoint and enforces the minimum API version optionally
+// pinned in the deployment's manifest.
+//
+// Clients enforce the pin on their side, but without the gate an attacker who can tamper with
+// client traffic could still talk to the Coordinator over an older API version.
+type APIVersionGate struct {
+	// Version is the API version of the wrapped endpoint. It is 0 for the legacy endpoints
+	// that predate API versioning, which sort below all versioned endpoints.
+	Version int
+	// StateGuard provides the manifest whose pin is enforced.
+	StateGuard StateGuard
+	// Next is the wrapped endpoint.
+	Next http.Handler
+}
+
+// ServeHTTP implements [http.Handler].
+func (g *APIVersionGate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	state, err := g.StateGuard.GetState(r.Context())
+	switch {
+	case errors.Is(err, stateguard.ErrNoState), errors.Is(err, stateguard.ErrStaleState):
+		// Without an unsealed manifest there is no pin to enforce. The initial SetManifest must pass while there is no manifest yet.
+		g.Next.ServeHTTP(w, r)
+		return
+	case err != nil:
+		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("%w: %w", errGettingState, err))
+		return
+	}
+
+	pin := state.Manifest().MinimumAPIVersion
+	if pin == "" {
+		g.Next.ServeHTTP(w, r)
+		return
+	}
+	minVersion, err := apitypes.ParseAPIVersion(pin)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("parsing the manifest's MinimumAPIVersion: %w", err))
+		return
+	}
+	if g.Version < minVersion {
+		requested := fmt.Sprintf("version v%d", g.Version)
+		if g.Version == 0 {
+			requested = "the unversioned legacy API"
+		}
+		writeJSONError(w, http.StatusForbidden,
+			fmt.Errorf("%w: the manifest requires at least API version %s, but the request used %s", errAPIVersionTooOld, pin, requested))
+		return
+	}
+	g.Next.ServeHTTP(w, r)
+}

--- a/coordinator/internal/httpapi/versiongate_test.go
+++ b/coordinator/internal/httpapi/versiongate_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Edgeless Systems GmbH
+// SPDX-License-Identifier: BUSL-1.1
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgelesssys/contrast/apitypes"
+	"github.com/edgelesssys/contrast/coordinator/internal/stateguard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIVersionGate(t *testing.T) {
+	testCases := map[string]struct {
+		endpointVersion int
+		guard           *stubGuard
+
+		expStatus int
+		expCode   apitypes.ErrorCode
+	}{
+		"no pin allows v1": {
+			endpointVersion: 1,
+			guard:           &stubGuard{},
+			expStatus:       http.StatusOK,
+		},
+		"no pin allows legacy": {
+			endpointVersion: 0,
+			guard:           &stubGuard{},
+			expStatus:       http.StatusOK,
+		},
+		"pin v1 allows v1": {
+			endpointVersion: 1,
+			guard:           &stubGuard{minimumAPIVersion: "v1"},
+			expStatus:       http.StatusOK,
+		},
+		"pin v1 rejects legacy": {
+			endpointVersion: 0,
+			guard:           &stubGuard{minimumAPIVersion: "v1"},
+			expStatus:       http.StatusForbidden,
+			expCode:         apitypes.ErrorCodeAPIVersionTooOld,
+		},
+		"pin v2 rejects v1": {
+			endpointVersion: 1,
+			guard:           &stubGuard{minimumAPIVersion: "v2"},
+			expStatus:       http.StatusForbidden,
+			expCode:         apitypes.ErrorCodeAPIVersionTooOld,
+		},
+		"no state passes through": {
+			endpointVersion: 0,
+			guard:           &stubGuard{getStateErr: stateguard.ErrNoState},
+			expStatus:       http.StatusOK,
+		},
+		"stale state passes through": {
+			endpointVersion: 0,
+			guard:           &stubGuard{getStateErr: stateguard.ErrStaleState},
+			expStatus:       http.StatusOK,
+		},
+		"unknown state error fails closed": {
+			endpointVersion: 1,
+			guard:           &stubGuard{getStateErr: assert.AnError},
+			expStatus:       http.StatusInternalServerError,
+			expCode:         apitypes.ErrorCodeInternal,
+		},
+		"unparseable pin fails closed": {
+			endpointVersion: 1,
+			guard:           &stubGuard{minimumAPIVersion: "not-a-version"},
+			expStatus:       http.StatusInternalServerError,
+			expCode:         apitypes.ErrorCodeInternal,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			gate := &APIVersionGate{
+				Version:    tc.endpointVersion,
+				StateGuard: tc.guard,
+				Next: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+			}
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/attest", nil)
+			rec := httptest.NewRecorder()
+
+			gate.ServeHTTP(rec, req)
+			res := rec.Result()
+			defer res.Body.Close()
+
+			require.Equal(tc.expStatus, res.StatusCode)
+
+			if tc.expCode != "" {
+				var apiErr apitypes.APIError
+				require.NoError(json.NewDecoder(res.Body).Decode(&apiErr))
+				require.Equal(tc.expCode, apiErr.Code)
+			}
+		})
+	}
+}

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -168,10 +168,10 @@ func run() (retErr error) {
 		capabilities := httpapi.NewCapabilitiesHandler()
 
 		mux := http.NewServeMux()
-		mux.Handle("/attest", &httpapi.AttestationHandler{
+		mux.Handle("/attest", &httpapi.APIVersionGate{Version: 0, StateGuard: meshAuth, Next: &httpapi.AttestationHandler{
 			Issuer:     issuer,
 			StateGuard: meshAuth,
-		})
+		}})
 		mux.Handle("/capabilities", capabilities)
 
 		httpAPIServer.Addr = ":" + apitypes.Port

--- a/coordinator/main.go
+++ b/coordinator/main.go
@@ -165,14 +165,14 @@ func run() (retErr error) {
 	eg, ctx := errgroup.WithContext(ctxSignal)
 
 	eg.Go(func() error {
-		h := httpapi.AttestationHandler{
-			Issuer:     issuer,
-			StateGuard: meshAuth,
-		}
+		capabilities := httpapi.NewCapabilitiesHandler()
 
 		mux := http.NewServeMux()
-		mux.Handle("/attest", &h)
-		mux.Handle("/capabilities", &httpapi.CapabilitiesHandler{})
+		mux.Handle("/attest", &httpapi.AttestationHandler{
+			Issuer:     issuer,
+			StateGuard: meshAuth,
+		})
+		mux.Handle("/capabilities", capabilities)
 
 		httpAPIServer.Addr = ":" + apitypes.Port
 		httpAPIServer.Handler = mux

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/edgelesssys/contrast/apitypes"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/idblock"
 	"github.com/edgelesssys/contrast/internal/platforms"
@@ -37,6 +38,8 @@ type Manifest struct {
 	WorkloadOwnerPubKeys []HexString
 	// SeedshareOwnerPubKeys is a list of RSA public keys in PKCS1 DER format, hex-encoded.
 	SeedshareOwnerPubKeys []HexString
+	// MinimumAPIVersion optionally pins the oldest Contrast HTTP API version, e.g. "v1".
+	MinimumAPIVersion string `json:",omitempty"`
 }
 
 // Default returns a default manifest with reference values for the given platform.
@@ -104,6 +107,12 @@ func (m *Manifest) Validate() error {
 	for i, key := range m.SeedshareOwnerPubKeys {
 		if _, err := ParseSeedShareOwnerKey(key); err != nil {
 			errs = append(errs, newValidationError(fmt.Sprintf("SeedshareOwnerPubKeys[%d]", i), err))
+		}
+	}
+
+	if m.MinimumAPIVersion != "" {
+		if _, err := apitypes.ParseAPIVersion(m.MinimumAPIVersion); err != nil {
+			errs = append(errs, newValidationError("MinimumAPIVersion", err))
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -129,6 +129,19 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"valid minimum API version": {
+			m: newTestManifestSNP(),
+			mutate: func(m *Manifest) {
+				m.MinimumAPIVersion = "v1"
+			},
+		},
+		"invalid minimum API version": {
+			m: newTestManifestSNP(),
+			mutate: func(m *Manifest) {
+				m.MinimumAPIVersion = "1"
+			},
+			wantErr: true,
+		},
 		"invalid workload owner key": {
 			m: newTestManifestSNP(),
 			mutate: func(m *Manifest) {

--- a/sdk/capabilities.go
+++ b/sdk/capabilities.go
@@ -7,6 +7,7 @@ package sdk
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,23 +36,46 @@ func (c *Client) NegotiateAPIVersion(ctx context.Context) (string, error) {
 		return c.negotiatedVersion, nil
 	}
 
+	caps, err := c.getCapabilitiesLocked(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for _, version := range supportedAPIVersions {
+		if !slices.Contains(caps.APIVersions, version) {
+			continue
+		}
+		c.negotiatedVersion = version
+		return version, nil
+	}
+	return "", fmt.Errorf("no common API version: Coordinator supports %v, SDK supports %v", caps.APIVersions, supportedAPIVersions)
+}
+
+// getCapabilitiesLocked fetches and parses the Coordinator's capabilities.
+func (c *Client) getCapabilitiesLocked(ctx context.Context) (*apitypes.CapabilitiesResponse, error) {
 	body, err := c.httpapi.DoJSON(ctx, http.MethodGet, capabilitiesPath, nil)
 	if err != nil {
-		return "", fmt.Errorf("getting capabilities: %w", err)
+		return nil, fmt.Errorf("getting capabilities: %w", err)
 	}
 	var caps apitypes.CapabilitiesResponse
 	if err := json.Unmarshal(body, &caps); err != nil {
-		return "", fmt.Errorf("unmarshalling capabilities: %w", err)
+		return nil, fmt.Errorf("unmarshalling capabilities: %w", err)
 	}
+	digest := sha256.Sum256(body)
+	c.capabilitiesDigest = digest[:]
+	return &caps, nil
+}
 
-	// supportedAPIVersions is ordered newest first, so the first match is the best one.
-	for _, version := range supportedAPIVersions {
-		if slices.Contains(caps.APIVersions, version) {
-			c.negotiatedVersion = version
-			return version, nil
+// getCapabilitiesDigest returns the SHA-256 digest of the raw capabilities response body.
+func (c *Client) getCapabilitiesDigest(ctx context.Context) ([]byte, error) {
+	c.negotiateMu.Lock()
+	defer c.negotiateMu.Unlock()
+	if c.capabilitiesDigest == nil {
+		if _, err := c.getCapabilitiesLocked(ctx); err != nil {
+			return nil, err
 		}
 	}
-	return "", fmt.Errorf("no common API version: Coordinator supports %v, SDK supports %v", caps.APIVersions, supportedAPIVersions)
+	return c.capabilitiesDigest, nil
 }
 
 // V1 returns a client for version v1 of the Coordinator's HTTP API.

--- a/sdk/capabilities.go
+++ b/sdk/capabilities.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 
 	"github.com/edgelesssys/contrast/apitypes"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/sdk/apiv1"
 )
 
@@ -28,11 +29,16 @@ var supportedAPIVersions = []string{apiv1.Version}
 
 // NegotiateAPIVersion returns the newest API version supported by both this SDK and the Coordinator.
 //
+// If the expected manifest pins a MinimumAPIVersion, negotiation fails rather than settle on an older version.
+//
 // The first successful result is cached, so this costs at most one successful request per [Client].
 func (c *Client) NegotiateAPIVersion(ctx context.Context) (string, error) {
 	c.negotiateMu.Lock()
 	defer c.negotiateMu.Unlock()
 	if c.negotiatedVersion != "" {
+		if err := enforceMinimumAPIVersion(c.negotiatedVersion, c.expectedManifest); err != nil {
+			return "", err
+		}
 		return c.negotiatedVersion, nil
 	}
 
@@ -44,6 +50,9 @@ func (c *Client) NegotiateAPIVersion(ctx context.Context) (string, error) {
 	for _, version := range supportedAPIVersions {
 		if !slices.Contains(caps.APIVersions, version) {
 			continue
+		}
+		if err := enforceMinimumAPIVersion(version, c.expectedManifest); err != nil {
+			return "", fmt.Errorf("refusing to negotiate: %w", err)
 		}
 		c.negotiatedVersion = version
 		return version, nil
@@ -76,6 +85,25 @@ func (c *Client) getCapabilitiesDigest(ctx context.Context) ([]byte, error) {
 		}
 	}
 	return c.capabilitiesDigest, nil
+}
+
+// enforceMinimumAPIVersion returns an error if version is older than the given manifest's optional MinimumAPIVersion pin.
+func enforceMinimumAPIVersion(version string, m *manifest.Manifest) error {
+	if m == nil || m.MinimumAPIVersion == "" {
+		return nil
+	}
+	minVersion, err := apitypes.ParseAPIVersion(m.MinimumAPIVersion)
+	if err != nil {
+		return fmt.Errorf("parsing the manifest's MinimumAPIVersion: %w", err)
+	}
+	v, err := apitypes.ParseAPIVersion(version)
+	if err != nil {
+		return fmt.Errorf("parsing API version %q: %w", version, err)
+	}
+	if v < minVersion {
+		return fmt.Errorf("API version %s is older than the minimum %s required by the manifest", version, m.MinimumAPIVersion)
+	}
+	return nil
 }
 
 // V1 returns a client for version v1 of the Coordinator's HTTP API.

--- a/sdk/capabilities_test.go
+++ b/sdk/capabilities_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/contrast/apitypes"
+	"github.com/edgelesssys/contrast/internal/manifest"
 	"github.com/edgelesssys/contrast/sdk/apiv1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,6 +136,55 @@ func TestWithAPIVersionSkipsNegotiation(t *testing.T) {
 	require.NoError(err)
 	require.Equal(apiv1.Version, version)
 	require.False(contacted.Load(), "Coordinator must not be contacted for a pinned API version")
+}
+
+func TestNegotiateAPIVersionManifestPin(t *testing.T) {
+	for name, tc := range map[string]struct {
+		minimumAPIVersion string
+		pinnedVersion     string
+
+		wantVersion string
+		wantErr     string
+	}{
+		"minimum matches the negotiated version": {
+			minimumAPIVersion: "v1",
+			wantVersion:       apiv1.Version,
+		},
+		"minimum above all common versions": {
+			minimumAPIVersion: "v2",
+			wantErr:           "older than the minimum",
+		},
+		"pinned version below the minimum": {
+			minimumAPIVersion: "v2",
+			pinnedVersion:     apiv1.Version,
+			wantErr:           "older than the minimum",
+		},
+		"pinned version meets the minimum": {
+			minimumAPIVersion: "v1",
+			pinnedVersion:     apiv1.Version,
+			wantVersion:       apiv1.Version,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			srv := httptest.NewServer(capabilitiesHandler([]string{apiv1.Version}))
+			t.Cleanup(srv.Close)
+
+			client := New(srv.URL).WithExpectedManifest(&manifest.Manifest{MinimumAPIVersion: tc.minimumAPIVersion})
+			if tc.pinnedVersion != "" {
+				client = client.WithAPIVersion(tc.pinnedVersion)
+			}
+
+			version, err := client.NegotiateAPIVersion(t.Context())
+			if tc.wantErr != "" {
+				require.ErrorContains(err, tc.wantErr)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tc.wantVersion, version)
+		})
+	}
 }
 
 func capabilitiesHandler(versions []string) http.Handler {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -40,6 +40,10 @@ type Client struct {
 	// from the Coordinator, nil until one was fetched.
 	capabilitiesDigest []byte
 
+	// expectedManifest, if set, provides the reference values the Coordinator is validated
+	// against, instead of the manifest the Coordinator reports.
+	expectedManifest *manifest.Manifest
+
 	// validatorsFromManifestOverride is used by tests to replace the validators.
 	validatorsFromManifestOverride func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) (validators.Validator, error)
 }
@@ -96,6 +100,17 @@ func (c *Client) WithSlog(log *slog.Logger) *Client {
 // WithHTTPClient replaces the Client's default [http.Client].
 func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
 	c.httpapi.HTTPClient = httpClient
+	return c
+}
+
+// WithExpectedManifest makes [Client.ValidateAttestation] derive the Coordinator's reference
+// values from the given manifest, instead of from the manifest the Coordinator reports.
+//
+// Callers that know which manifest the Coordinator is supposed to run should set this. Without
+// it, validation only proves that the Coordinator runs *some* manifest it vouches for itself,
+// and the caller has to compare the returned manifest against its expectation.
+func (c *Client) WithExpectedManifest(m *manifest.Manifest) *Client {
+	c.expectedManifest = m
 	return c
 }
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -31,11 +31,14 @@ type Client struct {
 
 	log *slog.Logger
 
-	// negotiateMu guards negotiatedVersion.
+	// negotiateMu guards negotiatedVersion and capabilitiesDigest.
 	negotiateMu sync.Mutex
 	// negotiatedVersion caches the API version agreed on with the Coordinator,
 	// empty until negotiated or pinned via [Client.WithAPIVersion].
 	negotiatedVersion string
+	// capabilitiesDigest is the SHA-256 digest of the raw capabilities response body received
+	// from the Coordinator, nil until one was fetched.
+	capabilitiesDigest []byte
 
 	// validatorsFromManifestOverride is used by tests to replace the validators.
 	validatorsFromManifestOverride func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) (validators.Validator, error)

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -18,6 +18,7 @@ import (
 	"github.com/edgelesssys/contrast/internal/cryptohelpers"
 	"github.com/edgelesssys/contrast/internal/history"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/sdk/apiv1"
 )
 
 // attestPath is the path of the Coordinator's attestation endpoint, which is unversioned.
@@ -95,6 +96,11 @@ func (c *Client) ValidateAttestation(ctx context.Context, nonce []byte, attestat
 	if err := validator.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)
 	}
+
+	if err := enforceMinimumAPIVersion(c.usedAPIVersion(), &latestManifest); err != nil {
+		return nil, err
+	}
+
 	state := CoordinatorState{
 		Manifests: resp.Manifests,
 		Policies:  resp.Policies,
@@ -102,6 +108,15 @@ func (c *Client) ValidateAttestation(ctx context.Context, nonce []byte, attestat
 		MeshCA:    resp.MeshCA,
 	}
 	return &state, nil
+}
+
+func (c *Client) usedAPIVersion() string {
+	c.negotiateMu.Lock()
+	defer c.negotiateMu.Unlock()
+	if c.negotiatedVersion != "" {
+		return c.negotiatedVersion
+	}
+	return apiv1.Version
 }
 
 // CoordinatorState represents the state of the Contrast Coordinator at a fixed point in time.

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -44,6 +44,9 @@ func (c *Client) GetAttestation(ctx context.Context, nonce []byte) ([]byte, erro
 // If this function returns nil, validation passed and the caller can rely on the state.MeshCA
 // issuing certificates according to the last entry of state.Manifests.
 //
+// The Coordinator binds the digest of its capabilities response into the report data, so
+// validation also proves that the capabilities this Client received weren't tampered with.
+//
 // Note: this function does not verify manifest content! It's the callers responsibility to compare
 // the latest manifest with an expected manifest, if that exists, or verify that all manifest
 // fields match their expectations.
@@ -80,9 +83,14 @@ func (c *Client) ValidateAttestation(ctx context.Context, nonce []byte, attestat
 		return nil, fmt.Errorf("getting validators: %w", err)
 	}
 
+	capabilitiesDigest, err := c.getCapabilitiesDigest(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting capabilities digest: %w", err)
+	}
+
 	transitions := history.BuildTransitionChain(resp.Manifests)
 	transitionDigest := transitions[len(transitions)-1].Digest()
-	reportData := apitypesv1.ConstructReportData(nonce, transitionDigest[:], &resp.CoordinatorState)
+	reportData := apitypesv1.ConstructReportData(nonce, transitionDigest[:], capabilitiesDigest, &resp.CoordinatorState)
 
 	if err := validator.Validate(ctx, resp.AttestationType, resp.RawAttestationDoc, reportData[:]); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -6,7 +6,9 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/asn1"
 	"encoding/json"
 	"log/slog"
@@ -14,11 +16,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/edgelesssys/contrast/apitypes"
 	apitypesv1 "github.com/edgelesssys/contrast/apitypes/apiv1"
 	"github.com/edgelesssys/contrast/internal/atls/validators"
 	"github.com/edgelesssys/contrast/internal/attestation/certcache"
 	"github.com/edgelesssys/contrast/internal/constants"
+	"github.com/edgelesssys/contrast/internal/history"
 	"github.com/edgelesssys/contrast/internal/manifest"
+	"github.com/edgelesssys/contrast/sdk/apiv1"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -156,11 +161,13 @@ func TestValidateAttestation(t *testing.T) {
 			attestation, err := json.Marshal(tc.resp)
 			require.NoError(err)
 
-			// ValidateAttestation is offline, so no Coordinator URL is needed.
-			c := New("")
+			srv := httptest.NewServer(capabilitiesHandler([]string{apiv1.Version}))
+			t.Cleanup(srv.Close)
+			c := New(srv.URL)
 
+			validator := &stubValidator{err: tc.validateErr}
 			c.validatorsFromManifestOverride = func(*certcache.CachedHTTPSGetter, *manifest.Manifest, *slog.Logger) (validators.Validator, error) {
-				return &stubValidator{err: tc.validateErr}, nil
+				return validator, nil
 			}
 			state, err := c.ValidateAttestation(t.Context(), tc.nonce, attestation)
 			if tc.wantErr != "" {
@@ -170,6 +177,8 @@ func TestValidateAttestation(t *testing.T) {
 			}
 			assert.NoError(err)
 
+			transitions := history.BuildTransitionChain(tc.resp.Manifests)
+			latestTransitionHash := transitions[len(transitions)-1].Digest()
 			expected := &CoordinatorState{
 				Manifests: tc.resp.Manifests,
 				Policies:  tc.resp.Policies,
@@ -178,6 +187,12 @@ func TestValidateAttestation(t *testing.T) {
 			}
 
 			assert.Equal(expected, state)
+
+			var capsBody bytes.Buffer
+			require.NoError(json.NewEncoder(&capsBody).Encode(apitypes.CapabilitiesResponse{APIVersions: []string{apiv1.Version}}))
+			capsDigest := sha256.Sum256(capsBody.Bytes())
+			wantReportData := apitypesv1.ConstructReportData(tc.nonce, latestTransitionHash[:], capsDigest[:], &tc.resp.CoordinatorState)
+			assert.Equal(wantReportData[:], validator.gotReportData)
 		})
 	}
 }
@@ -232,10 +247,12 @@ var testManifest = []byte(`
 `)
 
 type stubValidator struct {
-	err error
+	err           error
+	gotReportData []byte
 }
 
-func (v *stubValidator) Validate(context.Context, asn1.ObjectIdentifier, []byte, []byte) error {
+func (v *stubValidator) Validate(_ context.Context, _ asn1.ObjectIdentifier, _ []byte, reportData []byte) error {
+	v.gotReportData = reportData
 	return v.err
 }
 

--- a/sdk/verify_test.go
+++ b/sdk/verify_test.go
@@ -113,6 +113,16 @@ func TestGetAttestation(t *testing.T) {
 func TestValidateAttestation(t *testing.T) {
 	testNonce := make([]byte, 32)
 	testOID := asn1.ObjectIdentifier{1, 2, 3}
+
+	manifestWithMinAPIVersion := func(version string) []byte {
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(testManifest, &m))
+		m["MinimumAPIVersion"] = version
+		out, err := json.Marshal(m)
+		require.NoError(t, err)
+		return out
+	}
+
 	for name, tc := range map[string]struct {
 		nonce       []byte
 		resp        *apitypesv1.AttestationResponse
@@ -152,6 +162,17 @@ func TestValidateAttestation(t *testing.T) {
 			},
 			validateErr: assert.AnError,
 			wantErr:     assert.AnError.Error(),
+		},
+		"manifest pins a newer API version": {
+			nonce: testNonce,
+			resp: &apitypesv1.AttestationResponse{
+				AttestationType:   testOID,
+				RawAttestationDoc: testNonce,
+				CoordinatorState: apitypesv1.CoordinatorState{
+					Manifests: [][]byte{manifestWithMinAPIVersion("v2")},
+				},
+			},
+			wantErr: "older than the minimum",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
previous discussion: #2622

This adds two separate mechanisms to prevent downgrade attacks in API version negotiation.
1. users can (optionally) pin the minimum API version they want in the manifest, and the CLI enforces this;
2. the hash of the Coordinator capabilities response is included in the `ConstructReportData`, so clients can verify that the capabilities response they received in version negotiation was genuine.

(We currently fall back to gRPC if the minimum HTTP API version is not satisfied. I was a bit torn on this. Open to discussion.)
