### PR TITLE
ci: auto-fix govulncheck findings

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -71,6 +71,90 @@ jobs:
         run: |
           nix run ".#${SET}.scripts.govulncheck"
 
+  govulncheck-autofix:
+    name: "Fix vulnerabilities and open a PR"
+    needs: govulncheck
+    if: ${{ failure() && !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: read
+    concurrency:
+      group: govulncheck-autofix
+      cancel-in-progress: false
+    env:
+      SET: base
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+          persist-credentials: true
+      - name: Check for an existing autofix PR
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          number=$(gh pr list --head automated/govulncheck --state open --json number --jq '.[0].number // empty')
+          if [[ -n "${number}" ]]; then
+            echo "PR #${number} is already open, leaving it alone." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/setup_nix
+        if: ${{ steps.existing.outputs.number == '' }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          cachixToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Apply the mechanical fixes
+        id: fix
+        if: ${{ steps.existing.outputs.number == '' }}
+        run: |
+          set +e
+          nix run ".#${SET}.scripts.govulncheck-fix" > "${RUNNER_TEMP}/report.md"
+          echo "status=$?" >> "$GITHUB_OUTPUT"
+      - name: Build the PR body
+        if: ${{ steps.existing.outputs.number == '' }}
+        run: |
+          {
+            echo "Automated update created by the [static checks workflow](https://github.com/edgelesssys/contrast/blob/main/.github/workflows/static.yml)."
+            echo
+            cat "${RUNNER_TEMP}/report.md" 2>/dev/null || echo "No report produced."
+            echo
+            echo "\`generate\` ran after the fixes, so this PR also contains the follow-up changes it makes: \`go mod tidy\`, vendor hashes, the \`go\` directive across all modules and \`modernize\` rewrites. A dependency that requires a newer Go moves the \`go\` directive, which can touch far more files than the table above lists."
+          } > "${RUNNER_TEMP}/body.md"
+          cat "${RUNNER_TEMP}/body.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: Create PR
+        if: ${{ steps.existing.outputs.number == '' && contains(fromJSON('["0", "4"]'), steps.fix.outputs.status) }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          title: "deps: fix vulnerabilities reported by govulncheck"
+          body-path: ${{ runner.temp }}/body.md
+          commit-message: "deps: fix vulnerabilities reported by govulncheck"
+          base: main
+          draft: false
+          labels: "dependencies"
+          branch: automated/govulncheck
+          delete-branch: true
+          committer: edgelessci <edgelessci@users.noreply.github.com>
+          author: edgelessci <edgelessci@users.noreply.github.com>
+          token: ${{ secrets.NUNKI_CI_COMMIT_PUSH_PR }}
+      - name: Notify teams channel about findings that need a human
+        if: ${{ steps.fix.outputs.status == '4' }}
+        uses: ./.github/actions/post_to_teams
+        with:
+          webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
+          title: "govulncheck found vulnerabilities that cannot be fixed automatically"
+          message: "Check the run summary for the list."
+      - name: Notify teams channel about the autofix failing
+        if: ${{ steps.fix.outputs.status != '' && steps.fix.outputs.status != '0' && steps.fix.outputs.status != '4' }}
+        uses: ./.github/actions/post_to_teams
+        with:
+          webhook: ${{ secrets.TEAMS_CI_WEBHOOK }}
+          title: "The govulncheck autofix failed"
+          message: "No PR was opened, the vulnerabilities are still unfixed. Check the run for the error."
+
   golangci-lint:
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/justfile
+++ b/justfile
@@ -558,6 +558,10 @@ get-ghcr-read-token:
 codegen:
     nix run -L .#base.scripts.generate
 
+# Fix vulnerabilities reported by govulncheck. Pass --dry-run to only report them.
+govulnfix *ARGS:
+    nix run -L .#base.scripts.govulncheck-fix -- {{ ARGS }}
+
 # Format code.
 fmt:
     nix fmt

--- a/packages/govulncheck-fix.sh
+++ b/packages/govulncheck-fix.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Copyright 2026 Edgeless Systems GmbH
+# SPDX-License-Identifier: BUSL-1.1
+
+set -euo pipefail
+
+exec 3>&1 1>&2
+
+readonly overlay="overlays/nixpkgs.nix"
+readonly goAttr="legacyPackages.x86_64-linux.base.nixpkgs.go"
+
+readonly sep=$'\x1f'
+
+readonly exitNeedsHuman=4
+
+dryRun=false
+if [[ ${1:-} == "--dry-run" ]]; then
+  dryRun=true
+elif [[ $# -gt 0 ]]; then
+  echo "usage: govulncheck-fix [--dry-run]"
+  exit 2
+fi
+
+workdir=$(mktemp -d)
+trap 'rm -rf "${workdir}"' EXIT
+
+tags="${GOVULNCHECK_TAGS}"
+
+# Skips are (osvs, module, current, reason) and actions are (kind, dir, module, current, fixed, osvs).
+skip() { printf '%s\n' "$1${sep}$2${sep}$3${sep}$4" >>"${workdir}/skips"; }
+
+relative() {
+  if [[ $1 == "${PWD}" ]]; then
+    printf '.'
+  else
+    printf '%s' "${1#"${PWD}"/}"
+  fi
+}
+
+: >"${workdir}/findings.jsonl"
+while IFS= read -r dir; do
+  echo "  govulncheck ${dir}"
+  CGO_ENABLED=0 govulncheck -C "${dir}" -tags "${tags}" -format json ./... |
+    jq -c --arg dir "${dir}" 'select(.finding) | .finding + {dir: $dir}' >>"${workdir}/findings.jsonl"
+done < <(go list -f '{{.Dir}}' -m)
+
+if [[ ! -s ${workdir}/findings.jsonl ]]; then
+  echo "No vulnerabilities found."
+  exit 0
+fi
+
+# A single OSV yields module-level, package-level and symbol-level.
+# Only the symbol-level one (trace[0].function set) means we call the code path.
+jq -s -r '
+  [ .[] | select(.trace[0].function != null) ]
+  | group_by([ .dir, .trace[0].module ])
+  | map([
+      .[0].dir,
+      .[0].trace[0].module,
+      .[0].trace[0].version,
+      ([ .[] | .fixed_version // empty ] | unique | join(" ")),
+      ([ .[] | select(.fixed_version != null) | .osv ] | unique | join(", ")),
+      ([ .[] | select(.fixed_version == null) | .osv ] | unique | join(", "))
+    ])
+  | .[] | join("\u001f")
+' "${workdir}/findings.jsonl" >"${workdir}/targets"
+
+: >"${workdir}/actions"
+: >"${workdir}/skips"
+: >"${workdir}/stdlib"
+
+while IFS="${sep}" read -r dir module current fixedVersions osvs unfixed; do
+  if [[ -n ${unfixed} ]]; then
+    skip "${unfixed}" "${module}" "${current}" "no fixed version released yet"
+  fi
+
+  if [[ -z ${fixedVersions} ]]; then
+    continue
+  fi
+
+  fixed=$(printf '%s' "${fixedVersions}" | tr ' ' '\n' | sort -V | tail -n1)
+
+  if [[ ${module} == "stdlib" || ${module} == "toolchain" ]]; then
+    printf '%s\n' "${osvs}${sep}${current}${sep}${fixed}" >>"${workdir}/stdlib"
+    continue
+  fi
+
+  # v0 and v1 share the import path, only v2+ moves the module to a /vN path.
+  fixedMajor="${fixed%%.*}"
+  if [[ ${fixedMajor} != "v0" && ${fixedMajor} != "v1" && ${fixedMajor} != "${current%%.*}" ]]; then
+    skip "${osvs}" "${module}" "${current}" "needs a major version bump (${current} -> ${fixed})"
+    continue
+  fi
+
+  printf '%s\n' "gomod${sep}${dir}${sep}${module}${sep}${current}${sep}${fixed}${sep}${osvs}" \
+    >>"${workdir}/actions"
+done <"${workdir}/targets"
+
+if [[ -s ${workdir}/stdlib ]]; then
+  stdlibCurrent=$(cut -d"${sep}" -f2 "${workdir}/stdlib" | sort -V | tail -n1 | sed -E 's/^(go|v)//')
+  stdlibFixed=$(cut -d"${sep}" -f3 "${workdir}/stdlib" | sort -V | tail -n1 | sed -E 's/^(go|v)//')
+  stdlibOsvs=$(cut -d"${sep}" -f1 "${workdir}/stdlib" | tr ',' '\n' | tr -d ' ' |
+    grep -v '^$' | sort -u | paste -sd',' - | sed 's/,/, /g')
+
+  runningMinor=$(go version | sed -E 's/.*go([0-9]+\.[0-9]+).*/\1/')
+  goPin="go_${runningMinor//./_}"
+
+  if [[ ${stdlibFixed%.*} != "${runningMinor}" ]]; then
+    skip "${stdlibOsvs}" "stdlib" "${stdlibCurrent}" "needs go ${stdlibFixed}, pinning go_${stdlibFixed%.*} would not override the default \`go\`"
+  elif grep -qE '^  go_1_[0-9]+ = prev' "${overlay}" &&
+    ! grep -q "${goPin} = prev.${goPin}.overrideAttrs" "${overlay}"; then
+    skip "${stdlibOsvs}" "stdlib" "${stdlibCurrent}" \
+      "${overlay} pins a go minor other than ${runningMinor}, remove that pin first"
+  else
+    printf '%s\n' "stdlib${sep}${sep}stdlib${sep}${stdlibCurrent}${sep}${stdlibFixed}${sep}${stdlibOsvs}" \
+      >>"${workdir}/actions"
+  fi
+fi
+
+: >"${workdir}/applied"
+
+writeReport() {
+  if [[ -s ${workdir}/applied ]]; then
+    if [[ ${dryRun} == true ]]; then
+      printf '### Would fix automatically\n\n'
+    else
+      printf '### Fixed automatically\n\n'
+    fi
+    printf '| Advisory | Module | From | To | Where |\n|---|---|---|---|---|\n'
+    while IFS="${sep}" read -r kind dir module current fixed osvs; do
+      if [[ ${kind} == stdlib ]]; then
+        printf '| %s | go (toolchain) | %s | %s | %s |\n' \
+          "${osvs}" "${current}" "${fixed}" "${overlay}"
+      else
+        printf '| %s | %s | %s | %s | %s |\n' \
+          "${osvs}" "${module}" "${current}" "${fixed}" "$(relative "${dir}")"
+      fi
+    done <"${workdir}/applied"
+    printf '\n'
+  fi
+  if [[ -s ${workdir}/skips ]]; then
+    printf '### Needs a human\n\n'
+    printf '| Advisory | Module | Version | Reason |\n|---|---|---|---|\n'
+    sort -u "${workdir}/skips" |
+      while IFS="${sep}" read -r osvs module current reason; do
+        printf '| %s | %s | %s | %s |\n' "${osvs}" "${module}" "${current}" "${reason}"
+      done
+    printf '\n'
+  fi
+} >&3
+
+if [[ ! -s ${workdir}/actions ]]; then
+  writeReport
+  echo "Nothing to fix automatically."
+  if [[ -s ${workdir}/skips ]]; then
+    exit "${exitNeedsHuman}"
+  fi
+  exit 0
+fi
+
+if [[ ${dryRun} == true ]]; then
+  cp "${workdir}/actions" "${workdir}/applied"
+  writeReport
+  exit 0
+fi
+
+{
+  awk -F"${sep}" '$1 == "stdlib"' "${workdir}/actions"
+  awk -F"${sep}" '$1 != "stdlib"' "${workdir}/actions"
+} >"${workdir}/ordered"
+
+while IFS="${sep}" read -r kind dir module current fixed osvs; do
+  if [[ ${kind} == stdlib ]]; then
+    echo "Pinning go to ${fixed} in ${overlay}"
+    if ! grep -q "${goPin} = prev.${goPin}.overrideAttrs" "${overlay}"; then
+      awk -v attr="${goPin}" '
+        { print }
+        /^  # }\);$/ && !done {
+          print ""
+          print "  # Remove this once nixpkgs has caught up."
+          print "  " attr " = prev." attr ".overrideAttrs ("
+          print "    finalAttrs: _prevAttrs: {"
+          print "      version = \"0\";"
+          print "      src = final.fetchurl {"
+          print "        url = \"https://go.dev/dl/go${finalAttrs.version}.src.tar.gz\";"
+          print "        hash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\";"
+          print "      };"
+          print "    }"
+          print "  );"
+          done = 1
+        }
+      ' "${overlay}" >"${workdir}/overlay.nix"
+      mv "${workdir}/overlay.nix" "${overlay}"
+      grep -q "${goPin} = prev.${goPin}.overrideAttrs" "${overlay}"
+    fi
+    nix-update --flake --version="${fixed}" --override-filename="${overlay}" "${goAttr}"
+  else
+    echo "go get ${module}@${fixed} in ${dir}"
+    if ! go get -C "${dir}" "${module}@${fixed}"; then
+      skip "${osvs}" "${module}" "${current}" \
+        "\`go get ${module}@${fixed}\` failed, may need a toolchain bump first"
+      continue
+    fi
+  fi
+  printf '%s\n' "${kind}${sep}${dir}${sep}${module}${sep}${current}${sep}${fixed}${sep}${osvs}" \
+    >>"${workdir}/applied"
+done <"${workdir}/ordered"
+
+if [[ ! -s ${workdir}/applied ]]; then
+  writeReport
+  echo "Could not apply any fix."
+  exit "${exitNeedsHuman}"
+fi
+
+echo "Running codegen"
+generate
+
+writeReport
+
+if [[ -s ${workdir}/skips ]]; then
+  echo "Applied mechanical fixes, but some findings need a human."
+  exit "${exitNeedsHuman}"
+fi

--- a/packages/scripts.nix
+++ b/packages/scripts.nix
@@ -110,6 +110,24 @@
     '';
   };
 
+  govulncheck-fix = writeShellApplication {
+    name = "govulncheck-fix";
+    runtimeInputs = with pkgs; [
+      go
+      govulncheck
+      jq
+      gawk
+      gnugrep
+      gnused
+      coreutils
+      nix
+      nix-update
+      scripts.generate
+    ];
+    runtimeEnv.GOVULNCHECK_TAGS = lib.concatStringsSep "," contrastPkgs.contrast.contrast.tags;
+    text = builtins.readFile ./govulncheck-fix.sh;
+  };
+
   gofix = writeShellApplication {
     name = "gofix";
     runtimeInputs = with pkgs; [


### PR DESCRIPTION
When `govulncheck` fails due to found errors, a new CI step and script runs which attempts to autofix the findings, *on main*. I.e. after pushing to a feature branch and failing govulncheck there, we check if it also fails on main, and if so, if no existing autofix PR is open.

Only then do we open a bot PR which, depending on what's required,
- bumps imported go module versions,
- updates the go patch version,
- runs our `codegen` script

This will *usually* work just fine. However, in some cases (e.g. bump of the required minimum go version inside a module), it might fail because additional, not automate-able changes are required. The PR will still be opened, but needs human fixups.